### PR TITLE
Removed unused imports and formatted code and Moved static assets to …

### DIFF
--- a/src/main/java/com/aem/builder/controller/AemProjectController.java
+++ b/src/main/java/com/aem/builder/controller/AemProjectController.java
@@ -3,7 +3,6 @@ package com.aem.builder.controller;
 import com.aem.builder.model.AemProjectModel;
 import com.aem.builder.service.ComponentService;
 import com.aem.builder.service.TemplateService;
-import com.aem.builder.service.TemplateService;
 import com.aem.builder.service.impl.AemProjectServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -11,8 +10,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
-
 import java.io.IOException;
 import java.util.List;
 
@@ -39,10 +36,7 @@ public class AemProjectController {
         model.addAttribute("message", "AEM Project created successfully under generated-projects directory.");
         templateService.copySelectedTemplatesToGeneratedProject(
                 aemProjectModel.getProjectName(),
-                aemProjectModel.getSelectedTemplates()
-        );
-//        return "dashboard";
-//        redirectAttributes.addFlashAttribute("message" , "AEM Project created successfully under generated-projects directory.");
+                aemProjectModel.getSelectedTemplates());
         return "redirect:/";
     }
 }

--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -3,29 +3,13 @@ package com.aem.builder.controller;
 import com.aem.builder.service.ComponentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
-
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.aem.builder.service.ComponentService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
@@ -42,15 +26,13 @@ public class ComponentController {
                 .getProjectComponentsMap(List.of(projectname))
                 .getOrDefault(projectname, new ArrayList<>());
 
-
         log.info(projectname);
 
         List<String> distinctComponents = componentService.getDistinctComponents(allComponents, projectComponents);
         List<String> commonComponents = componentService.getCommonComponents(allComponents, projectComponents);
 
-        log.info("{}",distinctComponents);
-        log.info("{}",commonComponents);
-
+        log.info("{}", distinctComponents);
+        log.info("{}", commonComponents);
 
         Map<String, List<String>> response = new HashMap<>();
         response.put("unique", distinctComponents);
@@ -58,7 +40,6 @@ public class ComponentController {
 
         return response;
     }
-
 
     @PostMapping("/add-components/{projectname}")
     public String addComponentsToExistingProject(
@@ -76,9 +57,4 @@ public class ComponentController {
         }
     }
 
-
-
-
 }
-
-

--- a/src/main/java/com/aem/builder/controller/DeployController.java
+++ b/src/main/java/com/aem/builder/controller/DeployController.java
@@ -10,12 +10,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
-
 import java.util.List;
-// ...existing code...
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-// ...existing code...
 
 @Controller
 @RequiredArgsConstructor
@@ -23,17 +20,17 @@ public class DeployController {
 
     private static final Logger logger = LoggerFactory.getLogger(DeployController.class);
 
-    private final ComponentServiceImpl componentService ;
+    private final ComponentServiceImpl componentService;
     private final TemplateServiceImpl templateService;
     private final DeployServiceImpl deployService;
 
     @GetMapping("/{projectName}")
     public String projectDetails(@PathVariable String projectName, Model model) {
         logger.info("DEPLOY: Fetching project details for project: {}", projectName);
-     List<String> components = componentService.fetchComponentsFromGeneratedProjects(projectName);
-     List<String> templates = templateService.fetchTemplatesFromGeneratedProjects(projectName);
-        model.addAttribute("components",components);
-        model.addAttribute("templates", templates );
+        List<String> components = componentService.fetchComponentsFromGeneratedProjects(projectName);
+        List<String> templates = templateService.fetchTemplatesFromGeneratedProjects(projectName);
+        model.addAttribute("components", components);
+        model.addAttribute("templates", templates);
         model.addAttribute("canDeploy", true);
         logger.debug("DEPLOY: Added attributes to model for project: {}", projectName);
         return "deploy";
@@ -45,10 +42,11 @@ public class DeployController {
         try {
             String message = deployService.deployProject(projectName);
             logger.info("DEPLOY: Deployment successful for project: {}. Message: {}", projectName, message);
-            redirectAttributes.addFlashAttribute("message" , message);
+            redirectAttributes.addFlashAttribute("message", message);
         } catch (Exception e) {
             logger.error("DEPLOY: Deployment failed for project: {}", projectName, e);
-            redirectAttributes.addFlashAttribute("error", " Deployment failed for " + projectName + ": \n" + e.getMessage());
+            redirectAttributes.addFlashAttribute("error",
+                    " Deployment failed for " + projectName + ": \n" + e.getMessage());
         }
         return "redirect:/";
     }

--- a/src/main/java/com/aem/builder/controller/HomeController.java
+++ b/src/main/java/com/aem/builder/controller/HomeController.java
@@ -1,15 +1,11 @@
 package com.aem.builder.controller;
 
-import com.aem.builder.model.AemProjectModel;
 import com.aem.builder.model.ProjectDetails;
 import com.aem.builder.service.impl.AemProjectServiceImpl;
-import com.aem.builder.service.impl.DeployServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
 
 import java.io.IOException;
 import java.util.List;
@@ -18,16 +14,13 @@ import java.util.List;
 @RequiredArgsConstructor
 public class HomeController {
 
-
-private  final AemProjectServiceImpl aemProjectService;
+    private final AemProjectServiceImpl aemProjectService;
 
     @GetMapping("/")
     public String test(Model model) throws IOException {
-       List<ProjectDetails> projects = aemProjectService.getAllProjects();
+        List<ProjectDetails> projects = aemProjectService.getAllProjects();
         model.addAttribute("projects", projects);
         return "dashboard";
     }
 
-
 }
-

--- a/src/main/java/com/aem/builder/controller/TemplateController.java
+++ b/src/main/java/com/aem/builder/controller/TemplateController.java
@@ -1,17 +1,12 @@
 package com.aem.builder.controller;
 
-import com.aem.builder.model.AemProjectModel;
-import com.aem.builder.model.TemplateModel;
 import com.aem.builder.service.TemplateService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,23 +22,23 @@ public class TemplateController {
     @ResponseBody
     public Map<String, List<String>> getTemplates(@PathVariable String projectname, Model model) throws IOException {
         List<String> resourcetemplates = templateService.getTemplateFileNames();
-        List<String>projectTemplates=templateService.getTemplateNamesFromDestination(projectname);
-      List<String>distinct=templateService.getDistinctTemplates(projectname,resourcetemplates,projectTemplates);
-      List<String>common=templateService.getCommonTemplates(resourcetemplates,projectTemplates);
+        List<String> projectTemplates = templateService.getTemplateNamesFromDestination(projectname);
+        List<String> distinct = templateService.getDistinctTemplates(projectname, resourcetemplates, projectTemplates);
+        List<String> common = templateService.getCommonTemplates(resourcetemplates, projectTemplates);
         Map<String, List<String>> response = new HashMap<>();
         response.put("unique", distinct);
         response.put("duplicate", common);
         return response;
     }
 
-
     @PostMapping("/add-template/{projectname}")
-    public String addTemplateToExistingProject(@PathVariable  String projectname,@RequestBody List<String>templatelist){
+    public String addTemplateToExistingProject(@PathVariable String projectname,
+            @RequestBody List<String> templatelist) {
 
-        log.info( projectname);
-  log.info(templatelist.toString());
-        try{
-            templateService.copySelectedTemplatesToGeneratedProject(projectname,templatelist);
+        log.info(projectname);
+        log.info(templatelist.toString());
+        try {
+            templateService.copySelectedTemplatesToGeneratedProject(projectname, templatelist);
             return "dashboard";
 
         } catch (IOException e) {

--- a/src/main/java/com/aem/builder/service/impl/AemProjectServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/AemProjectServiceImpl.java
@@ -27,7 +27,6 @@ public class AemProjectServiceImpl implements AemProjectService {
 
     private final ComponentService componentService;
 
-
     private static final String PROJECTS_DIR = "generated-projects";
 
     @Override
@@ -69,8 +68,7 @@ public class AemProjectServiceImpl implements AemProjectService {
                     aemProjectModel.getProjectName(),
                     appId,
                     aemProjectModel.getPackageName(),
-                    aemProjectModel.getVersion()
-            );
+                    aemProjectModel.getVersion());
 
             // OS-specific ProcessBuilder (cross-platform)
             ProcessBuilder processBuilder;
@@ -98,7 +96,8 @@ public class AemProjectServiceImpl implements AemProjectService {
             }
 
             // Step 1: Copy selected components to ui.apps
-            String componentsTargetPath = baseDir + appId + "/ui.apps/src/main/content/jcr_root/apps/" + appId + "/components/";
+            String componentsTargetPath = baseDir + appId + "/ui.apps/src/main/content/jcr_root/apps/" + appId
+                    + "/components/";
             File contentFolder = new File(componentsTargetPath);
             if (!contentFolder.exists()) {
                 contentFolder.mkdirs();
@@ -109,11 +108,6 @@ public class AemProjectServiceImpl implements AemProjectService {
             e.printStackTrace();
         }
     }
-
-
-
-
-
 
     @Override
     public List<ProjectDetails> getAllProjects() {
@@ -147,20 +141,21 @@ public class AemProjectServiceImpl implements AemProjectService {
 
                         groupId = doc.getElementsByTagName("groupId").item(0).getTextContent();
                     }
-                } catch (Exception ignored) {}
+                } catch (Exception ignored) {
+                }
 
                 try {
-                    BasicFileAttributes attr = Files.readAttributes(new File(projectsFolder, name).toPath(), BasicFileAttributes.class);
+                    BasicFileAttributes attr = Files.readAttributes(new File(projectsFolder, name).toPath(),
+                            BasicFileAttributes.class);
                     createdDate = attr.creationTime().toInstant().atZone(java.time.ZoneId.systemDefault())
                             .format(DateTimeFormatter.ofPattern("MMM dd, yyyy HH:mm"));
-                } catch (Exception ignored) {}
+                } catch (Exception ignored) {
+                }
 
                 projects.add(new ProjectDetails(name, version, groupId, createdDate, path));
             }
         }
         return projects;
     }
-
-
 
 }

--- a/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
@@ -7,15 +7,12 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-
-
 import com.aem.builder.service.ComponentService;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.io.FileUtils;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.stereotype.Service;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,7 +29,8 @@ public class ComponentServiceImpl implements ComponentService {
 
     @Override
     public List<String> fetchComponentsFromGeneratedProjects(String projectName) {
-        File componentsDir = new File(PROJECTS_DIR, projectName + "/ui.apps/src/main/content/jcr_root/apps/" + projectName + "/components");
+        File componentsDir = new File(PROJECTS_DIR,
+                projectName + "/ui.apps/src/main/content/jcr_root/apps/" + projectName + "/components");
         if (componentsDir.exists()) {
             return Arrays.stream(componentsDir.listFiles(File::isDirectory))
                     .map(File::getName)
@@ -40,7 +38,6 @@ public class ComponentServiceImpl implements ComponentService {
         }
         return List.of();
     }
-
 
     @Override
     public List<String> getAllComponents() throws IOException {
@@ -117,16 +114,6 @@ public class ComponentServiceImpl implements ComponentService {
             String baseDir = System.getProperty("user.dir") + "/generated-projects/";
             String contentFolderPath = baseDir + projectName +
                     "/ui.apps/src/main/content/jcr_root/apps/" + projectName + "/components";
-
-//            File content = new File(contentFolderPath);
-//            if (!content.exists()) {
-//                boolean created = content.mkdirs();
-//                if (!created) {
-//                    System.err.println("Failed to create content folder for components.");
-//                    return;
-//                }
-//            }
-
             copySelectedComponents(selectedComponents, contentFolderPath);
 
             System.out.println(" Selected components copied to content folder in project: " + projectName);
@@ -138,7 +125,8 @@ public class ComponentServiceImpl implements ComponentService {
 
     @Override
     public void copySelectedComponents(List<String> selectedComponents, String targetPath) {
-        if (selectedComponents == null || selectedComponents.isEmpty()) return;
+        if (selectedComponents == null || selectedComponents.isEmpty())
+            return;
 
         try {
             for (String component : selectedComponents) {
@@ -146,7 +134,7 @@ public class ComponentServiceImpl implements ComponentService {
                 File destination = new File(targetPath + "/" + source.getName());
 
                 if (!source.exists()) {
-                    System.err.println("⚠️ Source component not found: " + source.getAbsolutePath());
+                    System.err.println("️ Source component not found: " + source.getAbsolutePath());
                     continue;
                 }
 
@@ -158,7 +146,7 @@ public class ComponentServiceImpl implements ComponentService {
                 System.out.println("Copied component: " + component + " → " + destination.getAbsolutePath());
             }
         } catch (IOException e) {
-            System.err.println("❌ Failed to copy selected components.");
+            System.err.println(" Failed to copy selected components.");
             e.printStackTrace();
         }
     }

--- a/src/main/java/com/aem/builder/service/impl/DeployServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/DeployServiceImpl.java
@@ -10,7 +10,6 @@ import java.io.InputStreamReader;
 @Service
 public class DeployServiceImpl implements DeployService {
 
-
     private static final String PROJECTS_DIR = "generated-projects";
 
     @Override
@@ -44,7 +43,7 @@ public class DeployServiceImpl implements DeployService {
     @Override
     public String extractErrorMessage(String fullOutput) {
         StringBuilder errorOutput = new StringBuilder();
-        String[] lines = fullOutput.split("\\R"); // Split by new lines
+        String[] lines = fullOutput.split("\\R");
 
         for (String line : lines) {
             if (line.contains("[ERROR]")) {

--- a/src/main/resources/static/css/deploy.css
+++ b/src/main/resources/static/css/deploy.css
@@ -1,0 +1,6 @@
+.removable-item { position: relative; padding-right: 20px; }
+        .remove-btn { position: absolute; top: 3px; right: 5px; color: red; cursor: pointer; }
+        #successMessage {
+            display: none;
+        }
+

--- a/src/main/resources/static/js/dashboard.js
+++ b/src/main/resources/static/js/dashboard.js
@@ -1,0 +1,11 @@
+setTimeout(() => {
+        const success = document.getElementById('successAlert');
+        const error = document.getElementById('errorAlert');
+
+        if (success) {
+            bootstrap.Alert.getOrCreateInstance(success).close();
+        }
+        if (error) {
+            bootstrap.Alert.getOrCreateInstance(error).close();
+        }
+    }, 5000);

--- a/src/main/resources/static/js/deploy.js
+++ b/src/main/resources/static/js/deploy.js
@@ -1,0 +1,159 @@
+
+    let selectedComponents = [];
+    let selectedTemplates = [];
+
+    function getProjectName() {
+        return document.getElementById('componentModal').getAttribute('data-project');
+    }
+
+    function renderList(containerId, dataList, selectedList, type) {
+        const container = document.getElementById(containerId);
+        container.innerHTML = '';
+
+        const allItems = [...new Set([...dataList.unique, ...dataList.duplicate, ...selectedList])];
+
+        allItems.forEach(item => {
+            const isAlreadyAdded = selectedList.includes(item);
+            const isDuplicate = dataList.duplicate.includes(item);
+
+            let labelSuffix = '';
+            let isDisabled = false;
+            let isChecked = false;
+
+            if (isAlreadyAdded) {
+                labelSuffix = ' (Already Added)';
+                isDisabled = true;
+                isChecked = true;
+            } else if (isDuplicate) {
+                labelSuffix = ' (Exists)';
+                isDisabled = true;
+            }
+
+            container.innerHTML += `
+                <div class="col">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" value="${item}" ${isChecked ? 'checked' : ''} ${isDisabled ? 'disabled' : ''}>
+                        <label class="form-check-label ${isDisabled ? 'text-muted' : ''}">${item}${labelSuffix}</label>
+                    </div>
+                </div>`;
+        });
+    }
+
+    function openComponentModal() {
+        const projectName = getProjectName();
+        fetch(`/fetch-components/${projectName}`)
+            .then(res => res.json())
+            .then(data => {
+                renderList('componentList', data, selectedComponents, 'component');
+                new bootstrap.Modal(document.getElementById('componentModal')).show();
+            });
+    }
+
+    function openTemplateModal() {
+        const projectName = getProjectName();
+        fetch(`/fetch-templates/${projectName}`)
+            .then(res => res.json())
+            .then(data => {
+                renderList('templateList', data, selectedTemplates, 'template');
+                new bootstrap.Modal(document.getElementById('templateModal')).show();
+            });
+    }
+
+    function addSelected(type) {
+        const listId = type === 'component' ? 'componentList' : 'templateList';
+        const selected = Array.from(document.querySelectorAll(`#${listId} input[type=checkbox]:checked:not(:disabled)`))
+                              .map(cb => cb.value);
+        const container = document.getElementById(type === 'component' ? 'newComponentsList' : 'newTemplatesList');
+        const list = type === 'component' ? selectedComponents : selectedTemplates;
+
+        selected.forEach(item => {
+            if (!list.includes(item)) list.push(item);
+            const div = document.createElement('div');
+            div.className = 'col';
+            div.innerHTML = `
+                <div class="border rounded p-2 bg-light text-center shadow-sm removable-item">
+                    ${item}
+                    <span class="remove-btn" onclick="removeItem('${item}', '${type}')">&times;</span>
+                </div>`;
+            container.appendChild(div);
+        });
+
+        document.getElementById(type === 'component' ? 'newComponentsContainer' : 'newTemplatesContainer').style.display = 'block';
+        showSave();
+        bootstrap.Modal.getInstance(document.getElementById(type + 'Modal')).hide();
+    }
+
+    function addSelectedComponents() {
+        addSelected('component');
+    }
+
+    function addSelectedTemplates() {
+        addSelected('template');
+    }
+
+    function removeItem(name, type) {
+        const list = type === 'component' ? selectedComponents : selectedTemplates;
+        const idx = list.indexOf(name);
+        if (idx !== -1) list.splice(idx, 1);
+        const containerId = type === 'component' ? 'newComponentsList' : 'newTemplatesList';
+        const container = document.getElementById(containerId);
+        Array.from(container.children).forEach(col => {
+            if (col.textContent.includes(name)) col.remove();
+        });
+
+        const mainContainerId = type === 'component' ? 'newComponentsContainer' : 'newTemplatesContainer';
+        if (list.length === 0) {
+            document.getElementById(mainContainerId).style.display = 'none';
+        }
+        checkSaveVisibility();
+    }
+
+    function showSave() {
+        document.getElementById('saveBtn').style.display = 'inline-block';
+        document.getElementById('deployBtn').disabled = true;
+    }
+
+    function checkSaveVisibility() {
+        if (selectedComponents.length === 0 && selectedTemplates.length === 0) {
+            document.getElementById('saveBtn').style.display = 'none';
+            document.getElementById('deployBtn').disabled = false;
+        }
+    }
+
+    function saveAll() {
+        const projectName = getProjectName();
+        const promises = [];
+
+        if (selectedComponents.length > 0) {
+            promises.push(fetch(`/add-components/${projectName}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(selectedComponents)
+            }));
+        }
+
+
+       if (selectedTemplates.length > 0) {
+    promises.push(fetch(`/add-template/${projectName}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(selectedTemplates)
+    }));
+}
+
+
+        Promise.all(promises).then(() => {
+            const msg = document.getElementById('successMessage');
+            msg.style.display = 'block';
+            setTimeout(() => {
+                msg.style.display = 'none';
+                window.location.reload();
+            }, 2000);
+        });
+    }
+
+    function showDeploySpinner() {
+        document.getElementById('deploySpinner').style.display = 'inline-block';
+        document.getElementById('deployBtn').disabled = true;
+        return true;
+    }

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
+    <script th:src="@{/js/dashboard.js}"></script>
+
     <title>AEM Builder - Dashboard</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/animate.css@4.1.1/animate.min.css" rel="stylesheet">
@@ -66,21 +68,6 @@
 <footer class="mt-auto" th:replace="fragments/navbar :: footer"></footer>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-
-<script>
-    // Auto-dismiss alerts after 2 seconds
-    setTimeout(() => {
-        const success = document.getElementById('successAlert');
-        const error = document.getElementById('errorAlert');
-
-        if (success) {
-            bootstrap.Alert.getOrCreateInstance(success).close();
-        }
-        if (error) {
-            bootstrap.Alert.getOrCreateInstance(error).close();
-        }
-    }, 5000);
-</script>
 
 </body>
 </html>

--- a/src/main/resources/templates/deploy.html
+++ b/src/main/resources/templates/deploy.html
@@ -1,272 +1,16 @@
 
-<!--<!DOCTYPE html>-->
-<!--<html xmlns:th="http://www.thymeleaf.org">-->
-<!--<head>-->
-<!--    <title>AEM Builder - Project Details</title>-->
-<!--    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">-->
-<!--    <style>-->
-<!--        .removable-item { position: relative; padding-right: 20px; }-->
-<!--        .remove-btn { position: absolute; top: 3px; right: 5px; color: red; cursor: pointer; }-->
-<!--    </style>-->
-<!--</head>-->
-<!--<body class="d-flex flex-column min-vh-100">-->
-
-<!--&lt;!&ndash; Navbar &ndash;&gt;-->
-<!--<div th:replace="fragments/navbar :: navbar"></div>-->
-
-<!--<main class="flex-grow-1">-->
-<!--    <div class="container mt-4">-->
-<!--        <h2 class="mb-4 text-primary" th:text="'Project: ' + ${projectName}"></h2>-->
-
-<!--        &lt;!&ndash; Action buttons &ndash;&gt;-->
-<!--        <div class="d-flex justify-content-end mb-3">-->
-<!--            <button id="saveBtn" class="btn btn-outline-success me-2" style="display:none" onclick="saveAll()">Save</button>-->
-<!--            <form th:action="@{'/' + ${projectName} + '/deploy'}" method="post" class="d-inline">-->
-<!--                <button id="deployBtn" class="btn btn-warning" type="submit" th:attr="disabled=${!canDeploy}">Deploy to AEM</button>-->
-<!--            </form>-->
-<!--            <a href="/" class="btn btn-secondary ms-3">Back to Dashboard</a>-->
-<!--        </div>-->
-
-<!--        &lt;!&ndash; Component & Template Lists &ndash;&gt;-->
-<!--        <div class="row g-4">-->
-<!--            &lt;!&ndash; Components &ndash;&gt;-->
-<!--            <div class="col-md-6">-->
-<!--                <div id="newComponentsContainer" style="display:none;">-->
-<!--                    <h6 class="text-success">Newly Added Components</h6>-->
-<!--                    <div id="newComponentsList" class="row row-cols-1 row-cols-sm-2 g-2"></div>-->
-<!--                </div>-->
-<!--                <div class="d-flex justify-content-between align-items-center mb-2">-->
-<!--                    <h4>Components</h4>-->
-<!--                    <a href="#" class="btn btn-sm btn-outline-primary" onclick="openComponentModal()">+ Add Component</a>-->
-<!--                </div>-->
-<!--                <div id="componentsList" class="row row-cols-1 row-cols-sm-2 g-2">-->
-<!--                    <div class="col" th:each="component : ${components}">-->
-<!--                        <div class="border rounded p-2 bg-light text-center shadow-sm" th:text="${component}"></div>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--            </div>-->
-
-<!--            &lt;!&ndash; Templates &ndash;&gt;-->
-<!--            <div class="col-md-6">-->
-<!--                <div id="newTemplatesContainer" style="display:none;">-->
-<!--                    <h6 class="text-success">Newly Added Templates</h6>-->
-<!--                    <div id="newTemplatesList" class="row row-cols-1 row-cols-sm-2 g-2"></div>-->
-<!--                </div>-->
-<!--                <div class="d-flex justify-content-between align-items-center mb-2">-->
-<!--                    <h4>Templates</h4>-->
-<!--                    <a href="#" class="btn btn-sm btn-outline-primary" onclick="openTemplateModal()">+ Add Template</a>-->
-<!--                </div>-->
-<!--                <div id="templatesList" class="row row-cols-1 row-cols-sm-2 g-2">-->
-<!--                    <div class="col" th:each="template : ${templates}">-->
-<!--                        <div class="border rounded p-2 bg-light text-center shadow-sm" th:text="${template}"></div>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--            </div>-->
-<!--        </div>-->
-<!--    </div>-->
-<!--</main>-->
-
-<!--&lt;!&ndash; Footer &ndash;&gt;-->
-<!--<div th:replace="fragments/navbar :: footer"></div>-->
-
-<!--&lt;!&ndash; Component Modal &ndash;&gt;-->
-<!--<div class="modal fade" id="componentModal" tabindex="-1" th:attr="data-project=${projectName}">-->
-<!--    <div class="modal-dialog modal-lg modal-dialog-scrollable">-->
-<!--        <div class="modal-content">-->
-<!--            <div class="modal-header">-->
-<!--                <h5>Select Components</h5>-->
-<!--                <button class="btn-close" data-bs-dismiss="modal"></button>-->
-<!--            </div>-->
-<!--            <div class="modal-body">-->
-<!--                <div id="componentList" class="row row-cols-2 g-2"></div>-->
-<!--            </div>-->
-<!--            <div class="modal-footer">-->
-<!--                <button class="btn btn-primary" onclick="addSelectedComponents()">Add Selected</button>-->
-<!--            </div>-->
-<!--        </div>-->
-<!--    </div>-->
-<!--</div>-->
-
-<!--&lt;!&ndash; Template Modal &ndash;&gt;-->
-<!--<div class="modal fade" id="templateModal" tabindex="-1" th:attr="data-project=${projectName}">-->
-<!--    <div class="modal-dialog modal-lg modal-dialog-scrollable">-->
-<!--        <div class="modal-content">-->
-<!--            <div class="modal-header">-->
-<!--                <h5>Select Templates</h5>-->
-<!--                <button class="btn-close" data-bs-dismiss="modal"></button>-->
-<!--            </div>-->
-<!--            <div class="modal-body">-->
-<!--                <div id="templateList" class="row row-cols-2 g-2"></div>-->
-<!--            </div>-->
-<!--            <div class="modal-footer">-->
-<!--                <button class="btn btn-primary" onclick="addSelectedTemplates()">Add Selected</button>-->
-<!--            </div>-->
-<!--        </div>-->
-<!--    </div>-->
-<!--</div>-->
-
-<!--&lt;!&ndash; Scripts &ndash;&gt;-->
-<!--<script>-->
-<!--    let selectedComponents = [];-->
-<!--    let selectedTemplates = [];-->
-
-<!--    function getProjectName() {-->
-<!--        return document.getElementById('componentModal').getAttribute('data-project');-->
-<!--    }-->
-
-<!--   function renderList(containerId, dataList, selectedList, type) {-->
-<!--    const container = document.getElementById(containerId);-->
-<!--    container.innerHTML = '';-->
-
-<!--    const allItems = [...new Set([...dataList.unique, ...dataList.duplicate, ...selectedList])];-->
-
-<!--    allItems.forEach(item => {-->
-<!--        const isAlreadyAdded = selectedList.includes(item);-->
-<!--        const isDuplicate = dataList.duplicate.includes(item);-->
-
-<!--        let labelSuffix = '';-->
-<!--        let isDisabled = false;-->
-<!--        let isChecked = false;-->
-
-<!--        if (isAlreadyAdded) {-->
-<!--            labelSuffix = ' (Already Added)';-->
-<!--            isDisabled = true;-->
-<!--            isChecked = true;-->
-<!--        } else if (isDuplicate) {-->
-<!--            labelSuffix = ' (Exists)';-->
-<!--            isDisabled = true;-->
-<!--        }-->
-
-<!--        container.innerHTML += `-->
-<!--            <div class="col">-->
-<!--                <div class="form-check">-->
-<!--                    <input class="form-check-input" type="checkbox" value="${item}" ${isChecked ? 'checked' : ''} ${isDisabled ? 'disabled' : ''}>-->
-<!--                    <label class="form-check-label ${isDisabled ? 'text-muted' : ''}">${item}${labelSuffix}</label>-->
-<!--                </div>-->
-<!--            </div>`;-->
-<!--    });-->
-<!--}-->
-
-
-<!--    function openComponentModal() {-->
-<!--        const projectName = getProjectName();-->
-<!--        fetch(`/api/components/${projectName}`)-->
-<!--            .then(res => res.json())-->
-<!--            .then(data => {-->
-<!--                renderList('componentList', data, selectedComponents, 'component');-->
-<!--                new bootstrap.Modal(document.getElementById('componentModal')).show();-->
-<!--            });-->
-<!--    }-->
-
-<!--    function openTemplateModal() {-->
-<!--        const projectName = getProjectName();-->
-<!--        fetch(`/fetch-templates/${projectName}`)-->
-<!--            .then(res => res.json())-->
-<!--            .then(data => {-->
-<!--                renderList('templateList', data, selectedTemplates, 'template');-->
-<!--                new bootstrap.Modal(document.getElementById('templateModal')).show();-->
-<!--            });-->
-<!--    }-->
-
-<!--    function addSelected(type) {-->
-<!--        const listId = type === 'component' ? 'componentList' : 'templateList';-->
-<!--        const selected = Array.from(document.querySelectorAll(`#${listId} input[type=checkbox]:checked:not(:disabled)`))-->
-<!--                              .map(cb => cb.value);-->
-<!--        const container = document.getElementById(type === 'component' ? 'newComponentsList' : 'newTemplatesList');-->
-<!--        const list = type === 'component' ? selectedComponents : selectedTemplates;-->
-
-<!--        selected.forEach(item => {-->
-<!--            if (!list.includes(item)) list.push(item);-->
-<!--            const div = document.createElement('div');-->
-<!--            div.className = 'col';-->
-<!--            div.innerHTML = `-->
-<!--                <div class="border rounded p-2 bg-light text-center shadow-sm removable-item">-->
-<!--                    ${item}-->
-<!--                    <span class="remove-btn" onclick="removeItem('${item}', '${type}')">&times;</span>-->
-<!--                </div>`;-->
-<!--            container.appendChild(div);-->
-<!--        });-->
-
-<!--        document.getElementById(type === 'component' ? 'newComponentsContainer' : 'newTemplatesContainer').style.display = 'block';-->
-<!--        showSave();-->
-<!--        bootstrap.Modal.getInstance(document.getElementById(type + 'Modal')).hide();-->
-<!--    }-->
-
-<!--    function addSelectedComponents() {-->
-<!--        addSelected('component');-->
-<!--    }-->
-
-<!--    function addSelectedTemplates() {-->
-<!--        addSelected('template');-->
-<!--    }-->
-
-<!--    function removeItem(name, type) {-->
-<!--        const list = type === 'component' ? selectedComponents : selectedTemplates;-->
-<!--        const idx = list.indexOf(name);-->
-<!--        if (idx !== -1) list.splice(idx, 1);-->
-<!--        const containerId = type === 'component' ? 'newComponentsList' : 'newTemplatesList';-->
-<!--        const container = document.getElementById(containerId);-->
-<!--        Array.from(container.children).forEach(col => {-->
-<!--            if (col.textContent.includes(name)) col.remove();-->
-<!--        });-->
-<!--        if (list.length === 0) {-->
-<!--            document.getElementById(containerId + 'Container').style.display = 'none';-->
-<!--        }-->
-<!--        checkSaveVisibility();-->
-<!--    }-->
-
-<!--    function showSave() {-->
-<!--        document.getElementById('saveBtn').style.display = 'inline-block';-->
-<!--        document.getElementById('deployBtn').disabled = true;-->
-<!--    }-->
-
-<!--    function checkSaveVisibility() {-->
-<!--        if (selectedComponents.length === 0 && selectedTemplates.length === 0) {-->
-<!--            document.getElementById('saveBtn').style.display = 'none';-->
-<!--            document.getElementById('deployBtn').disabled = false;-->
-<!--        }-->
-<!--    }-->
-
-<!--    function saveAll() {-->
-<!--        const projectName = getProjectName();-->
-<!--        const promises = [];-->
-
-<!--        if (selectedComponents.length > 0) {-->
-<!--            promises.push(fetch(`/${projectName}/components/save`, {-->
-<!--                method: 'POST',-->
-<!--                headers: {'Content-Type': 'application/json'},-->
-<!--                body: JSON.stringify(selectedComponents)-->
-<!--            }));-->
-<!--        }-->
-
-<!--        if (selectedTemplates.length > 0) {-->
-<!--            promises.push(fetch(`/${projectName}/templates/save`, {-->
-<!--                method: 'POST',-->
-<!--                headers: {'Content-Type': 'application/json'},-->
-<!--                body: JSON.stringify(selectedTemplates)-->
-<!--            }));-->
-<!--        }-->
-
-<!--        Promise.all(promises).then(() => window.location.reload());-->
-<!--    }-->
-<!--</script>-->
-
-<!--<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>-->
-<!--</body>-->
-<!--</html>-->
-
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>AEM Builder - Project Details</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <style>
-        .removable-item { position: relative; padding-right: 20px; }
-        .remove-btn { position: absolute; top: 3px; right: 5px; color: red; cursor: pointer; }
-        #successMessage {
-            display: none;
-        }
-    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+
+
+    <link rel="stylesheet" href="/css/deploy.css">
+
+    <script th:src="@{/js/deploy.js}"></script>
 </head>
 <body class="d-flex flex-column min-vh-100">
 
@@ -277,7 +21,7 @@
     <div class="container mt-4">
         <h2 class="mb-4 text-primary" th:text="'Project: ' + ${projectName}"></h2>
 
-        <!-- ✅ Success Message -->
+        <!-- Success Message -->
         <div id="successMessage" class="alert alert-success text-center" role="alert">
             Components and Templates saved successfully.
         </div>
@@ -305,6 +49,7 @@
                 </div>
                 <div class="d-flex justify-content-between align-items-center mb-2">
                     <h4>Components</h4>
+
                     <a href="#" class="btn btn-sm btn-outline-primary" onclick="openComponentModal()">+ Component Library</a>
                 </div>
                 <div id="componentsList" class="row row-cols-1 row-cols-sm-2 g-2">
@@ -322,6 +67,7 @@
                 </div>
                 <div class="d-flex justify-content-between align-items-center mb-2">
                     <h4>Templates</h4>
+
                     <a href="#" class="btn btn-sm btn-outline-primary" onclick="openTemplateModal()">+ Template Library </a>
                 </div>
                 <div id="templatesList" class="row row-cols-1 row-cols-sm-2 g-2">
@@ -373,168 +119,8 @@
     </div>
 </div>
 
-<!-- Scripts -->
-<script>
-    let selectedComponents = [];
-    let selectedTemplates = [];
-
-    function getProjectName() {
-        return document.getElementById('componentModal').getAttribute('data-project');
-    }
-
-    function renderList(containerId, dataList, selectedList, type) {
-        const container = document.getElementById(containerId);
-        container.innerHTML = '';
-
-        const allItems = [...new Set([...dataList.unique, ...dataList.duplicate, ...selectedList])];
-
-        allItems.forEach(item => {
-            const isAlreadyAdded = selectedList.includes(item);
-            const isDuplicate = dataList.duplicate.includes(item);
-
-            let labelSuffix = '';
-            let isDisabled = false;
-            let isChecked = false;
-
-            if (isAlreadyAdded) {
-                labelSuffix = ' (Already Added)';
-                isDisabled = true;
-                isChecked = true;
-            } else if (isDuplicate) {
-                labelSuffix = ' (Exists)';
-                isDisabled = true;
-            }
-
-            container.innerHTML += `
-                <div class="col">
-                    <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="${item}" ${isChecked ? 'checked' : ''} ${isDisabled ? 'disabled' : ''}>
-                        <label class="form-check-label ${isDisabled ? 'text-muted' : ''}">${item}${labelSuffix}</label>
-                    </div>
-                </div>`;
-        });
-    }
-
-    function openComponentModal() {
-        const projectName = getProjectName();
-        fetch(`/fetch-components/${projectName}`)
-            .then(res => res.json())
-            .then(data => {
-                renderList('componentList', data, selectedComponents, 'component');
-                new bootstrap.Modal(document.getElementById('componentModal')).show();
-            });
-    }
-
-    function openTemplateModal() {
-        const projectName = getProjectName();
-        fetch(`/fetch-templates/${projectName}`)
-            .then(res => res.json())
-            .then(data => {
-                renderList('templateList', data, selectedTemplates, 'template');
-                new bootstrap.Modal(document.getElementById('templateModal')).show();
-            });
-    }
-
-    function addSelected(type) {
-        const listId = type === 'component' ? 'componentList' : 'templateList';
-        const selected = Array.from(document.querySelectorAll(`#${listId} input[type=checkbox]:checked:not(:disabled)`))
-                              .map(cb => cb.value);
-        const container = document.getElementById(type === 'component' ? 'newComponentsList' : 'newTemplatesList');
-        const list = type === 'component' ? selectedComponents : selectedTemplates;
-
-        selected.forEach(item => {
-            if (!list.includes(item)) list.push(item);
-            const div = document.createElement('div');
-            div.className = 'col';
-            div.innerHTML = `
-                <div class="border rounded p-2 bg-light text-center shadow-sm removable-item">
-                    ${item}
-                    <span class="remove-btn" onclick="removeItem('${item}', '${type}')">&times;</span>
-                </div>`;
-            container.appendChild(div);
-        });
-
-        document.getElementById(type === 'component' ? 'newComponentsContainer' : 'newTemplatesContainer').style.display = 'block';
-        showSave();
-        bootstrap.Modal.getInstance(document.getElementById(type + 'Modal')).hide();
-    }
-
-    function addSelectedComponents() {
-        addSelected('component');
-    }
-
-    function addSelectedTemplates() {
-        addSelected('template');
-    }
-
-    function removeItem(name, type) {
-        const list = type === 'component' ? selectedComponents : selectedTemplates;
-        const idx = list.indexOf(name);
-        if (idx !== -1) list.splice(idx, 1);
-        const containerId = type === 'component' ? 'newComponentsList' : 'newTemplatesList';
-        const container = document.getElementById(containerId);
-        Array.from(container.children).forEach(col => {
-            if (col.textContent.includes(name)) col.remove();
-        });
-
-        const mainContainerId = type === 'component' ? 'newComponentsContainer' : 'newTemplatesContainer';
-        if (list.length === 0) {
-            document.getElementById(mainContainerId).style.display = 'none';
-        }
-        checkSaveVisibility();
-    }
-
-    function showSave() {
-        document.getElementById('saveBtn').style.display = 'inline-block';
-        document.getElementById('deployBtn').disabled = true;
-    }
-
-    function checkSaveVisibility() {
-        if (selectedComponents.length === 0 && selectedTemplates.length === 0) {
-            document.getElementById('saveBtn').style.display = 'none';
-            document.getElementById('deployBtn').disabled = false;
-        }
-    }
-
-    function saveAll() {
-        const projectName = getProjectName();
-        const promises = [];
-
-        if (selectedComponents.length > 0) {
-            promises.push(fetch(`/add-components/${projectName}`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(selectedComponents)
-            }));
-        }
 
 
-       if (selectedTemplates.length > 0) {
-    promises.push(fetch(`/add-template/${projectName}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(selectedTemplates)
-    }));
-}
-
-
-        Promise.all(promises).then(() => {
-            const msg = document.getElementById('successMessage');
-            msg.style.display = 'block';
-            setTimeout(() => {
-                msg.style.display = 'none';
-                window.location.reload();
-            }, 2000);
-        });
-    }
-
-    function showDeploySpinner() {
-        document.getElementById('deploySpinner').style.display = 'inline-block';
-        document.getElementById('deployBtn').disabled = true;
-        return true;
-    }
-</script>
-
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<!--<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>-->
 </body>
 </html>

--- a/src/main/resources/templates/fragments/navbar.html
+++ b/src/main/resources/templates/fragments/navbar.html
@@ -9,10 +9,7 @@
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarNav">
-<!--        <ul class="navbar-nav ms-auto">-->
-<!--          <li class="nav-item"><a class="nav-link" href="/">Dashboard</a></li>-->
-<!--          <li class="nav-item"><a class="nav-link" href="/create">Create</a></li>-->
-<!--        </ul>-->
+
       </div>
     </div>
   </nav>


### PR DESCRIPTION
### Summary

This PR focuses on code cleanup and restructuring of static assets for better maintainability and scalability. 

### Changes Made

-  Removed unused imports across Java classes and templates
-  Applied consistent code formatting to improve readability
- Moved static assets into organized folders:
  - Moved CSS files to `static/css/`
  - Moved JS files to `static/js/`
-  Modularized page-specific assets:
  - Moved `deploy.html` scripts to `static/js/deploy.js`
  - Moved `deploy.html` styles to `static/css/deploy.css`
  - Moved dashboard scripts to `static/js/dashboard.js`
-  Cleaned up `deploy.html` to use `th:href` and `th:src` for linking static files
