### PR TITLE
Add component detail view

### DIFF
--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -96,4 +96,41 @@ public class ComponentController {
         return ResponseEntity.ok(isAvailable); // true means name is available
     }
 
+    @GetMapping("/{projectName}/component/{componentName}")
+    public String viewComponent(@PathVariable String projectName,
+                                @PathVariable String componentName,
+                                Model model) {
+        model.addAttribute("projectName", projectName);
+        model.addAttribute("componentName", componentName);
+        model.addAttribute("htlCode", readFileFromProject(projectName, componentName, componentName + ".html"));
+        model.addAttribute("dialogXml", readFileFromProject(projectName, componentName, "_cq_dialog/.content.xml"));
+        model.addAttribute("designDialogXml", readFileFromProject(projectName, componentName, "_cq_design_dialog/.content.xml"));
+        model.addAttribute("javaCodes", findJavaSources(componentName));
+        return "component-details";
+    }
+
+    private String readFileFromProject(String project, String component, String relative) {
+        java.nio.file.Path path = java.nio.file.Paths.get("generated-projects", project,
+                "ui.apps/src/main/content/jcr_root/apps", project, "components", component, relative);
+        try {
+            return java.nio.file.Files.exists(path) ? java.nio.file.Files.readString(path) : "File not found";
+        } catch (java.io.IOException e) {
+            return "Error reading file";
+        }
+    }
+
+    private java.util.List<String> findJavaSources(String componentName) {
+        java.util.List<String> list = new java.util.ArrayList<>();
+        java.nio.file.Path dir = java.nio.file.Paths.get("src/main/java/com/aem/builder/slingModels");
+        if (java.nio.file.Files.isDirectory(dir)) {
+            try (java.nio.file.DirectoryStream<java.nio.file.Path> ds = java.nio.file.Files.newDirectoryStream(dir, "*" + componentName + "*.java")) {
+                for (java.nio.file.Path p : ds) {
+                    list.add(java.nio.file.Files.readString(p));
+                }
+            } catch (java.io.IOException ignored) {
+            }
+        }
+        return list;
+    }
+
     }

--- a/src/main/java/com/aem/builder/controller/DeployController.java
+++ b/src/main/java/com/aem/builder/controller/DeployController.java
@@ -31,6 +31,7 @@ public class DeployController {
         List<String> templates = templateService.fetchTemplatesFromGeneratedProjects(projectName);
         model.addAttribute("components", components);
         model.addAttribute("templates", templates);
+        model.addAttribute("projectName", projectName);
         model.addAttribute("canDeploy", true);
         logger.debug("DEPLOY: Added attributes to model for project: {}", projectName);
         return "deploy";

--- a/src/main/resources/templates/component-details.html
+++ b/src/main/resources/templates/component-details.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Component Details</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container mt-4">
+    <h2 th:text="${componentName}"></h2>
+    <a th:href="@{'/' + ${projectName}}" class="btn btn-outline-secondary mb-3">← Back to Project</a>
+    <div class="mb-4">
+        <h5>HTL</h5>
+        <pre><code th:text="${htlCode}"></code></pre>
+    </div>
+    <div class="mb-4">
+        <h5>Dialog XML</h5>
+        <pre><code th:text="${dialogXml}"></code></pre>
+    </div>
+    <div class="mb-4">
+        <h5>Design Dialog XML</h5>
+        <pre><code th:text="${designDialogXml}"></code></pre>
+    </div>
+    <div class="mb-4" th:if="${javaCodes}">
+        <h5>Java Files</h5>
+        <div th:each="code : ${javaCodes}">
+            <pre><code th:text="${code}"></code></pre>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/deploy.html
+++ b/src/main/resources/templates/deploy.html
@@ -45,7 +45,9 @@
                 </div>
                 <div id="componentsList" class="row row-cols-1 row-cols-sm-2 g-2">
                     <div class="col" th:each="component : ${components}">
-                        <div class="border rounded p-2 bg-light text-center shadow-sm" th:text="${component}"></div>
+                        <a th:href="@{'/' + ${projectName} + '/component/' + ${component}}" class="text-decoration-none">
+                            <div class="border rounded p-2 bg-light text-center shadow-sm" th:text="${component}"></div>
+                        </a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- allow project details page to expose project name
- make component list items link to details page
- add controller endpoint to show component detail info
- display HTL, dialog and code in new page

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_b_6889d0c6215c8325aee67bf1b5bb6202