### PR TITLE
Add template details view

### DIFF
--- a/src/main/java/com/aem/builder/controller/DeployController.java
+++ b/src/main/java/com/aem/builder/controller/DeployController.java
@@ -31,6 +31,7 @@ public class DeployController {
         List<String> templates = templateService.fetchTemplatesFromGeneratedProjects(projectName);
         model.addAttribute("components", components);
         model.addAttribute("templates", templates);
+        model.addAttribute("projectName", projectName);
         model.addAttribute("canDeploy", true);
         logger.debug("DEPLOY: Added attributes to model for project: {}", projectName);
         return "deploy";

--- a/src/main/java/com/aem/builder/controller/TemplateController.java
+++ b/src/main/java/com/aem/builder/controller/TemplateController.java
@@ -58,6 +58,16 @@ public class TemplateController {
 
     }
 
+    @GetMapping("/{projectName}/templates/{templateName}")
+    public String templateDetails(@PathVariable String projectName,
+                                  @PathVariable String templateName,
+                                  Model model) throws IOException {
+        TemplateModel details = templateService.getTemplateDetails(projectName, templateName);
+        model.addAttribute("template", details);
+        model.addAttribute("projectName", projectName);
+        return "template-details";
+    }
+
     @GetMapping("/{projectName}/createtemplate")
     public String showCreateTemplateForm(@PathVariable String projectName, Model model) {
         model.addAttribute("projectName", projectName);

--- a/src/main/java/com/aem/builder/service/TemplateService.java
+++ b/src/main/java/com/aem/builder/service/TemplateService.java
@@ -14,6 +14,8 @@ public interface TemplateService {
     public List<String> getTemplateNamesFromDestination(String projectName);
     List<String> fetchTemplatesFromGeneratedProjects(String projectName);
 
+    TemplateModel getTemplateDetails(String projectName, String templateName) throws IOException;
+
 
     //creating template
     void createTemplate(TemplateModel model, String projectname) throws IOException;

--- a/src/main/java/com/aem/builder/service/impl/TemplateServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/TemplateServiceImpl.java
@@ -99,6 +99,36 @@ public class TemplateServiceImpl implements TemplateService {
         return List.of();
     }
 
+    @Override
+    public TemplateModel getTemplateDetails(String projectName, String templateName) throws IOException {
+        String base = PROJECTS_DIR + "/" + projectName + "/ui.content/src/main/content/jcr_root/conf/" +
+                projectName + "/settings/wcm/templates/" + templateName + "/.content.xml";
+        TemplateModel model = new TemplateModel();
+        model.setName(templateName);
+
+        File file = new File(base);
+        if (file.exists()) {
+            String xml = Files.readString(file.toPath());
+
+            java.util.regex.Matcher titleMatcher = java.util.regex.Pattern.compile("jcr:title=\"([^\"]+)\"").matcher(xml);
+            if (titleMatcher.find()) {
+                model.setTitle(titleMatcher.group(1));
+            }
+
+            java.util.regex.Matcher statusMatcher = java.util.regex.Pattern.compile("status=\"([^\"]+)\"").matcher(xml);
+            if (statusMatcher.find()) {
+                model.setStatus(statusMatcher.group(1));
+            }
+
+            java.util.regex.Matcher typeMatcher = java.util.regex.Pattern.compile("cq:templateType=\"([^\"]+)\"").matcher(xml);
+            if (typeMatcher.find()) {
+                String path = typeMatcher.group(1);
+                model.setTemplateType(path.substring(path.lastIndexOf('/') + 1));
+            }
+        }
+        return model;
+    }
+
     //creating templates
 
 

--- a/src/main/resources/templates/deploy.html
+++ b/src/main/resources/templates/deploy.html
@@ -62,7 +62,9 @@
                 </div>
                 <div id="templatesList" class="row row-cols-1 row-cols-sm-2 g-2">
                     <div class="col" th:each="template : ${templates}">
-                        <div class="border rounded p-2 bg-light text-center shadow-sm" th:text="${template}"></div>
+                        <a th:href="@{'/' + ${projectName} + '/templates/' + ${template}}" target="_blank" class="text-decoration-none">
+                            <div class="border rounded p-2 bg-light text-center shadow-sm" th:text="${template}"></div>
+                        </a>
                     </div>
                 </div>
             </div>

--- a/src/main/resources/templates/template-details.html
+++ b/src/main/resources/templates/template-details.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Template Details</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+<div class="container">
+    <h3 class="mb-3" th:text="${template.name}"></h3>
+    <ul class="list-group">
+        <li class="list-group-item"><strong>Title:</strong> <span th:text="${template.title}"></span></li>
+        <li class="list-group-item"><strong>Status:</strong> <span th:text="${template.status}"></span></li>
+        <li class="list-group-item"><strong>Type:</strong> <span th:text="${template.templateType}"></span></li>
+    </ul>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide projectName attribute to deploy view
- allow fetching template details from generated projects
- display template details via new endpoint and template
- make template names clickable in deploy page

## Testing
- `./mvnw -q test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6889db0a363483259151991b1bc5c710