### PR TITLE
Enhance component utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,4 +98,38 @@ Supports **multi-select** functionality.
 git clone https://github.com/your-org/aem-project-generator.git
 cd aem-project-generator
 ./mvnw spring-boot:run
- 
+```
+
+## 🔧 Supported Dialog Field Types
+
+The component generator supports a variety of Touch UI dialog fields. The table below lists the available types and the Granite resource types used during generation:
+
+| Type | Granite Resource |
+|------|-----------------|
+| textfield | granite/ui/components/coral/foundation/form/textfield |
+| textarea | granite/ui/components/coral/foundation/form/textarea |
+| numberfield | granite/ui/components/coral/foundation/form/numberfield |
+| hidden | granite/ui/components/coral/foundation/form/hidden |
+| checkbox | granite/ui/components/coral/foundation/form/checkbox |
+| checkboxgroup | granite/ui/components/coral/foundation/form/checkboxgroup |
+| radiogroup | granite/ui/components/coral/foundation/form/radiogroup |
+| select | granite/ui/components/coral/foundation/form/select |
+| multiselect | granite/ui/components/coral/foundation/form/multifield |
+| pathfield | granite/ui/components/coral/foundation/form/pathfield |
+| autocomplete | granite/ui/components/coral/foundation/form/autocomplete |
+| datepicker | granite/ui/components/coral/foundation/form/datepicker |
+| image | cq/gui/components/authoring/dialog/fileupload |
+| fileupload | cq/gui/components/authoring/dialog/fileupload |
+| richtext | cq/gui/components/authoring/dialog/richtext |
+| multifield | granite/ui/components/coral/foundation/form/multifield |
+| nestedmultifield | granite/ui/components/coral/foundation/form/multifield |
+| tabs | granite/ui/components/coral/foundation/tabs |
+| button | granite/ui/components/coral/foundation/form/button |
+| password | granite/ui/components/coral/foundation/form/password |
+| switch | granite/ui/components/coral/foundation/form/switch |
+| anchorbrowser | cq/gui/components/coral/common/form/anchorbrowser |
+| tagfield | cq/gui/components/coral/common/form/tagfield |
+
+## 🌐 API snippets
+
+* `GET /projects` – returns all available projects detected under `generated-projects/`.

--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -26,6 +26,16 @@ public class ComponentController {
 
     private final ComponentService componentService;
 
+    /**
+     * Returns all generated AEM project names so the UI can populate project
+     * selectors dynamically.
+     */
+    @GetMapping("/projects")
+    @ResponseBody
+    public List<String> listProjects() {
+        return componentService.getExistingProjects();
+    }
+
     @GetMapping("/fetch-components/{projectname}")
     @ResponseBody
     public Map<String, List<String>> getComponents(@PathVariable String projectname) throws IOException {

--- a/src/main/java/com/aem/builder/model/Enum/FieldType.java
+++ b/src/main/java/com/aem/builder/model/Enum/FieldType.java
@@ -23,7 +23,9 @@ public enum FieldType {
     PASSWORD("password", "granite/ui/components/coral/foundation/form/password"),
     SWITCH("switch", "granite/ui/components/coral/foundation/form/switch"),
     ANCHORBROWSER("anchorbrowser", "cq/gui/components/coral/common/form/anchorbrowser"),
-    TAGFIELD("tagfield", "cq/gui/components/coral/common/form/tagfield");
+    TAGFIELD("tagfield", "cq/gui/components/coral/common/form/tagfield"),
+    TABS("tabs", "granite/ui/components/coral/foundation/tabs"),
+    NESTED_MULTIFIELD("nestedmultifield", "granite/ui/components/coral/foundation/form/multifield");
 
     private final String type;
     private final String resourceType;
@@ -48,7 +50,7 @@ public enum FieldType {
                 MULTISELECT.toEntry(), PATHFIELD.toEntry(), AUTOCOMPLETE.toEntry(), DATEPICKER.toEntry(),
                 IMAGE.toEntry(), FILEUPLOAD.toEntry(), RICHTEXT.toEntry(), MULTIFIELD.toEntry(),
                 BUTTON.toEntry(), PASSWORD.toEntry(), SWITCH.toEntry(), ANCHORBROWSER.toEntry(),
-                TAGFIELD.toEntry()
+                TAGFIELD.toEntry(), TABS.toEntry(), NESTED_MULTIFIELD.toEntry()
         );
     }
 

--- a/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
@@ -334,7 +334,18 @@ public class ComponentServiceImpl implements ComponentService {
                 }
             }
         }
-        return groups.isEmpty() ? List.of(projectName) : new ArrayList<>(groups);
+        // Exclude hidden or generic groups
+        groups.remove(projectName + "-content");
+        groups.remove(projectName + "-structure");
+        groups.remove(".hidden");
+
+        if (groups.isEmpty()) {
+            return List.of(projectName);
+        }
+
+        List<String> sorted = new ArrayList<>(groups);
+        Collections.sort(sorted);
+        return sorted;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- expose `/projects` endpoint for listing generated projects
- filter and sort component groups
- support additional field types (tabs and nested multifield)
- document supported field types and API snippet

## Testing
- `./mvnw -q test` *(fails: Failed to fetch maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6889ec56b2348330b2740f759581d299