### PR TITLE
Support nested fields on component creation

### DIFF
--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -76,10 +77,16 @@ public class ComponentController {
     @PostMapping("/component/create/{project}")
     public String createComponent(@PathVariable String project,
                                   @ModelAttribute ComponentRequest request,
-                                  Model model) {
-        componentService.generateComponent(project, request);
-        model.addAttribute("message", "Component created successfully!");
-        return "redirect:/" + project;
+                                  RedirectAttributes redirectAttributes) {
+        try {
+            componentService.generateComponent(project, request);
+            redirectAttributes.addFlashAttribute("message", "Component created successfully!");
+            return "redirect:/" + project;
+        } catch (Exception e) {
+            log.error("Error creating component", e);
+            redirectAttributes.addFlashAttribute("error", "Failed to create component: " + e.getMessage());
+            return "redirect:/create/" + project;
+        }
     }
 
 //component checking

--- a/src/main/java/com/aem/builder/model/DTO/ComponentField.java
+++ b/src/main/java/com/aem/builder/model/DTO/ComponentField.java
@@ -6,7 +6,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
-import java.util.Map;
+
+import com.aem.builder.model.DTO.OptionItem;
+
+/**
+ * Represents a single dialog field definition.
+ */
 
 @Data
 @AllArgsConstructor
@@ -16,6 +21,6 @@ public class ComponentField {
     private String fieldLabel;                 // e.g., Title
     private String fieldType;                  // from FieldType enum
     private List<ComponentField> nestedFields; // only for multifields
-    private List<String> options;
+    private List<OptionItem> options;          // for select/checkboxgroup values
 
 }

--- a/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
@@ -174,6 +174,9 @@ public class ComponentServiceImpl implements ComponentService {
                 }
             }
         }
+        groups.removeIf(g -> g.equals(projectName + "-content")
+                || g.equals(projectName + "-structure")
+                || g.equals(".hidden"));
         return groups.isEmpty() ? List.of(projectName) : new ArrayList<>(groups);
     }
 

--- a/src/main/java/com/aem/builder/util/FileGenerationUtil.java
+++ b/src/main/java/com/aem/builder/util/FileGenerationUtil.java
@@ -2,6 +2,7 @@ package com.aem.builder.util;
 
 import com.aem.builder.model.DTO.ComponentField;
 import com.aem.builder.model.DTO.ComponentRequest;
+import com.aem.builder.model.DTO.OptionItem;
 import com.aem.builder.model.Enum.FieldType;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -228,7 +229,7 @@ public class FileGenerationUtil {
         String type = field.getFieldType().toLowerCase();
         String label = field.getFieldLabel();
         String name = field.getFieldName();
-        List<String> options = field.getOptions();
+        List<OptionItem> options = field.getOptions();
         List<ComponentField> nested = field.getNestedFields();
 
         return switch (type) {
@@ -282,10 +283,11 @@ public class FileGenerationUtil {
                         .append("    <items jcr:primaryType=\"nt:unstructured\">\n");
                 if (options != null) {
                     for (int i = 0; i < options.size(); i++) {
+                        OptionItem opt = options.get(i);
                         sb.append("      <option").append(i + 1).append("\n")
                                 .append("        jcr:primaryType=\"nt:unstructured\"\n")
-                                .append("        text=\"").append(options.get(i)).append("\"\n")
-                                .append("        value=\"").append(options.get(i)).append("\"/>\n");
+                                .append("        text=\"").append(opt.getText()).append("\"\n")
+                                .append("        value=\"").append(opt.getValue()).append("\"/>\n");
                     }
                 }
                 sb.append("    </items>\n")
@@ -308,10 +310,11 @@ public class FileGenerationUtil {
                         .append("    <items jcr:primaryType=\"nt:unstructured\">\n");
                 if (options != null) {
                     for (int i = 0; i < options.size(); i++) {
+                        OptionItem opt = options.get(i);
                         sb.append("      <option").append(i + 1).append("\n")
                                 .append("        jcr:primaryType=\"nt:unstructured\"\n")
-                                .append("        text=\"").append(options.get(i)).append("\"\n")
-                                .append("        value=\"").append(options.get(i)).append("\"/>\n");
+                                .append("        text=\"").append(opt.getText()).append("\"\n")
+                                .append("        value=\"").append(opt.getValue()).append("\"/>\n");
                     }
                 }
                 sb.append("    </items>\n")

--- a/src/main/resources/static/css/create-component.css
+++ b/src/main/resources/static/css/create-component.css
@@ -16,3 +16,8 @@
       text-align: center;
       box-shadow: 0 -2px 5px rgba(0,0,0,0.1);
     }
+
+.nested-row {
+  border: 1px dashed #ced4da;
+  padding: 10px;
+}

--- a/src/main/resources/static/js/create-component.js
+++ b/src/main/resources/static/js/create-component.js
@@ -1,10 +1,146 @@
 document.addEventListener("DOMContentLoaded", function () {
-  let fieldIndex = 1;
+  const typeOptions = document.querySelector('.fieldType').innerHTML;
+
+  function createBaseRow(isNested) {
+    const div = document.createElement('div');
+    div.className = isNested ? 'nested-row mb-2' : 'field-row border p-2 mb-3';
+    div.innerHTML = `
+      <div class="row g-2 align-items-end">
+        <div class="col">
+          <input type="text" class="form-control fieldLabel" placeholder="Field Label" oninput="autoFillFieldName(this)" required>
+        </div>
+        <div class="col">
+          <input type="text" class="form-control fieldName" placeholder="Field Name" required>
+        </div>
+        <div class="col">
+          <select class="form-select fieldType" onchange="handleFieldTypeChange(this)" required>${typeOptions}</select>
+        </div>
+        <div class="col-auto action-col">
+          ${isNested ? '<button type="button" class="btn btn-danger" onclick="removeNestedFieldRow(this)">-</button>' : ''}
+        </div>
+      </div>
+      <div class="options-container mt-2"></div>
+      <div class="nested-container mt-2"></div>`;
+    return div;
+  }
+
+  window.autoFillFieldName = function (labelInput) {
+    const row = labelInput.closest('.field-row, .nested-row');
+    const nameInput = row.querySelector('.fieldName');
+    const labelValue = labelInput.value.trim();
+    const camelCase = labelValue
+      .replace(/[^a-zA-Z0-9 ]/g, '')
+      .split(/\s+/)
+      .map((w, i) => i === 0 ? w.toLowerCase() : w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+      .join('');
+    nameInput.value = camelCase;
+    validateFormFields();
+  };
+
+  window.handleFieldTypeChange = function (select) {
+    const row = select.closest('.field-row, .nested-row');
+    const type = select.value;
+    const opt = row.querySelector('.options-container');
+    const nested = row.querySelector('.nested-container');
+    opt.innerHTML = '';
+    nested.innerHTML = '';
+
+    if (["select", "multiselect", "checkboxgroup", "radiogroup"].includes(type)) {
+      const addBtn = document.createElement('button');
+      addBtn.type = 'button';
+      addBtn.className = 'btn btn-sm btn-secondary mb-2';
+      addBtn.textContent = 'Add Option';
+      addBtn.onclick = () => addOptionRow(addBtn);
+      opt.appendChild(addBtn);
+      addOptionRow(addBtn);
+    } else if (type === 'multifield') {
+      const addBtn = document.createElement('button');
+      addBtn.type = 'button';
+      addBtn.className = 'btn btn-sm btn-secondary mb-2';
+      addBtn.textContent = 'Add Field';
+      addBtn.onclick = () => addNestedFieldRow(addBtn);
+      nested.appendChild(addBtn);
+      addNestedFieldRow(addBtn);
+    }
+    updateIndexes();
+  };
+
+  window.addFieldRow = function () {
+    const container = document.getElementById('fieldsContainer');
+    const row = createBaseRow(false);
+    row.querySelector('.action-col').innerHTML = '<button type="button" class="btn btn-danger" onclick="removeFieldRow(this)">-</button>';
+    container.appendChild(row);
+    updateIndexes();
+    row.classList.add('animate__animated','animate__fadeIn');
+  };
+
+  window.removeFieldRow = function (btn) {
+    btn.closest('.field-row').remove();
+    updateIndexes();
+  };
+
+  function addNestedFieldRow(btn) {
+    const container = btn.closest('.nested-container');
+    const row = createBaseRow(true);
+    container.insertBefore(row, btn);
+    updateIndexes();
+  }
+  window.removeNestedFieldRow = function (btn) {
+    btn.closest('.nested-row').remove();
+    updateIndexes();
+  };
+
+  function addOptionRow(btn) {
+    const container = btn.closest('.options-container');
+    const div = document.createElement('div');
+    div.className = 'option-row input-group mb-2';
+    div.innerHTML = `<input type="text" class="form-control optionText" placeholder="Text" required>
+      <input type="text" class="form-control optionValue" placeholder="Value" required>
+      <button type="button" class="btn btn-danger" onclick="removeOptionRow(this)">-</button>`;
+    container.insertBefore(div, btn);
+    updateIndexes();
+  }
+  window.removeOptionRow = function (btn) {
+    btn.parentElement.remove();
+    updateIndexes();
+  };
+
+  function updateIndexes() {
+    const fieldRows = document.querySelectorAll('#fieldsContainer > .field-row');
+    fieldRows.forEach((row, i) => {
+      row.dataset.index = i;
+      row.querySelector('.fieldLabel').name = `fields[${i}].fieldLabel`;
+      row.querySelector('.fieldName').name = `fields[${i}].fieldName`;
+      row.querySelector('.fieldType').name = `fields[${i}].fieldType`;
+      updateOptionIndexes(row, `fields[${i}]`);
+      updateNestedIndexes(row, i);
+    });
+  }
+
+  function updateNestedIndexes(parentRow, parentIndex) {
+    const nestedRows = parentRow.querySelectorAll('.nested-row');
+    nestedRows.forEach((row, j) => {
+      row.dataset.index = j;
+      row.dataset.parent = parentIndex;
+      row.querySelector('.fieldLabel').name = `fields[${parentIndex}].nestedFields[${j}].fieldLabel`;
+      row.querySelector('.fieldName').name = `fields[${parentIndex}].nestedFields[${j}].fieldName`;
+      row.querySelector('.fieldType').name = `fields[${parentIndex}].nestedFields[${j}].fieldType`;
+      updateOptionIndexes(row, `fields[${parentIndex}].nestedFields[${j}]`);
+    });
+  }
+
+  function updateOptionIndexes(row, prefix) {
+    const options = row.querySelectorAll('.option-row');
+    options.forEach((opt, k) => {
+      opt.querySelector('.optionText').name = `${prefix}.options[${k}].text`;
+      opt.querySelector('.optionValue').name = `${prefix}.options[${k}].value`;
+    });
+  }
 
   const componentNameInput = document.getElementById('componentName');
   const errorDiv = document.getElementById('nameError');
   const createButton = document.getElementById('createButton');
-  const projectName = document.getElementById("projectName").value;
+  const projectName = document.getElementById('projectName').value;
 
   function debounce(func, delay) {
     let timer;
@@ -17,7 +153,7 @@ document.addEventListener("DOMContentLoaded", function () {
   const checkComponentNameAvailability = debounce(() => {
     const componentName = componentNameInput.value.trim();
     if (!componentName) {
-      errorDiv.innerText = "";
+      errorDiv.innerText = '';
       errorDiv.classList.remove('text-danger', 'text-success');
       componentNameInput.classList.remove('is-invalid');
       validateFormFields();
@@ -28,24 +164,21 @@ document.addEventListener("DOMContentLoaded", function () {
       .then(response => response.json())
       .then(isAvailable => {
         if (isAvailable === false) {
-          //  Exact match found
-          errorDiv.innerText = "⚠️ Component name already exists. Please choose another.";
+          errorDiv.innerText = '⚠️ Component name already exists. Please choose another.';
           errorDiv.classList.add('text-danger');
           errorDiv.classList.remove('text-success');
           componentNameInput.classList.add('is-invalid');
           createButton.disabled = true;
         } else {
-          // Name is available
-          errorDiv.innerText = "✅ Component name is available.";
+          errorDiv.innerText = '✅ Component name is available.';
           errorDiv.classList.remove('text-danger');
           errorDiv.classList.add('text-success');
           componentNameInput.classList.remove('is-invalid');
           validateFormFields();
         }
       })
-      .catch(err => {
-        console.error("Error checking component name:", err);
-        errorDiv.innerText = "⚠️ Server error while checking component name.";
+      .catch(() => {
+        errorDiv.innerText = '⚠️ Server error while checking component name.';
         errorDiv.classList.add('text-danger');
         errorDiv.classList.remove('text-success');
         componentNameInput.classList.add('is-invalid');
@@ -55,73 +188,33 @@ document.addEventListener("DOMContentLoaded", function () {
 
   componentNameInput.addEventListener('input', checkComponentNameAvailability);
 
-  window.autoFillFieldName = function (labelInput) {
-    const row = labelInput.closest('.field-row');
-    const nameInput = row.querySelector('.fieldName');
-    const labelValue = labelInput.value.trim();
-
-    const camelCase = labelValue
-      .replace(/[^a-zA-Z0-9 ]/g, '')
-      .split(/\s+/)
-      .map((word, i) => i === 0 ? word.toLowerCase() : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-      .join('');
-
-    nameInput.value = camelCase;
-    validateFormFields();
-  };
-
-  window.addFieldRow = function () {
-    const container = document.getElementById('fieldsContainer');
-    const firstRow = container.querySelector('.field-row');
-    const newRow = firstRow.cloneNode(true);
-
-    newRow.querySelectorAll('input').forEach(input => input.value = "");
-    newRow.querySelectorAll('select').forEach(select => select.value = "");
-
-    newRow.querySelector('.fieldLabel').setAttribute('name', `fields[${fieldIndex}].fieldLabel`);
-    newRow.querySelector('.fieldName').setAttribute('name', `fields[${fieldIndex}].fieldName`);
-    newRow.querySelector('.fieldType').setAttribute('name', `fields[${fieldIndex}].fieldType`);
-
-    const colAuto = newRow.querySelector('.col-auto');
-    colAuto.innerHTML = `<button type="button" class="btn btn-danger" onclick="removeFieldRow(this)">-</button>`;
-
-    newRow.classList.add('animate__animated', 'animate__fadeIn');
-    container.appendChild(newRow);
-    fieldIndex++;
-  };
-
-  window.removeFieldRow = function (button) {
-    const row = button.closest('.field-row');
-    const container = document.getElementById('fieldsContainer');
-    if (container.querySelectorAll('.field-row').length > 1) {
-      row.classList.add('removed');
-      setTimeout(() => row.remove(), 300);
-    }
-    validateFormFields();
-  };
-
   window.validateFormFields = function () {
-    const componentName = componentNameInput.value.trim();
-    const componentGroup = document.getElementById('componentGroup').value;
-
-    if (!componentName || !componentGroup || componentNameInput.classList.contains('is-invalid')) {
+    const name = componentNameInput.value.trim();
+    const group = document.getElementById('componentGroup').value;
+    if (!name || !group || componentNameInput.classList.contains('is-invalid')) {
       createButton.disabled = true;
       return;
     }
-
-    const rows = document.querySelectorAll('.field-row');
+    const rows = document.querySelectorAll('.field-row, .nested-row');
     for (let row of rows) {
       const label = row.querySelector('.fieldLabel').value.trim();
-      const name = row.querySelector('.fieldName').value.trim();
+      const fname = row.querySelector('.fieldName').value.trim();
       const type = row.querySelector('.fieldType').value;
-      if (!label || !name || !type) {
+      if (!label || !fname || !type) {
         createButton.disabled = true;
         return;
       }
+      const optionInputs = row.querySelectorAll('.option-row input');
+      for (let inp of optionInputs) {
+        if (!inp.value.trim()) {
+          createButton.disabled = true;
+          return;
+        }
+      }
     }
-
     createButton.disabled = false;
   };
 
   document.addEventListener('input', validateFormFields);
+  updateIndexes();
 });

--- a/src/main/resources/templates/create-component.html
+++ b/src/main/resources/templates/create-component.html
@@ -18,6 +18,15 @@
 
   <a th:href="@{'/' + ${projectName}}" class="btn btn-outline-secondary mb-3">← Back to DeployPage</a>
 
+  <div th:if="${message}" class="alert alert-success alert-dismissible fade show" role="alert">
+    <span th:text="${message}"></span>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  </div>
+  <div th:if="${error}" class="alert alert-danger alert-dismissible fade show" role="alert">
+    <span th:text="${error}"></span>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  </div>
+
   <form id="componentForm" th:action="@{'/component/create/' + ${projectName}}" method="post">
     <!-- Hidden input to pass projectName into JS -->
     <input type="hidden" id="projectName" th:value="${projectName}">
@@ -41,20 +50,24 @@
     <!-- Dialog Fields -->
     <div id="fieldsContainer" class="mb-3">
       <label>Dialog Fields</label>
-      <div class="field-row row mb-2 animate__animated animate__fadeIn">
-        <div class="col">
-          <input type="text" class="form-control fieldLabel" name="fields[0].fieldLabel" placeholder="Field Label" oninput="autoFillFieldName(this)" required>
+      <div class="field-row border p-2 mb-3 animate__animated animate__fadeIn">
+        <div class="row g-2 align-items-end">
+          <div class="col">
+            <input type="text" class="form-control fieldLabel" name="fields[0].fieldLabel" placeholder="Field Label" oninput="autoFillFieldName(this)" required>
+          </div>
+          <div class="col">
+            <input type="text" class="form-control fieldName" name="fields[0].fieldName" placeholder="Field Name" required>
+          </div>
+          <div class="col">
+            <select class="form-select fieldType" name="fields[0].fieldType" onchange="handleFieldTypeChange(this)" required>
+              <option value="">-- Select Type --</option>
+              <option th:each="type : ${fieldTypes}" th:value="${type.key}" th:text="${type.key}"></option>
+            </select>
+          </div>
+          <div class="col-auto action-col"></div>
         </div>
-        <div class="col">
-          <input type="text" class="form-control fieldName" name="fields[0].fieldName" placeholder="Field Name" required>
-        </div>
-        <div class="col">
-          <select class="form-select fieldType" name="fields[0].fieldType" required>
-            <option value="">-- Select Type --</option>
-            <option th:each="type : ${fieldTypes}" th:value="${type.key}" th:text="${type.key}"></option>
-          </select>
-        </div>
-        <div class="col-auto"></div>
+        <div class="options-container mt-2"></div>
+        <div class="nested-container mt-2"></div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- filter special component groups when listing groups
- preserve success/error messages when creating components
- store option value/text pairs for component fields
- support complex component field types on create page
- enhance component creation JS for nested fields/options

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6889fd19a7848326a82008d1d2288cf4