### PR TITLE
Add custom component editing

### DIFF
--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -96,4 +96,29 @@ public class ComponentController {
         return ResponseEntity.ok(isAvailable); // true means name is available
     }
 
+    //component editing
+    @GetMapping("/edit/{project}/{component}")
+    public String showEditForm(@PathVariable String project,
+                               @PathVariable String component,
+                               Model model) {
+        ComponentRequest req = componentService.getComponentDetails(project, component);
+        if (req == null) {
+            return "redirect:/" + project;
+        }
+        model.addAttribute("projectName", project);
+        model.addAttribute("component", req);
+        model.addAttribute("fieldTypes", FieldType.getTypeResourceMap());
+        model.addAttribute("componentGroups", componentService.getComponentGroups(project));
+        return "edit-component";
     }
+
+    @PostMapping("/component/edit/{project}/{component}")
+    public String updateComponent(@PathVariable String project,
+                                  @PathVariable String component,
+                                  @ModelAttribute ComponentRequest request) {
+        request.setComponentName(component);
+        componentService.updateComponent(project, component, request);
+        return "redirect:/" + project;
+    }
+
+}

--- a/src/main/java/com/aem/builder/model/Enum/FieldType.java
+++ b/src/main/java/com/aem/builder/model/Enum/FieldType.java
@@ -55,4 +55,13 @@ public enum FieldType {
     private Map.Entry<String, String> toEntry() {
         return Map.entry(this.type, this.resourceType);
     }
+
+    public static FieldType fromResourceType(String resourceType) {
+        for (FieldType type : values()) {
+            if (type.getResourceType().equals(resourceType)) {
+                return type;
+            }
+        }
+        return TEXTFIELD;
+    }
 }

--- a/src/main/java/com/aem/builder/service/ComponentService.java
+++ b/src/main/java/com/aem/builder/service/ComponentService.java
@@ -27,6 +27,10 @@ public interface ComponentService {
     List<String> getComponentGroups(String projectName);
     void generateComponent(String projectName, ComponentRequest request);
 
+    ComponentRequest getComponentDetails(String projectName, String componentName);
+
+    void updateComponent(String projectName, String componentName, ComponentRequest request);
+
     //component checking
     boolean isComponentNameAvailable(String projectName, String componentName);
 

--- a/src/main/resources/static/js/edit-component.js
+++ b/src/main/resources/static/js/edit-component.js
@@ -1,0 +1,67 @@
+document.addEventListener("DOMContentLoaded", function () {
+  let fieldIndex = typeof existingFieldCount !== 'undefined' ? existingFieldCount : 1;
+
+  const createButton = document.getElementById('createButton');
+  const componentNameInput = document.getElementById('componentName');
+
+  window.autoFillFieldName = function (labelInput) {
+    const row = labelInput.closest('.field-row');
+    const nameInput = row.querySelector('.fieldName');
+    const labelValue = labelInput.value.trim();
+    const camelCase = labelValue
+      .replace(/[^a-zA-Z0-9 ]/g, '')
+      .split(/\s+/)
+      .map((word, i) => i === 0 ? word.toLowerCase() : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .join('');
+    nameInput.value = camelCase;
+    validateFormFields();
+  };
+
+  window.addFieldRow = function () {
+    const container = document.getElementById('fieldsContainer');
+    const firstRow = container.querySelector('.field-row');
+    const newRow = firstRow.cloneNode(true);
+    newRow.querySelectorAll('input').forEach(input => input.value = "");
+    newRow.querySelectorAll('select').forEach(select => select.value = "");
+    newRow.querySelector('.fieldLabel').setAttribute('name', `fields[${fieldIndex}].fieldLabel`);
+    newRow.querySelector('.fieldName').setAttribute('name', `fields[${fieldIndex}].fieldName`);
+    newRow.querySelector('.fieldType').setAttribute('name', `fields[${fieldIndex}].fieldType`);
+    const colAuto = newRow.querySelector('.col-auto');
+    colAuto.innerHTML = `<button type="button" class="btn btn-danger" onclick="removeFieldRow(this)">-</button>`;
+    newRow.classList.add('animate__animated', 'animate__fadeIn');
+    container.appendChild(newRow);
+    fieldIndex++;
+  };
+
+  window.removeFieldRow = function (button) {
+    const row = button.closest('.field-row');
+    const container = document.getElementById('fieldsContainer');
+    if (container.querySelectorAll('.field-row').length > 1) {
+      row.classList.add('removed');
+      setTimeout(() => row.remove(), 300);
+    }
+    validateFormFields();
+  };
+
+  window.validateFormFields = function () {
+    const componentGroup = document.getElementById('componentGroup').value;
+    if (!componentGroup) {
+      createButton.disabled = true;
+      return;
+    }
+    const rows = document.querySelectorAll('.field-row');
+    for (let row of rows) {
+      const label = row.querySelector('.fieldLabel').value.trim();
+      const name = row.querySelector('.fieldName').value.trim();
+      const type = row.querySelector('.fieldType').value;
+      if (!label || !name || !type) {
+        createButton.disabled = true;
+        return;
+      }
+    }
+    createButton.disabled = false;
+  };
+
+  document.addEventListener('input', validateFormFields);
+  validateFormFields();
+});

--- a/src/main/resources/templates/edit-component.html
+++ b/src/main/resources/templates/edit-component.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>Edit AEM Component</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/animate.css@4.1.1/animate.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <link rel="stylesheet" href="/css/create-component.css">
+  <script th:inline="javascript">
+    /*<![CDATA[*/
+    var existingFieldCount = [[${component.fields.size()}]];
+    /*]]>*/
+  </script>
+  <script th:src="@{/js/edit-component.js}"></script>
+</head>
+<body>
+<div th:replace="fragments/navbar :: navbar"></div>
+
+<div class="container mt-4 mb-5">
+  <h2 class="mb-4 animate__animated animate__fadeInDown">Edit AEM Component for [[${projectName}]]</h2>
+
+  <a th:href="@{'/' + ${projectName}}" class="btn btn-outline-secondary mb-3">← Back to DeployPage</a>
+
+  <form id="componentForm" th:action="@{'/component/edit/' + ${projectName} + '/' + ${component.componentName}}" method="post">
+    <input type="hidden" id="projectName" th:value="${projectName}">
+
+    <div class="mb-3">
+      <label class="form-label">Component Name</label>
+      <input type="text" class="form-control" name="componentName" id="componentName" th:value="${component.componentName}" readonly>
+    </div>
+
+    <div class="mb-3">
+      <label class="form-label">Component Group</label>
+      <select class="form-select" name="componentGroup" id="componentGroup" required>
+        <option value="">-- Select Component Group --</option>
+        <option th:each="group : ${componentGroups}" th:value="${group}" th:text="${group}" th:selected="${group == component.componentGroup}"></option>
+      </select>
+    </div>
+
+    <div id="fieldsContainer" class="mb-3">
+      <label>Dialog Fields</label>
+      <div th:each="field,iter : ${component.fields}" class="field-row row mb-2 animate__animated animate__fadeIn">
+        <div class="col">
+          <input type="text" class="form-control fieldLabel" th:name="'fields[' + ${iter.index} + '].fieldLabel'" th:value="${field.fieldLabel}" oninput="autoFillFieldName(this)" required>
+        </div>
+        <div class="col">
+          <input type="text" class="form-control fieldName" th:name="'fields[' + ${iter.index} + '].fieldName'" th:value="${field.fieldName}" required>
+        </div>
+        <div class="col">
+          <select class="form-select fieldType" th:name="'fields[' + ${iter.index} + '].fieldType'" required>
+            <option value="">-- Select Type --</option>
+            <option th:each="type : ${fieldTypes}" th:value="${type.key}" th:text="${type.key}" th:selected="${type.key == field.fieldType}"></option>
+          </select>
+        </div>
+        <div class="col-auto" th:if="${iter.index > 0}">
+          <button type="button" class="btn btn-danger" onclick="removeFieldRow(this)">-</button>
+        </div>
+      </div>
+    </div>
+
+    <button type="button" class="btn btn-primary mb-3" onclick="addFieldRow()">+ Add Field</button><br>
+    <button type="submit" class="btn btn-primary" id="createButton" disabled>Update Component</button>
+  </form>
+</div>
+
+<footer>
+  <div th:replace="fragments/navbar :: footer"></div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add capability to load and update custom component definitions
- expose edit endpoints in `ComponentController`
- support retrieving existing component data and regenerating files
- add helper in `FieldType` to map from resourceType
- create `edit-component.html` template and JS helper

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_688a012b9ff483309b061cf9f44b0450