### PR TITLE
Add module selection for AEM deployment

### DIFF
--- a/src/main/java/com/aem/builder/controller/DeployController.java
+++ b/src/main/java/com/aem/builder/controller/DeployController.java
@@ -32,16 +32,20 @@ public class DeployController {
         model.addAttribute("components", components);
         model.addAttribute("templates", templates);
         model.addAttribute("canDeploy", true);
+        model.addAttribute("projectName", projectName);
         logger.debug("DEPLOY: Added attributes to model for project: {}", projectName);
         return "deploy";
     }
 
     @PostMapping("/{projectName}/deploy")
-    public String deployProject(@PathVariable String projectName, RedirectAttributes redirectAttributes) {
+    public String deployProject(
+            @PathVariable String projectName,
+            @org.springframework.web.bind.annotation.RequestParam(value = "module", defaultValue = "all") String module,
+            RedirectAttributes redirectAttributes) {
         logger.info("DEPLOY: Starting deployment for project: {}", projectName);
         try {
-            String message = deployService.deployProject(projectName);
-            logger.info("DEPLOY: Deployment successful for project: {}. Message: {}", projectName, message);
+            String message = deployService.deployProject(projectName, module);
+            logger.info("DEPLOY: Deployment successful for project: {} module: {}. Message: {}", projectName, module, message);
             redirectAttributes.addFlashAttribute("message", message);
         } catch (Exception e) {
             logger.error("DEPLOY: Deployment failed for project: {}", projectName, e);

--- a/src/main/java/com/aem/builder/service/DeployService.java
+++ b/src/main/java/com/aem/builder/service/DeployService.java
@@ -1,6 +1,6 @@
 package com.aem.builder.service;
 
 public interface DeployService {
-    String deployProject(String projectName) throws Exception;
+    String deployProject(String projectName, String module) throws Exception;
     String extractErrorMessage(String fullOutput);
 }

--- a/src/main/java/com/aem/builder/service/impl/DeployServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/DeployServiceImpl.java
@@ -13,10 +13,17 @@ public class DeployServiceImpl implements DeployService {
     private static final String PROJECTS_DIR = "generated-projects";
 
     @Override
-    public String deployProject(String projectName) throws Exception {
+    public String deployProject(String projectName, String module) throws Exception {
         File projectDir = new File(PROJECTS_DIR, projectName);
-        ProcessBuilder pb = new ProcessBuilder("mvn", "clean", "install", "-PautoInstallPackage");
-        pb.directory(projectDir);
+        ProcessBuilder pb;
+        if (module == null || module.equalsIgnoreCase("all")) {
+            pb = new ProcessBuilder("mvn", "clean", "install", "-PautoInstallPackage");
+            pb.directory(projectDir);
+        } else {
+            File moduleDir = new File(projectDir, module);
+            pb = new ProcessBuilder("mvn", "clean", "install", "-PautoInstallBundle");
+            pb.directory(moduleDir);
+        }
         pb.redirectErrorStream(true); // stderr + stdout combined
 
         Process process = pb.start();
@@ -37,7 +44,10 @@ public class DeployServiceImpl implements DeployService {
             throw new RuntimeException(meaningfulError);
         }
 
-        return "Build successful for project: " + projectName;
+        if (module == null || module.equalsIgnoreCase("all")) {
+            return "Build successful for project: " + projectName;
+        }
+        return "Build successful for module: " + module + " of project: " + projectName;
     }
 
     @Override

--- a/src/main/resources/templates/deploy.html
+++ b/src/main/resources/templates/deploy.html
@@ -31,6 +31,12 @@
             <button id="saveBtn" class="btn btn-outline-success me-2" style="display:none" onclick="saveAll()">Save</button>
 
             <form th:action="@{'/' + ${projectName} + '/deploy'}" method="post" class="d-inline" onsubmit="return showDeploySpinner()">
+                <select name="module" class="form-select form-select-sm me-2" style="width:auto; display:inline-block;">
+                    <option value="all">All Packages</option>
+                    <option value="core">core</option>
+                    <option value="ui.apps">ui.apps</option>
+                    <option value="ui.content">ui.content</option>
+                </select>
                 <button id="deployBtn" class="btn btn-warning" type="submit" th:attr="disabled=${!canDeploy}">
                     <span id="deploySpinner" class="spinner-border spinner-border-sm me-2" style="display: none;"></span>
                     Deploy to AEM


### PR DESCRIPTION
## Summary
- allow choosing which module to deploy on the deploy page
- wire DeployController and DeployService to support module option

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_688a0741bd4883309caa8fdf869b9096