### PR TITLE
Add template edit option

### DIFF
--- a/src/main/java/com/aem/builder/controller/TemplateController.java
+++ b/src/main/java/com/aem/builder/controller/TemplateController.java
@@ -77,4 +77,15 @@ public class TemplateController {
         return "createtemplate";
     }
 
+    @GetMapping("/{projectName}/edittemplate/{templateName}")
+    public String editTemplateForm(@PathVariable String projectName,
+                                   @PathVariable String templateName,
+                                   Model model) throws Exception {
+        TemplateModel template = templateService.getTemplateDetails(projectName, templateName);
+        model.addAttribute("projectName", projectName);
+        model.addAttribute("template", template);
+        model.addAttribute("edit", true);
+        return "createtemplate";
+    }
+
 }

--- a/src/main/java/com/aem/builder/service/TemplateService.java
+++ b/src/main/java/com/aem/builder/service/TemplateService.java
@@ -21,5 +21,7 @@ public interface TemplateService {
     //template type xf
     void createTemplateXf(TemplateModel model,String projectname) throws IOException;
 
+    TemplateModel getTemplateDetails(String projectName, String templateName) throws Exception;
+
 
 }

--- a/src/main/java/com/aem/builder/service/impl/TemplateServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/TemplateServiceImpl.java
@@ -181,6 +181,42 @@ public class TemplateServiceImpl implements TemplateService {
         writeFile(targetpath+"/policies/.content.xml",TemplateUtil.generatePoliciesXmlXf(projectname));
     }
 
+    @Override
+    public TemplateModel getTemplateDetails(String projectName, String templateName) throws Exception {
+        String basePath = PROJECTS_DIR + "/" + projectName +
+                "/ui.content/src/main/content/jcr_root/conf/" + projectName +
+                "/settings/wcm/templates/" + templateName + "/.content.xml";
+
+        File xmlFile = new File(basePath);
+        if (!xmlFile.exists()) {
+            return null;
+        }
+
+        javax.xml.parsers.DocumentBuilderFactory dbFactory = javax.xml.parsers.DocumentBuilderFactory.newInstance();
+        javax.xml.parsers.DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        org.w3c.dom.Document doc = dBuilder.parse(xmlFile);
+        doc.getDocumentElement().normalize();
+        org.w3c.dom.NodeList nodeList = doc.getElementsByTagName("jcr:content");
+        if (nodeList.getLength() == 0) {
+            return null;
+        }
+        org.w3c.dom.Element element = (org.w3c.dom.Element) nodeList.item(0);
+        String title = element.getAttribute("jcr:title");
+        String status = element.getAttribute("status");
+        String typePath = element.getAttribute("cq:templateType");
+        String templateType = "";
+        if (typePath != null && typePath.contains("template-types/")) {
+            templateType = typePath.substring(typePath.lastIndexOf('/') + 1);
+        }
+
+        return TemplateModel.builder()
+                .name(templateName)
+                .title(title)
+                .status(status)
+                .templateType(templateType)
+                .build();
+    }
+
 
 
 

--- a/src/main/resources/templates/createtemplate.html
+++ b/src/main/resources/templates/createtemplate.html
@@ -6,24 +6,24 @@
     <meta charset="UTF-8">
 </head>
 <body>
-<h2>Create Template</h2>
+<h2 th:text="${edit} ? 'Edit Template' : 'Create Template'"></h2>
 
 <form id="templateForm">
     <input type="hidden" id="projectname" th:value="${projectName}">
     <label for="name">Template Name:</label><br>
-    <input type="text" id="name" name="name" required><br><br>
+    <input type="text" id="name" name="name" required th:value="${template?.name}"><br><br>
     <label for="title">Title:</label><br>
-    <input type="text" id="title" name="title" required><br><br>
+    <input type="text" id="title" name="title" required th:value="${template?.title}"><br><br>
     <label for="description">Description:</label><br>
-    <input type="text" id="description" name="description" required><br><br>
+    <input type="text" id="description" name="description" required th:value="${template?.description}"><br><br>
     <label for="status">enable or draft</label><br>
-    <input type="text" id="status" name="status" required><br><br>
+    <input type="text" id="status" name="status" required th:value="${template?.status}"><br><br>
 
     <label for="templatetype">Template Type:</label><br>
     <select id="templatetype" name="templatetype" required>
         <option value="">--Select Type--</option>
-        <option value="xf">Generic template for empty exp (xf)</option>
-        <option value="page">Page</option>
+        <option value="xf" th:selected="${template?.templateType == 'xf'}">Generic template for empty exp (xf)</option>
+        <option value="page" th:selected="${template?.templateType == 'page'}">Page</option>
     </select><br><br>
 
     <button type="submit">Create Template</button>

--- a/src/main/resources/templates/deploy.html
+++ b/src/main/resources/templates/deploy.html
@@ -63,7 +63,10 @@
                 </div>
                 <div id="templatesList" class="row row-cols-1 row-cols-sm-2 g-2">
                     <div class="col" th:each="template : ${templates}">
-                        <div class="border rounded p-2 bg-light text-center shadow-sm" th:text="${template}"></div>
+                        <div class="border rounded p-2 bg-light text-center shadow-sm d-flex justify-content-between align-items-center">
+                            <span th:text="${template}"></span>
+                            <a th:href="@{/{projectName}/edittemplate/{t}(projectName=${projectName}, t=${template})}" class="btn btn-sm btn-outline-secondary">Edit</a>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- support retrieving template details from generated project
- expose GET endpoint to load template data
- add edit button on deploy page
- pre-fill fields on template creation page when editing

## Testing
- `mvn -q test` *(fails: parent POM non-resolvable)*

------
https://chatgpt.com/codex/tasks/task_b_688a0e20c7ac8330952cecc0d69b5edb