### PR TITLE
Add component extension support

### DIFF
--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -47,6 +47,12 @@ public class ComponentController {
         return response;
     }
 
+    @GetMapping("/available-components/{project}")
+    @ResponseBody
+    public List<String> availableComponents(@PathVariable String project) throws IOException {
+        return componentService.getAvailableComponents(project);
+    }
+
     @PostMapping("/add-components/{projectname}")
     public String addComponentsToExistingProject(
             @PathVariable String projectname,

--- a/src/main/java/com/aem/builder/model/DTO/ComponentRequest.java
+++ b/src/main/java/com/aem/builder/model/DTO/ComponentRequest.java
@@ -13,6 +13,7 @@ public class ComponentRequest {
     private String projectName;
     private String componentName;
     private String componentGroup;
+    private String extendsComponent;
     private List<ComponentField> fields;
 
 }

--- a/src/main/java/com/aem/builder/service/ComponentService.java
+++ b/src/main/java/com/aem/builder/service/ComponentService.java
@@ -30,6 +30,8 @@ public interface ComponentService {
     List<String> getComponentGroups(String projectName);
     void generateComponent(String projectName, ComponentRequest request);
 
+    List<String> getAvailableComponents(String projectName) throws IOException;
+
     //component checking
     boolean isComponentNameAvailable(String projectName, String componentName);
 

--- a/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
@@ -185,6 +185,18 @@ public class ComponentServiceImpl implements ComponentService {
         FileGenerationUtil.generateAllFiles(projectName, request);
     }
 
+    @Override
+    public List<String> getAvailableComponents(String projectName) throws IOException {
+        List<String> result = new ArrayList<>();
+        for (String comp : getAllComponents()) {
+            result.add("/apps/core/wcm/components/" + comp);
+        }
+        for (String comp : fetchComponentsFromGeneratedProjects(projectName)) {
+            result.add("/apps/" + projectName + "/components/" + comp);
+        }
+        return result;
+    }
+
 
 //component checking
 @Override

--- a/src/main/java/com/aem/builder/util/FileGenerationUtil.java
+++ b/src/main/java/com/aem/builder/util/FileGenerationUtil.java
@@ -32,7 +32,7 @@ public class FileGenerationUtil {
             String packageName = "com." + projectName + ".core.models";
 
             generateComponent(basePath, modelBasePath, packageName, request.getComponentName(),
-                    request.getComponentGroup(), request.getFields());
+                    request.getComponentGroup(), request.getFields(), request.getExtendsComponent());
             logger.info("FILEGEN: Successfully generated all files for project: {}", projectName);
         } catch (Exception e) {
             logger.info("FILEGEN: Error generating files for project: {}", projectName, e);
@@ -44,7 +44,7 @@ public class FileGenerationUtil {
      * Generates component folders, content.xml, HTL, dialog, and Sling model.
      */
     public static void generateComponent(String basePath, String modelBasePath, String packageName,
-            String componentName, String componentGroup, List<ComponentField> fields) throws Exception {
+            String componentName, String componentGroup, List<ComponentField> fields, String superType) throws Exception {
         logger.info("COMPONENT: Generating component '{}'", componentName);
 
         String componentFolder = basePath + "/" + componentName;
@@ -52,7 +52,7 @@ public class FileGenerationUtil {
 
         new File(dialogFolder).mkdirs();
 
-        generateComponentContentXml(componentFolder, componentName, componentGroup);
+        generateComponentContentXml(componentFolder, componentName, componentGroup, superType);
         generateHTL(componentFolder, fields, packageName, componentName);
         generateDialogContentXml(componentName, dialogFolder, fields);
         generateSlingModel(modelBasePath, packageName, componentName, fields);
@@ -63,8 +63,8 @@ public class FileGenerationUtil {
     /**
      * Generates the .content.xml for the component.
      */
-    private static void generateComponentContentXml(String folderPath, String componentName, String componentGroup)
-            throws Exception {
+    private static void generateComponentContentXml(String folderPath, String componentName, String componentGroup,
+            String superType) throws Exception {
         logger.info("CONTENTXML: Generating .content.xml for component '{}'", componentName);
         String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<jcr:root xmlns:sling=\"http://sling.apache.org/jcr/sling/1.0\"\n" +
@@ -72,7 +72,11 @@ public class FileGenerationUtil {
                 "          xmlns:jcr=\"http://www.jcp.org/jcr/1.0\"\n" +
                 "          jcr:primaryType=\"cq:Component\"\n" +
                 "          jcr:title=\"" + componentName + "\"\n" +
-                "          componentGroup=\"" + componentGroup + "\"/>";
+                "          componentGroup=\"" + componentGroup + "\"";
+        if (superType != null && !superType.isBlank()) {
+            content += "\n          sling:resourceSuperType=\"" + superType + "\"";
+        }
+        content += "/>";
         FileUtils.writeStringToFile(new File(folderPath + "/.content.xml"), content, StandardCharsets.UTF_8);
         logger.info("CONTENTXML: .content.xml generated at {}/.content.xml", folderPath);
     }

--- a/src/main/resources/static/js/create-component.js
+++ b/src/main/resources/static/js/create-component.js
@@ -103,6 +103,7 @@ document.addEventListener("DOMContentLoaded", function () {
       addNestedFieldRow(addBtn);
     }
     updateIndexes();
+    validateFormFields();
   };
 
   window.addFieldRow = function () {
@@ -112,11 +113,13 @@ document.addEventListener("DOMContentLoaded", function () {
     container.appendChild(row);
     updateIndexes();
     row.classList.add('animate__animated','animate__fadeIn');
+    validateFormFields();
   };
 
   window.removeFieldRow = function (btn) {
     btn.closest('.field-row').remove();
     updateIndexes();
+    validateFormFields();
   };
 
   function addNestedFieldRow(btn) {
@@ -126,10 +129,12 @@ document.addEventListener("DOMContentLoaded", function () {
     const row = createBaseRow(true, level);
     container.insertBefore(row, btn);
     updateIndexes();
+    validateFormFields();
   }
   window.removeNestedFieldRow = function (btn) {
     btn.closest('.nested-row').remove();
     updateIndexes();
+    validateFormFields();
   };
 
   function addOptionRow(btn) {
@@ -141,10 +146,12 @@ document.addEventListener("DOMContentLoaded", function () {
       <button type="button" class="btn btn-danger" onclick="removeOptionRow(this)">-</button>`;
     container.insertBefore(div, btn);
     updateIndexes();
+    validateFormFields();
   }
   window.removeOptionRow = function (btn) {
     btn.parentElement.remove();
     updateIndexes();
+    validateFormFields();
   };
 
   function updateIndexes() {
@@ -260,5 +267,6 @@ document.addEventListener("DOMContentLoaded", function () {
   };
 
   document.addEventListener('input', validateFormFields);
+  document.addEventListener('change', validateFormFields);
   updateIndexes();
 });

--- a/src/main/resources/static/js/create-component.js
+++ b/src/main/resources/static/js/create-component.js
@@ -5,6 +5,10 @@ document.addEventListener("DOMContentLoaded", function () {
   const extendsDiv = document.getElementById('extendsDiv');
   const extendsSelect = document.getElementById('extendsComponent');
 
+  document.querySelectorAll('.fieldName').forEach(f => {
+    f.dataset.touched = 'false';
+  });
+
   function loadAvailableComponents() {
     fetch(`/available-components/${projectName}`)
       .then(res => res.json())
@@ -50,7 +54,7 @@ document.addEventListener("DOMContentLoaded", function () {
           <input type="text" class="form-control fieldLabel" placeholder="Field Label" oninput="autoFillFieldName(this)" required>
         </div>
         <div class="col">
-          <input type="text" class="form-control fieldName" placeholder="Field Name" required>
+          <input type="text" class="form-control fieldName" placeholder="Field Name" oninput="markFieldNameTouched(this)" required>
         </div>
         <div class="col">
           <select class="form-select fieldType" onchange="handleFieldTypeChange(this)" required>${typeOptions}</select>
@@ -61,12 +65,17 @@ document.addEventListener("DOMContentLoaded", function () {
       </div>
       <div class="options-container mt-2"></div>
       <div class="nested-container mt-2"></div>`;
+    div.querySelector('.fieldName').dataset.touched = 'false';
     return div;
   }
 
   window.autoFillFieldName = function (labelInput) {
     const row = labelInput.closest('.field-row, .nested-row');
     const nameInput = row.querySelector('.fieldName');
+    if (nameInput.dataset.touched === 'true') {
+      validateFormFields();
+      return;
+    }
     const labelValue = labelInput.value.trim();
     const camelCase = labelValue
       .replace(/[^a-zA-Z0-9 ]/g, '')
@@ -74,6 +83,13 @@ document.addEventListener("DOMContentLoaded", function () {
       .map((w, i) => i === 0 ? w.toLowerCase() : w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
       .join('');
     nameInput.value = camelCase;
+    nameInput.dataset.autofilled = 'true';
+    validateFormFields();
+  };
+
+  window.markFieldNameTouched = function (input) {
+    input.dataset.touched = 'true';
+    input.dataset.autofilled = 'false';
     validateFormFields();
   };
 

--- a/src/main/resources/static/js/create-component.js
+++ b/src/main/resources/static/js/create-component.js
@@ -1,5 +1,40 @@
 document.addEventListener("DOMContentLoaded", function () {
   const typeOptions = document.querySelector('.fieldType').innerHTML;
+  const projectName = document.getElementById('projectName').value;
+  const componentType = document.getElementById('componentType');
+  const extendsDiv = document.getElementById('extendsDiv');
+  const extendsSelect = document.getElementById('extendsComponent');
+
+  function loadAvailableComponents() {
+    fetch(`/available-components/${projectName}`)
+      .then(res => res.json())
+      .then(data => {
+        extendsSelect.innerHTML = '<option value="">-- Select Component --</option>';
+        data.forEach(item => {
+          const opt = document.createElement('option');
+          opt.value = item;
+          opt.textContent = item.split('/').pop();
+          extendsSelect.appendChild(opt);
+        });
+      });
+  }
+
+  function handleTypeChange() {
+    if (componentType.value === 'extend') {
+      extendsDiv.style.display = 'block';
+      loadAvailableComponents();
+    } else {
+      extendsDiv.style.display = 'none';
+      extendsSelect.innerHTML = '';
+    }
+    validateFormFields();
+  }
+
+  componentType.addEventListener('change', handleTypeChange);
+  if (extendsSelect) {
+    extendsSelect.addEventListener('change', validateFormFields);
+  }
+  handleTypeChange();
 
   function createBaseRow(isNested, level = 0) {
     const div = document.createElement('div');
@@ -146,7 +181,6 @@ document.addEventListener("DOMContentLoaded", function () {
   const componentNameInput = document.getElementById('componentName');
   const errorDiv = document.getElementById('nameError');
   const createButton = document.getElementById('createButton');
-  const projectName = document.getElementById('projectName').value;
 
   function debounce(func, delay) {
     let timer;
@@ -198,6 +232,10 @@ document.addEventListener("DOMContentLoaded", function () {
     const name = componentNameInput.value.trim();
     const group = document.getElementById('componentGroup').value;
     if (!name || !group || componentNameInput.classList.contains('is-invalid')) {
+      createButton.disabled = true;
+      return;
+    }
+    if (componentType.value === 'extend' && !extendsSelect.value) {
       createButton.disabled = true;
       return;
     }

--- a/src/main/resources/templates/create-component.html
+++ b/src/main/resources/templates/create-component.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/animate.css@4.1.1/animate.min.css">
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <link rel="stylesheet" href="/css/create-component.css">
-  <script th:src="@{/js/create-component.js}"></script>
+  <script th:src="@{/js/create-component.js}" defer></script>
 </head>
 <body>
 

--- a/src/main/resources/templates/create-component.html
+++ b/src/main/resources/templates/create-component.html
@@ -71,7 +71,7 @@
             <input type="text" class="form-control fieldLabel" name="fields[0].fieldLabel" placeholder="Field Label" oninput="autoFillFieldName(this)" required>
           </div>
           <div class="col">
-            <input type="text" class="form-control fieldName" name="fields[0].fieldName" placeholder="Field Name" required>
+            <input type="text" class="form-control fieldName" name="fields[0].fieldName" placeholder="Field Name" oninput="markFieldNameTouched(this)" required>
           </div>
           <div class="col">
             <select class="form-select fieldType" name="fields[0].fieldType" onchange="handleFieldTypeChange(this)" required>

--- a/src/main/resources/templates/create-component.html
+++ b/src/main/resources/templates/create-component.html
@@ -31,6 +31,21 @@
     <!-- Hidden input to pass projectName into JS -->
     <input type="hidden" id="projectName" th:value="${projectName}">
 
+    <!-- Component Type -->
+    <div class="mb-3">
+      <label class="form-label">Component Type</label>
+      <select class="form-select" id="componentType">
+        <option value="new">New Component</option>
+        <option value="extend">Extend Existing</option>
+      </select>
+    </div>
+
+    <div class="mb-3" id="extendsDiv" style="display:none;">
+      <label class="form-label">Extend From</label>
+      <select class="form-select" id="extendsComponent" name="extendsComponent">
+      </select>
+    </div>
+
     <!-- Component Name -->
     <div class="mb-3">
       <label class="form-label">Component Name</label>


### PR DESCRIPTION
## Summary
- add `extendsComponent` field to request DTO
- expose available component list via controller and service
- update file generation logic to set `sling:resourceSuperType`
- update create-component UI and JS to support extending existing components

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_688aecfff10c83268114ff78546e7d2b