### PR TITLE
Enable component extension parsing

### DIFF
--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -1,6 +1,7 @@
 package com.aem.builder.controller;
 
 import com.aem.builder.model.DTO.ComponentRequest;
+import com.aem.builder.model.DTO.ComponentField;
 import com.aem.builder.model.Enum.FieldType;
 import com.aem.builder.service.ComponentService;
 import lombok.RequiredArgsConstructor;
@@ -51,6 +52,12 @@ public class ComponentController {
     @ResponseBody
     public List<String> availableComponents(@PathVariable String project) throws IOException {
         return componentService.getAvailableComponents(project);
+    }
+
+    @GetMapping("/component/fields")
+    @ResponseBody
+    public List<ComponentField> componentFields(@RequestParam String path) {
+        return componentService.getComponentFields(path);
     }
 
     @PostMapping("/add-components/{projectname}")

--- a/src/main/java/com/aem/builder/model/Enum/FieldType.java
+++ b/src/main/java/com/aem/builder/model/Enum/FieldType.java
@@ -52,6 +52,19 @@ public enum FieldType {
         );
     }
 
+    /**
+     * Utility to map a sling:resourceType back to the logical field type.
+     * Returns an empty string if the resource type is unknown.
+     */
+    public static String getTypeByResource(String resourceType) {
+        for (FieldType ft : values()) {
+            if (ft.resourceType.equals(resourceType)) {
+                return ft.type;
+            }
+        }
+        return "";
+    }
+
     private Map.Entry<String, String> toEntry() {
         return Map.entry(this.type, this.resourceType);
     }

--- a/src/main/java/com/aem/builder/service/ComponentService.java
+++ b/src/main/java/com/aem/builder/service/ComponentService.java
@@ -1,12 +1,11 @@
 package com.aem.builder.service;
 
 import com.aem.builder.model.DTO.ComponentRequest;
+import com.aem.builder.model.DTO.ComponentField;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-
-import java.util.List;
 
 public interface ComponentService {
     List<String> fetchComponentsFromGeneratedProjects(String projectName);
@@ -31,6 +30,8 @@ public interface ComponentService {
     void generateComponent(String projectName, ComponentRequest request);
 
     List<String> getAvailableComponents(String projectName) throws IOException;
+
+    List<ComponentField> getComponentFields(String componentPath);
 
     //component checking
     boolean isComponentNameAvailable(String projectName, String componentName);

--- a/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
@@ -1,23 +1,19 @@
 package com.aem.builder.service.impl;
 
 import com.aem.builder.model.DTO.ComponentRequest;
+import com.aem.builder.model.DTO.ComponentField;
 import com.aem.builder.service.ComponentService;
 import com.aem.builder.util.FileGenerationUtil;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-
-import java.io.File;
-import java.util.*;
-import java.util.stream.Collectors;
-import com.aem.builder.service.ComponentService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.stereotype.Service;
+
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -195,6 +191,33 @@ public class ComponentServiceImpl implements ComponentService {
             result.add("/apps/" + projectName + "/components/" + comp);
         }
         return result;
+    }
+
+    @Override
+    public List<ComponentField> getComponentFields(String componentPath) {
+        try {
+            String dialogPath;
+            if (componentPath.startsWith("/apps/core/wcm/components/")) {
+                String name = componentPath.substring("/apps/core/wcm/components/".length());
+                dialogPath = "src/main/resources/aem-components/" + name + "/_cq_dialog/.content.xml";
+            } else if (componentPath.startsWith("/apps/")) {
+                String[] parts = componentPath.split("/");
+                if (parts.length >= 5) {
+                    String project = parts[2];
+                    String comp = parts[4];
+                    dialogPath = PROJECTS_DIR + "/" + project + "/ui.apps/src/main/content/jcr_root/apps/" + project
+                            + "/components/" + comp + "/_cq_dialog/.content.xml";
+                } else {
+                    return List.of();
+                }
+            } else {
+                return List.of();
+            }
+            return FileGenerationUtil.parseDialogFields(dialogPath);
+        } catch (Exception e) {
+            log.error("Failed to read dialog for {}", componentPath, e);
+            return List.of();
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- allow fetching component field data from a component path
- parse cq:dialog XML to discover field definitions
- expose new endpoint `/component/fields`
- update JavaScript to populate fields when extending a component

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/...)*

------
https://chatgpt.com/codex/tasks/task_b_688afa67be948326acff788ff046e07a