### PR TITLE
Add super type selection for component creation

### DIFF
--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -72,7 +72,8 @@ public class ComponentController {
         model.addAttribute("fieldTypes", FieldType.getTypeResourceMap());
         model.addAttribute("componentGroups", componentService.getComponentGroups(project));
         // Components that can be extended (core components + existing ones)
-        List<String> available = new ArrayList<>();
+        // Use a LinkedHashSet to avoid duplicates while preserving order
+        Set<String> available = new LinkedHashSet<>();
         try {
             available.addAll(componentService.fetchComponentsFromGeneratedProjects(project).stream()
                     .map(name -> "/apps/" + project + "/components/" + name)
@@ -81,7 +82,7 @@ public class ComponentController {
         } catch (IOException e) {
             log.error("Error loading available components", e);
         }
-        model.addAttribute("availableComponents", available);
+        model.addAttribute("availableComponents", new ArrayList<>(available));
         return "create-component"; // Thymeleaf template
     }
 

--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -71,6 +71,17 @@ public class ComponentController {
         model.addAttribute("projectName", project);
         model.addAttribute("fieldTypes", FieldType.getTypeResourceMap());
         model.addAttribute("componentGroups", componentService.getComponentGroups(project));
+        // Components that can be extended (core components + existing ones)
+        List<String> available = new ArrayList<>();
+        try {
+            available.addAll(componentService.fetchComponentsFromGeneratedProjects(project).stream()
+                    .map(name -> "/apps/" + project + "/components/" + name)
+                    .toList());
+            available.addAll(componentService.getAllComponents());
+        } catch (IOException e) {
+            log.error("Error loading available components", e);
+        }
+        model.addAttribute("availableComponents", available);
         return "create-component"; // Thymeleaf template
     }
 

--- a/src/main/java/com/aem/builder/model/DTO/ComponentRequest.java
+++ b/src/main/java/com/aem/builder/model/DTO/ComponentRequest.java
@@ -13,6 +13,12 @@ public class ComponentRequest {
     private String projectName;
     private String componentName;
     private String componentGroup;
+    /**
+     * Optional component that this component extends. This value will be used as
+     * {@code sling:resourceSuperType} when generating the component's
+     * {@code .content.xml}.
+     */
+    private String superType;
     private List<ComponentField> fields;
 
 }

--- a/src/main/java/com/aem/builder/util/FileGenerationUtil.java
+++ b/src/main/java/com/aem/builder/util/FileGenerationUtil.java
@@ -32,7 +32,7 @@ public class FileGenerationUtil {
             String packageName = "com." + projectName + ".core.models";
 
             generateComponent(basePath, modelBasePath, packageName, request.getComponentName(),
-                    request.getComponentGroup(), request.getFields());
+                    request.getComponentGroup(), request.getSuperType(), request.getFields());
             logger.info("FILEGEN: Successfully generated all files for project: {}", projectName);
         } catch (Exception e) {
             logger.info("FILEGEN: Error generating files for project: {}", projectName, e);
@@ -44,7 +44,7 @@ public class FileGenerationUtil {
      * Generates component folders, content.xml, HTL, dialog, and Sling model.
      */
     public static void generateComponent(String basePath, String modelBasePath, String packageName,
-            String componentName, String componentGroup, List<ComponentField> fields) throws Exception {
+            String componentName, String componentGroup, String superType, List<ComponentField> fields) throws Exception {
         logger.info("COMPONENT: Generating component '{}'", componentName);
 
         String componentFolder = basePath + "/" + componentName;
@@ -52,7 +52,7 @@ public class FileGenerationUtil {
 
         new File(dialogFolder).mkdirs();
 
-        generateComponentContentXml(componentFolder, componentName, componentGroup);
+        generateComponentContentXml(componentFolder, componentName, componentGroup, superType);
         generateHTL(componentFolder, fields, packageName, componentName);
         generateDialogContentXml(componentName, dialogFolder, fields);
         generateSlingModel(modelBasePath, packageName, componentName, fields);
@@ -63,8 +63,8 @@ public class FileGenerationUtil {
     /**
      * Generates the .content.xml for the component.
      */
-    private static void generateComponentContentXml(String folderPath, String componentName, String componentGroup)
-            throws Exception {
+    private static void generateComponentContentXml(String folderPath, String componentName, String componentGroup,
+            String superType) throws Exception {
         logger.info("CONTENTXML: Generating .content.xml for component '{}'", componentName);
         String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<jcr:root xmlns:sling=\"http://sling.apache.org/jcr/sling/1.0\"\n" +
@@ -72,7 +72,10 @@ public class FileGenerationUtil {
                 "          xmlns:jcr=\"http://www.jcp.org/jcr/1.0\"\n" +
                 "          jcr:primaryType=\"cq:Component\"\n" +
                 "          jcr:title=\"" + componentName + "\"\n" +
-                "          componentGroup=\"" + componentGroup + "\"/>";
+                "          componentGroup=\"" + componentGroup + "\"" +
+                (superType != null && !superType.isBlank()
+                        ? "\n          sling:resourceSuperType=\"" + superType + "\"" : "") +
+                "/>";
         FileUtils.writeStringToFile(new File(folderPath + "/.content.xml"), content, StandardCharsets.UTF_8);
         logger.info("CONTENTXML: .content.xml generated at {}/.content.xml", folderPath);
     }

--- a/src/main/resources/static/js/create-component.js
+++ b/src/main/resources/static/js/create-component.js
@@ -1,5 +1,19 @@
 document.addEventListener("DOMContentLoaded", function () {
   const typeOptions = document.querySelector('.fieldType').innerHTML;
+  const modeSelect = document.getElementById('creationMode');
+  const extendsDiv = document.getElementById('extendsComponentDiv');
+
+  function toggleSuperType() {
+    if (modeSelect.value === 'extend') {
+      extendsDiv.style.display = '';
+    } else {
+      extendsDiv.style.display = 'none';
+      document.getElementById('superType').value = '';
+    }
+  }
+
+  modeSelect.addEventListener('change', toggleSuperType);
+  toggleSuperType();
 
   function createBaseRow(isNested, level = 0) {
     const div = document.createElement('div');
@@ -197,7 +211,13 @@ document.addEventListener("DOMContentLoaded", function () {
   window.validateFormFields = function () {
     const name = componentNameInput.value.trim();
     const group = document.getElementById('componentGroup').value;
+    const mode = modeSelect.value;
+    const superTypeValue = document.getElementById('superType').value;
     if (!name || !group || componentNameInput.classList.contains('is-invalid')) {
+      createButton.disabled = true;
+      return;
+    }
+    if (mode === 'extend' && !superTypeValue) {
       createButton.disabled = true;
       return;
     }

--- a/src/main/resources/templates/create-component.html
+++ b/src/main/resources/templates/create-component.html
@@ -47,11 +47,20 @@
       </select>
     </div>
 
-    <!-- Extends Component -->
+    <!-- Creation Mode -->
     <div class="mb-3">
-      <label class="form-label">Extends Component (optional)</label>
+      <label class="form-label">Creation Mode</label>
+      <select class="form-select" id="creationMode" name="creationMode">
+        <option value="new">New Component</option>
+        <option value="extend">Extend Existing Component</option>
+      </select>
+    </div>
+
+    <!-- Extends Component -->
+    <div class="mb-3" id="extendsComponentDiv">
+      <label class="form-label">Extends Component</label>
       <select class="form-select" name="superType" id="superType">
-        <option value="">-- None --</option>
+        <option value="">-- Select Component --</option>
         <option th:each="comp : ${availableComponents}" th:value="${comp}" th:text="${comp}"></option>
       </select>
     </div>

--- a/src/main/resources/templates/create-component.html
+++ b/src/main/resources/templates/create-component.html
@@ -47,6 +47,15 @@
       </select>
     </div>
 
+    <!-- Extends Component -->
+    <div class="mb-3">
+      <label class="form-label">Extends Component (optional)</label>
+      <select class="form-select" name="superType" id="superType">
+        <option value="">-- None --</option>
+        <option th:each="comp : ${availableComponents}" th:value="${comp}" th:text="${comp}"></option>
+      </select>
+    </div>
+
     <!-- Dialog Fields -->
     <div id="fieldsContainer" class="mb-3">
       <label>Dialog Fields</label>


### PR DESCRIPTION
## Summary
- allow specifying super type when generating components
- expose list of available components to extend in the component creation form
- generate sling:resourceSuperType in `.content.xml` when super type is selected

## Testing
- `./mvnw test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_688afe8c01548326877fbe8b7c6db77d