### PR TITLE
Add extend mode for component creation

### DIFF
--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -71,6 +71,18 @@ public class ComponentController {
         model.addAttribute("projectName", project);
         model.addAttribute("fieldTypes", FieldType.getTypeResourceMap());
         model.addAttribute("componentGroups", componentService.getComponentGroups(project));
+        // Components that can be extended (core components + existing ones)
+        // Use a LinkedHashSet to avoid duplicates while preserving order
+        Set<String> available = new LinkedHashSet<>();
+        try {
+            available.addAll(componentService.fetchComponentsFromGeneratedProjects(project).stream()
+                    .map(name -> "/apps/" + project + "/components/" + name)
+                    .toList());
+            available.addAll(componentService.getAllComponents());
+        } catch (IOException e) {
+            log.error("Error loading available components", e);
+        }
+        model.addAttribute("availableComponents", new ArrayList<>(available));
         return "create-component"; // Thymeleaf template
     }
 

--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -82,7 +82,12 @@ public class ComponentController {
         } catch (IOException e) {
             log.error("Error loading available components", e);
         }
-        model.addAttribute("availableComponents", new ArrayList<>(available));
+        Map<String, String> compMap = new LinkedHashMap<>();
+        for (String path : available) {
+            int idx = path.lastIndexOf('/') + 1;
+            compMap.put(path, path.substring(idx));
+        }
+        model.addAttribute("availableComponents", compMap);
         return "create-component"; // Thymeleaf template
     }
 

--- a/src/main/java/com/aem/builder/model/DTO/ComponentRequest.java
+++ b/src/main/java/com/aem/builder/model/DTO/ComponentRequest.java
@@ -13,6 +13,12 @@ public class ComponentRequest {
     private String projectName;
     private String componentName;
     private String componentGroup;
+    /**
+     * Optional component that this component extends. This value will be used as
+     * {@code sling:resourceSuperType} when generating the component's
+     * {@code .content.xml}.
+     */
+    private String superType;
     private List<ComponentField> fields;
 
 }

--- a/src/main/java/com/aem/builder/util/FileGenerationUtil.java
+++ b/src/main/java/com/aem/builder/util/FileGenerationUtil.java
@@ -89,15 +89,18 @@ public class FileGenerationUtil {
         String modelClassName = capitalize(componentName) + "Model";
         StringBuilder sb = new StringBuilder();
 
-        sb.append("<sly data-sly-use.model=\"")
-                .append(packageName).append(".").append(modelClassName).append("\"/>\n");
-        if (superType != null && !superType.isBlank()) {
+        boolean extending = superType != null && !superType.isBlank();
+        if (extending) {
             sb.append("<sly data-sly-resource=\"${@ resourceType='")
                     .append(superType).append("'}\"/>\n");
+        } else {
+            sb.append("<sly data-sly-use.model=\"")
+                    .append(packageName).append(".").append(modelClassName).append("\"/>\n")
+                    .append("<sly data-sly-use.placeholderTemplate=\"core/wcm/components/commons/v1/templates.html\"/>\n")
+                    .append("<sly data-sly-test.hasContent=\"${!model.empty}\">\n");
         }
-        sb.append("<sly data-sly-use.placeholderTemplate=\"core/wcm/components/commons/v1/templates.html\"/>\n")
-                .append("<sly data-sly-test.hasContent=\"${!model.empty}\">\n");
 
+        if (!extending) {
         for (ComponentField field : fields) {
             String fieldName = field.getFieldName();
             String fieldLabel = field.getFieldLabel();
@@ -163,6 +166,7 @@ public class FileGenerationUtil {
 
         sb.append("</sly>\n");
         sb.append("<sly data-sly-call=\"${placeholderTemplate.placeholder @ isEmpty = !hasContent}\" />\n");
+        }
 
         FileUtils.writeStringToFile(new File(folderPath + "/" + componentName + ".html"), sb.toString(),
                 StandardCharsets.UTF_8);

--- a/src/main/java/com/aem/builder/util/FileGenerationUtil.java
+++ b/src/main/java/com/aem/builder/util/FileGenerationUtil.java
@@ -55,7 +55,9 @@ public class FileGenerationUtil {
         generateComponentContentXml(componentFolder, componentName, componentGroup, superType);
         generateHTL(componentFolder, fields, packageName, componentName, superType);
         generateDialogContentXml(componentName, dialogFolder, superType, fields);
-        generateSlingModel(modelBasePath, packageName, componentName, fields);
+        if (superType == null || superType.isBlank()) {
+            generateSlingModel(modelBasePath, packageName, componentName, fields);
+        }
 
         logger.info("COMPONENT: Finished generating component '{}'", componentName);
     }

--- a/src/main/java/com/aem/builder/util/FileGenerationUtil.java
+++ b/src/main/java/com/aem/builder/util/FileGenerationUtil.java
@@ -32,7 +32,7 @@ public class FileGenerationUtil {
             String packageName = "com." + projectName + ".core.models";
 
             generateComponent(basePath, modelBasePath, packageName, request.getComponentName(),
-                    request.getComponentGroup(), request.getFields());
+                    request.getComponentGroup(), request.getSuperType(), request.getFields());
             logger.info("FILEGEN: Successfully generated all files for project: {}", projectName);
         } catch (Exception e) {
             logger.info("FILEGEN: Error generating files for project: {}", projectName, e);
@@ -44,7 +44,7 @@ public class FileGenerationUtil {
      * Generates component folders, content.xml, HTL, dialog, and Sling model.
      */
     public static void generateComponent(String basePath, String modelBasePath, String packageName,
-            String componentName, String componentGroup, List<ComponentField> fields) throws Exception {
+            String componentName, String componentGroup, String superType, List<ComponentField> fields) throws Exception {
         logger.info("COMPONENT: Generating component '{}'", componentName);
 
         String componentFolder = basePath + "/" + componentName;
@@ -52,9 +52,9 @@ public class FileGenerationUtil {
 
         new File(dialogFolder).mkdirs();
 
-        generateComponentContentXml(componentFolder, componentName, componentGroup);
-        generateHTL(componentFolder, fields, packageName, componentName);
-        generateDialogContentXml(componentName, dialogFolder, fields);
+        generateComponentContentXml(componentFolder, componentName, componentGroup, superType);
+        generateHTL(componentFolder, fields, packageName, componentName, superType);
+        generateDialogContentXml(componentName, dialogFolder, superType, fields);
         generateSlingModel(modelBasePath, packageName, componentName, fields);
 
         logger.info("COMPONENT: Finished generating component '{}'", componentName);
@@ -63,8 +63,8 @@ public class FileGenerationUtil {
     /**
      * Generates the .content.xml for the component.
      */
-    private static void generateComponentContentXml(String folderPath, String componentName, String componentGroup)
-            throws Exception {
+    private static void generateComponentContentXml(String folderPath, String componentName, String componentGroup,
+            String superType) throws Exception {
         logger.info("CONTENTXML: Generating .content.xml for component '{}'", componentName);
         String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<jcr:root xmlns:sling=\"http://sling.apache.org/jcr/sling/1.0\"\n" +
@@ -72,7 +72,10 @@ public class FileGenerationUtil {
                 "          xmlns:jcr=\"http://www.jcp.org/jcr/1.0\"\n" +
                 "          jcr:primaryType=\"cq:Component\"\n" +
                 "          jcr:title=\"" + componentName + "\"\n" +
-                "          componentGroup=\"" + componentGroup + "\"/>";
+                "          componentGroup=\"" + componentGroup + "\"" +
+                (superType != null && !superType.isBlank()
+                        ? "\n          sling:resourceSuperType=\"" + superType + "\"" : "") +
+                "/>";
         FileUtils.writeStringToFile(new File(folderPath + "/.content.xml"), content, StandardCharsets.UTF_8);
         logger.info("CONTENTXML: .content.xml generated at {}/.content.xml", folderPath);
     }
@@ -81,14 +84,18 @@ public class FileGenerationUtil {
      * Generates the HTL (HTML Template Language) file for the component.
      */
     private static void generateHTL(String folderPath, List<ComponentField> fields, String packageName,
-            String componentName) throws Exception {
+            String componentName, String superType) throws Exception {
         logger.info("HTL: Generating HTL for component '{}'", componentName);
         String modelClassName = capitalize(componentName) + "Model";
         StringBuilder sb = new StringBuilder();
 
         sb.append("<sly data-sly-use.model=\"")
-                .append(packageName).append(".").append(modelClassName).append("\"/>\n")
-                .append("<sly data-sly-use.placeholderTemplate=\"core/wcm/components/commons/v1/templates.html\"/>\n")
+                .append(packageName).append(".").append(modelClassName).append("\"/>\n");
+        if (superType != null && !superType.isBlank()) {
+            sb.append("<sly data-sly-resource=\"${@ resourceType='")
+                    .append(superType).append("'}\"/>\n");
+        }
+        sb.append("<sly data-sly-use.placeholderTemplate=\"core/wcm/components/commons/v1/templates.html\"/>\n")
                 .append("<sly data-sly-test.hasContent=\"${!model.empty}\">\n");
 
         for (ComponentField field : fields) {
@@ -192,12 +199,15 @@ public class FileGenerationUtil {
     /**
      * Generates the dialog .content.xml for the component.
      */
-    public static void generateDialogContentXml(String componentName, String dialogFolder, List<ComponentField> fields)
-            throws Exception {
+    public static void generateDialogContentXml(String componentName, String dialogFolder, String superType,
+            List<ComponentField> fields) throws Exception {
         logger.info("DIALOG: Generating dialog .content.xml for component '{}'", componentName);
         String dialogTitle = componentName + " Dialog";
 
         StringBuilder sb = new StringBuilder();
+        String superTypeAttr = (superType != null && !superType.isBlank())
+                ? "\n                          sling:resourceSuperType=\"" + superType + "/cq:dialog\""
+                : "";
         sb.append(String.format("""
                 <?xml version="1.0" encoding="UTF-8"?>
                 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
@@ -206,10 +216,10 @@ public class FileGenerationUtil {
                           xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
                           jcr:primaryType="nt:unstructured"
                           jcr:title="%s"
-                          sling:resourceType="cq/gui/components/authoring/dialog">
-                  <content
-                    jcr:primaryType="nt:unstructured"
-                    sling:resourceType="granite/ui/components/coral/foundation/container">
+                          sling:resourceType="cq/gui/components/authoring/dialog"%s>
+                <content
+                  jcr:primaryType="nt:unstructured"
+                  sling:resourceType="granite/ui/components/coral/foundation/container">
                     <items
                       jcr:primaryType="nt:unstructured">
                       <tabs
@@ -223,7 +233,7 @@ public class FileGenerationUtil {
                             sling:resourceType="granite/ui/components/coral/foundation/container">
                             <items
                               jcr:primaryType="nt:unstructured">
-                """, dialogTitle));
+                """, dialogTitle, superTypeAttr));
 
         for (ComponentField field : fields) {
             String nodeName = field.getFieldName();

--- a/src/main/resources/static/css/create-component.css
+++ b/src/main/resources/static/css/create-component.css
@@ -21,3 +21,7 @@
   border: 1px dashed #ced4da;
   padding: 10px;
 }
+
+select.form-select option {
+  text-transform: capitalize;
+}

--- a/src/main/resources/static/js/create-component.js
+++ b/src/main/resources/static/js/create-component.js
@@ -1,5 +1,19 @@
 document.addEventListener("DOMContentLoaded", function () {
   const typeOptions = document.querySelector('.fieldType').innerHTML;
+  const modeSelect = document.getElementById('creationMode');
+  const extendsDiv = document.getElementById('extendsComponentDiv');
+
+  function toggleSuperType() {
+    if (modeSelect.value === 'extend') {
+      extendsDiv.style.display = '';
+    } else {
+      extendsDiv.style.display = 'none';
+      document.getElementById('superType').value = '';
+    }
+  }
+
+  modeSelect.addEventListener('change', toggleSuperType);
+  toggleSuperType();
 
   function createBaseRow(isNested, level = 0) {
     const div = document.createElement('div');
@@ -197,7 +211,13 @@ document.addEventListener("DOMContentLoaded", function () {
   window.validateFormFields = function () {
     const name = componentNameInput.value.trim();
     const group = document.getElementById('componentGroup').value;
+    const mode = modeSelect.value;
+    const superTypeValue = document.getElementById('superType').value;
     if (!name || !group || componentNameInput.classList.contains('is-invalid')) {
+      createButton.disabled = true;
+      return;
+    }
+    if (mode === 'extend' && !superTypeValue) {
       createButton.disabled = true;
       return;
     }

--- a/src/main/resources/static/js/create-component.js
+++ b/src/main/resources/static/js/create-component.js
@@ -239,7 +239,7 @@ document.addEventListener("DOMContentLoaded", function () {
       createButton.disabled = true;
       return;
     }
-    const rows = document.querySelectorAll('.field-row, .nested-row');
+    const rows = document.querySelectorAll('#fieldsContainer .field-row, #fieldsContainer .nested-row');
     if (mode === 'new' && rows.length === 0) {
       createButton.disabled = true;
       return;

--- a/src/main/resources/static/js/create-component.js
+++ b/src/main/resources/static/js/create-component.js
@@ -5,9 +5,6 @@ document.addEventListener("DOMContentLoaded", function () {
   function toggleSuperType() {
     if (modeSelect.value === 'extend') {
       extendsDiv.style.display = '';
-      if (document.getElementById('fieldsContainer').childElementCount === 0) {
-        // no default field rows
-      }
     } else {
       extendsDiv.style.display = 'none';
       document.getElementById('superType').value = '';
@@ -15,6 +12,7 @@ document.addEventListener("DOMContentLoaded", function () {
         addFieldRow();
       }
     }
+    updateMandatoryButtons();
   }
 
   modeSelect.addEventListener('change', () => {
@@ -89,12 +87,14 @@ document.addEventListener("DOMContentLoaded", function () {
     updateIndexes();
     row.classList.add('animate__animated','animate__fadeIn');
     validateFormFields();
+    updateMandatoryButtons();
   };
 
   window.removeFieldRow = function (btn) {
     btn.closest('.field-row').remove();
     updateIndexes();
     validateFormFields();
+    updateMandatoryButtons();
   };
 
   function addNestedFieldRow(btn) {
@@ -134,6 +134,7 @@ document.addEventListener("DOMContentLoaded", function () {
     fieldRows.forEach((row, i) => {
       setRowNames(row, `fields[${i}]`);
     });
+    updateMandatoryButtons();
   }
 
   function setRowNames(row, prefix) {
@@ -157,6 +158,20 @@ document.addEventListener("DOMContentLoaded", function () {
     options.forEach((opt, k) => {
       opt.querySelector('.optionText').name = `${prefix}.options[${k}].text`;
       opt.querySelector('.optionValue').name = `${prefix}.options[${k}].value`;
+    });
+  }
+
+  function updateMandatoryButtons() {
+    const rows = document.querySelectorAll('#fieldsContainer > .field-row');
+    rows.forEach((row, idx) => {
+      const actionCol = row.querySelector('.action-col');
+      if (modeSelect.value === 'new' && idx === 0) {
+        actionCol.innerHTML = '';
+      } else {
+        if (!actionCol.querySelector('button')) {
+          actionCol.innerHTML = '<button type="button" class="btn btn-danger" onclick="removeFieldRow(this)">-</button>';
+        }
+      }
     });
   }
 
@@ -249,5 +264,6 @@ document.addEventListener("DOMContentLoaded", function () {
   };
 
   document.addEventListener('input', validateFormFields);
+  document.addEventListener('change', validateFormFields);
   updateIndexes();
 });

--- a/src/main/resources/static/js/create-component.js
+++ b/src/main/resources/static/js/create-component.js
@@ -17,15 +17,16 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   }
 
-  modeSelect.addEventListener('change', toggleSuperType);
+  modeSelect.addEventListener('change', () => {
+    toggleSuperType();
+    validateFormFields();
+  });
   toggleSuperType();
-  if (modeSelect.value === 'new') {
-    addFieldRow();
-  }
 
   function createBaseRow(isNested, level = 0) {
     const template = document.getElementById('fieldRowTemplate');
     const div = template.cloneNode(true);
+    div.removeAttribute('id');
     div.style.display = '';
     div.dataset.level = level;
     if (isNested) {
@@ -87,11 +88,13 @@ document.addEventListener("DOMContentLoaded", function () {
     container.appendChild(row);
     updateIndexes();
     row.classList.add('animate__animated','animate__fadeIn');
+    validateFormFields();
   };
 
   window.removeFieldRow = function (btn) {
     btn.closest('.field-row').remove();
     updateIndexes();
+    validateFormFields();
   };
 
   function addNestedFieldRow(btn) {
@@ -101,10 +104,12 @@ document.addEventListener("DOMContentLoaded", function () {
     const row = createBaseRow(true, level);
     container.insertBefore(row, btn);
     updateIndexes();
+    validateFormFields();
   }
   window.removeNestedFieldRow = function (btn) {
     btn.closest('.nested-row').remove();
     updateIndexes();
+    validateFormFields();
   };
 
   function addOptionRow(btn) {
@@ -116,10 +121,12 @@ document.addEventListener("DOMContentLoaded", function () {
       <button type="button" class="btn btn-danger" onclick="removeOptionRow(this)">-</button>`;
     container.insertBefore(div, btn);
     updateIndexes();
+    validateFormFields();
   }
   window.removeOptionRow = function (btn) {
     btn.parentElement.remove();
     updateIndexes();
+    validateFormFields();
   };
 
   function updateIndexes() {

--- a/src/main/resources/static/js/create-component.js
+++ b/src/main/resources/static/js/create-component.js
@@ -1,45 +1,41 @@
 document.addEventListener("DOMContentLoaded", function () {
-  const typeOptions = document.querySelector('.fieldType').innerHTML;
   const modeSelect = document.getElementById('creationMode');
   const extendsDiv = document.getElementById('extendsComponentDiv');
 
   function toggleSuperType() {
     if (modeSelect.value === 'extend') {
       extendsDiv.style.display = '';
+      if (document.getElementById('fieldsContainer').childElementCount === 0) {
+        // no default field rows
+      }
     } else {
       extendsDiv.style.display = 'none';
       document.getElementById('superType').value = '';
+      if (document.getElementById('fieldsContainer').childElementCount === 0) {
+        addFieldRow();
+      }
     }
   }
 
   modeSelect.addEventListener('change', toggleSuperType);
   toggleSuperType();
+  if (modeSelect.value === 'new') {
+    addFieldRow();
+  }
 
   function createBaseRow(isNested, level = 0) {
-    const div = document.createElement('div');
-    div.className = isNested ? 'nested-row mb-2' : 'field-row border p-2 mb-3';
+    const template = document.getElementById('fieldRowTemplate');
+    const div = template.cloneNode(true);
+    div.style.display = '';
     div.dataset.level = level;
     if (isNested) {
+      div.classList.add('nested-row', 'mb-2');
       div.style.marginLeft = `${level * 20}px`;
       div.style.borderStyle = 'dashed';
+      div.querySelector('.action-col').innerHTML = '<button type="button" class="btn btn-danger" onclick="removeNestedFieldRow(this)">-</button>';
+    } else {
+      div.classList.add('field-row', 'border', 'p-2', 'mb-3');
     }
-    div.innerHTML = `
-      <div class="row g-2 align-items-end">
-        <div class="col">
-          <input type="text" class="form-control fieldLabel" placeholder="Field Label" oninput="autoFillFieldName(this)" required>
-        </div>
-        <div class="col">
-          <input type="text" class="form-control fieldName" placeholder="Field Name" required>
-        </div>
-        <div class="col">
-          <select class="form-select fieldType" onchange="handleFieldTypeChange(this)" required>${typeOptions}</select>
-        </div>
-        <div class="col-auto action-col">
-          ${isNested ? '<button type="button" class="btn btn-danger" onclick="removeNestedFieldRow(this)">-</button>' : ''}
-        </div>
-      </div>
-      <div class="options-container mt-2"></div>
-      <div class="nested-container mt-2"></div>`;
     return div;
   }
 
@@ -222,6 +218,10 @@ document.addEventListener("DOMContentLoaded", function () {
       return;
     }
     const rows = document.querySelectorAll('.field-row, .nested-row');
+    if (mode === 'new' && rows.length === 0) {
+      createButton.disabled = true;
+      return;
+    }
     for (let row of rows) {
       const label = row.querySelector('.fieldLabel').value.trim();
       const fname = row.querySelector('.fieldName').value.trim();

--- a/src/main/resources/templates/create-component.html
+++ b/src/main/resources/templates/create-component.html
@@ -57,7 +57,7 @@
     </div>
 
     <!-- Extends Component -->
-    <div class="mb-3" id="extendsComponentDiv">
+    <div class="mb-3" id="extendsComponentDiv" style="display:none">
       <label class="form-label">Extends Component</label>
       <select class="form-select" name="superType" id="superType">
         <option value="">-- Select Component --</option>

--- a/src/main/resources/templates/create-component.html
+++ b/src/main/resources/templates/create-component.html
@@ -61,32 +61,32 @@
       <label class="form-label">Extends Component</label>
       <select class="form-select" name="superType" id="superType">
         <option value="">-- Select Component --</option>
-        <option th:each="comp : ${availableComponents}" th:value="${comp}" th:text="${comp}"></option>
+        <option th:each="entry : ${availableComponents.entrySet()}" th:value="${entry.key}" th:text="${entry.value}"></option>
       </select>
     </div>
 
     <!-- Dialog Fields -->
     <div id="fieldsContainer" class="mb-3">
       <label>Dialog Fields</label>
-      <div class="field-row border p-2 mb-3 animate__animated animate__fadeIn">
-        <div class="row g-2 align-items-end">
-          <div class="col">
-            <input type="text" class="form-control fieldLabel" name="fields[0].fieldLabel" placeholder="Field Label" oninput="autoFillFieldName(this)" required>
-          </div>
-          <div class="col">
-            <input type="text" class="form-control fieldName" name="fields[0].fieldName" placeholder="Field Name" required>
-          </div>
-          <div class="col">
-            <select class="form-select fieldType" name="fields[0].fieldType" onchange="handleFieldTypeChange(this)" required>
-              <option value="">-- Select Type --</option>
-              <option th:each="type : ${fieldTypes}" th:value="${type.key}" th:text="${type.key}"></option>
-            </select>
-          </div>
-          <div class="col-auto action-col"></div>
+    </div>
+    <div id="fieldRowTemplate" class="field-row border p-2 mb-3" style="display:none">
+      <div class="row g-2 align-items-end">
+        <div class="col">
+          <input type="text" class="form-control fieldLabel" placeholder="Field Label" oninput="autoFillFieldName(this)" required>
         </div>
-        <div class="options-container mt-2"></div>
-        <div class="nested-container mt-2"></div>
+        <div class="col">
+          <input type="text" class="form-control fieldName" placeholder="Field Name" required>
+        </div>
+        <div class="col">
+          <select class="form-select fieldType" onchange="handleFieldTypeChange(this)" required>
+            <option value="">-- Select Type --</option>
+            <option th:each="type : ${fieldTypes}" th:value="${type.key}" th:text="${type.key}"></option>
+          </select>
+        </div>
+        <div class="col-auto action-col"></div>
       </div>
+      <div class="options-container mt-2"></div>
+      <div class="nested-container mt-2"></div>
     </div>
 
     <!-- Add Field Button -->

--- a/src/main/resources/templates/create-component.html
+++ b/src/main/resources/templates/create-component.html
@@ -47,6 +47,24 @@
       </select>
     </div>
 
+    <!-- Creation Mode -->
+    <div class="mb-3">
+      <label class="form-label">Creation Mode</label>
+      <select class="form-select" id="creationMode" name="creationMode">
+        <option value="new">New Component</option>
+        <option value="extend">Extend Existing Component</option>
+      </select>
+    </div>
+
+    <!-- Extends Component -->
+    <div class="mb-3" id="extendsComponentDiv">
+      <label class="form-label">Extends Component</label>
+      <select class="form-select" name="superType" id="superType">
+        <option value="">-- Select Component --</option>
+        <option th:each="comp : ${availableComponents}" th:value="${comp}" th:text="${comp}"></option>
+      </select>
+    </div>
+
     <!-- Dialog Fields -->
     <div id="fieldsContainer" class="mb-3">
       <label>Dialog Fields</label>


### PR DESCRIPTION
## Summary
- avoid duplicate component options when loading extendable components
- allow choosing between new or extend modes in component form
- toggle list of available components via JavaScript
- include sling:resourceSuperType for dialog and HTL when extending

## Testing
- `./mvnw test` *(fails to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_688afe8c01548326877fbe8b7c6db77d