### PR TITLE
Fix form submission for component creation

### DIFF
--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -106,6 +106,7 @@ public class ComponentController {
     public String createComponent(@PathVariable String project,
                                   @ModelAttribute ComponentRequest request,
                                   RedirectAttributes redirectAttributes) {
+        log.info("Creating component '{}' for project '{}'", request.getComponentName(), project);
         try {
             componentService.generateComponent(project, request);
             redirectAttributes.addFlashAttribute("message", "Component created successfully!");

--- a/src/main/resources/templates/create-component.html
+++ b/src/main/resources/templates/create-component.html
@@ -29,7 +29,7 @@
 
   <form id="componentForm" th:action="@{'/component/create/' + ${projectName}}" method="post">
     <!-- Hidden input to pass projectName into JS -->
-    <input type="hidden" id="projectName" th:value="${projectName}">
+    <input type="hidden" id="projectName" name="projectName" th:value="${projectName}">
 
     <!-- Component Name -->
     <div class="mb-3">


### PR DESCRIPTION
## Summary
- ensure project name is sent with the create component form
- log requests when creating components

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_688b31cdc9f4832682f0d0a2358c9b0a