### PR TITLE
Fix create component button disabled if name check fails

### DIFF
--- a/src/main/resources/static/js/create-component.js
+++ b/src/main/resources/static/js/create-component.js
@@ -216,11 +216,11 @@ document.addEventListener("DOMContentLoaded", function () {
         }
       })
       .catch(() => {
-        errorDiv.innerText = '⚠️ Server error while checking component name.';
-        errorDiv.classList.add('text-danger');
-        errorDiv.classList.remove('text-success');
-        componentNameInput.classList.add('is-invalid');
-        createButton.disabled = true;
+        errorDiv.innerText = '⚠️ Unable to verify component name.';
+        errorDiv.classList.add('text-warning');
+        errorDiv.classList.remove('text-danger', 'text-success');
+        componentNameInput.classList.remove('is-invalid');
+        validateFormFields();
       });
   }, 400);
 


### PR DESCRIPTION
## Summary
- handle failure when verifying component name

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_688b3d8ef1e88330973e45f491820e5f