### PR TITLE
Add component edit support on deploy page

### DIFF
--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -61,12 +61,24 @@ public class ComponentController {
         }
     }
 
+    @GetMapping("/component/details/{project}/{component}")
+    @ResponseBody
+    public ComponentRequest getComponentDetails(@PathVariable String project,
+                                                @PathVariable String component) throws IOException {
+        return componentService.getComponentDetails(project, component);
+    }
+
 
 
     //component creation
     @GetMapping("/create/{project}")
-    public String showComponentForm(@PathVariable String project, Model model) {
+    public String showComponentForm(@PathVariable String project,
+                                    @RequestParam(value = "component", required = false) String component,
+                                    Model model) {
         model.addAttribute("projectName", project);
+        if (component != null && !component.isBlank()) {
+            model.addAttribute("editComponentName", component);
+        }
 
 
         var typeResourceMap = FieldType.getTypeResourceMap();

--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -63,9 +63,13 @@ public class ComponentController {
 
     @GetMapping("/component/details/{project}/{component}")
     @ResponseBody
-    public ComponentRequest getComponentDetails(@PathVariable String project,
-                                                @PathVariable String component) throws IOException {
-        return componentService.getComponentDetails(project, component);
+    public ResponseEntity<ComponentRequest> getComponentDetails(@PathVariable String project,
+                                                                @PathVariable String component) throws IOException {
+        ComponentRequest details = componentService.getComponentDetails(project, component);
+        if (details == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(details);
     }
 
 

--- a/src/main/java/com/aem/builder/controller/DeployController.java
+++ b/src/main/java/com/aem/builder/controller/DeployController.java
@@ -31,6 +31,7 @@ public class DeployController {
         List<String> templates = templateService.fetchTemplatesFromGeneratedProjects(projectName);
         model.addAttribute("components", components);
         model.addAttribute("templates", templates);
+        model.addAttribute("projectName", projectName);
         model.addAttribute("canDeploy", true);
         logger.debug("DEPLOY: Added attributes to model for project: {}", projectName);
         return "deploy";

--- a/src/main/java/com/aem/builder/service/ComponentService.java
+++ b/src/main/java/com/aem/builder/service/ComponentService.java
@@ -27,6 +27,8 @@ public interface ComponentService {
     List<String> getComponentGroups(String projectName);
     void generateComponent(String projectName, ComponentRequest request);
 
+    ComponentRequest getComponentDetails(String projectName, String componentName) throws IOException;
+
     //component checking
     boolean isComponentNameAvailable(String projectName, String componentName);
 

--- a/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
@@ -4,6 +4,7 @@ import com.aem.builder.model.DTO.ComponentRequest;
 import com.aem.builder.service.ComponentService;
 
 import com.aem.builder.util.FileGenerationUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -344,6 +345,31 @@ public class ComponentServiceImpl implements ComponentService {
     @Override
     public void generateComponent(String projectName, ComponentRequest request) {
         FileGenerationUtil.generateAllFiles(projectName, request);
+        saveMetadata(projectName, request);
+    }
+
+    @Override
+    public ComponentRequest getComponentDetails(String projectName, String componentName) throws IOException {
+        File meta = new File(PROJECTS_DIR + "/" + projectName + "/component-data/" + componentName + ".json");
+        if (!meta.exists()) {
+            return null;
+        }
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(meta, ComponentRequest.class);
+    }
+
+    private void saveMetadata(String projectName, ComponentRequest request) {
+        try {
+            File dir = new File(PROJECTS_DIR + "/" + projectName + "/component-data");
+            if (!dir.exists()) {
+                dir.mkdirs();
+            }
+            File meta = new File(dir, request.getComponentName() + ".json");
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.writerWithDefaultPrettyPrinter().writeValue(meta, request);
+        } catch (IOException e) {
+            log.error("Failed to save component metadata", e);
+        }
     }
 
 

--- a/src/main/resources/static/js/create-component.js
+++ b/src/main/resources/static/js/create-component.js
@@ -182,10 +182,13 @@ document.addEventListener("DOMContentLoaded", function () {
   const editComponent = document.body.getAttribute('data-edit-component');
 
   if (editComponent) {
-    fetch(`/component/details/${projectName}/${editComponent}`)
-      .then(r => r.json())
+    const url = `/component/details/${projectName}/${encodeURIComponent(editComponent)}`;
+    fetch(url)
+      .then(r => {
+        if (!r.ok) throw new Error('No metadata');
+        return r.json();
+      })
       .then(data => {
-        if (!data) return;
         componentNameInput.value = data.componentName;
         componentNameInput.readOnly = true;
         document.getElementById('componentGroup').value = data.componentGroup;
@@ -218,6 +221,9 @@ document.addEventListener("DOMContentLoaded", function () {
         }
         updateIndexes();
         validateFormFields();
+      })
+      .catch(() => {
+        console.warn('No metadata found for component', editComponent);
       });
   }
 

--- a/src/main/resources/static/js/create-component.js
+++ b/src/main/resources/static/js/create-component.js
@@ -179,6 +179,47 @@ document.addEventListener("DOMContentLoaded", function () {
   const errorDiv = document.getElementById('nameError');
   const createButton = document.getElementById('createButton');
   const projectName = document.getElementById('projectName').value;
+  const editComponent = document.body.getAttribute('data-edit-component');
+
+  if (editComponent) {
+    fetch(`/component/details/${projectName}/${editComponent}`)
+      .then(r => r.json())
+      .then(data => {
+        if (!data) return;
+        componentNameInput.value = data.componentName;
+        componentNameInput.readOnly = true;
+        document.getElementById('componentGroup').value = data.componentGroup;
+        if (data.superType) {
+          modeSelect.value = 'extend';
+          toggleSuperType();
+          document.getElementById('superType').value = data.superType;
+        }
+        document.querySelectorAll('#fieldsContainer .field-row').forEach(e => e.remove());
+        if (Array.isArray(data.fields)) {
+          data.fields.forEach(f => {
+            addFieldRow();
+            const row = document.getElementById('fieldsContainer').lastElementChild;
+            row.querySelector('.fieldLabel').value = f.fieldLabel;
+            row.querySelector('.fieldName').value = f.fieldName;
+            row.querySelector('.fieldType').value = f.fieldType;
+            handleFieldTypeChange(row.querySelector('.fieldType'));
+            if (Array.isArray(f.options)) {
+              const optContainer = row.querySelector('.options-container');
+              f.options.forEach(o => {
+                const div = document.createElement('div');
+                div.className = 'option-row input-group mb-2';
+                div.innerHTML = `<input type="text" class="form-control optionText" placeholder="Text" required value="${o.text}">
+      <input type="text" class="form-control optionValue" placeholder="Value" required value="${o.value}">
+      <button type="button" class="btn btn-danger" onclick="removeOptionRow(this)">-</button>`;
+                optContainer.appendChild(div);
+              });
+            }
+          });
+        }
+        updateIndexes();
+        validateFormFields();
+      });
+  }
 
   function debounce(func, delay) {
     let timer;

--- a/src/main/resources/templates/create-component.html
+++ b/src/main/resources/templates/create-component.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="/css/create-component.css">
   <script th:src="@{/js/create-component.js}"></script>
 </head>
-<body>
+<body th:attr="data-edit-component=${editComponentName}">
 
 <!-- Navbar -->
 <div th:replace="fragments/navbar :: navbar"></div>

--- a/src/main/resources/templates/deploy.html
+++ b/src/main/resources/templates/deploy.html
@@ -45,7 +45,12 @@
                 </div>
                 <div id="componentsList" class="row row-cols-1 row-cols-sm-2 g-2">
                     <div class="col" th:each="component : ${components}">
-                        <div class="border rounded p-2 bg-light text-center shadow-sm" th:text="${component}"></div>
+                        <div class="border rounded p-2 bg-light text-center shadow-sm d-flex justify-content-between align-items-center">
+                            <span th:text="${component}"></span>
+                            <a th:if="${component != projectName + '-Content' and component != projectName + '-Structure'}"
+                               th:href="@{'/create/' + ${projectName} + '(component=' + ${component} + ')'}"
+                               class="btn btn-sm btn-outline-secondary">Edit</a>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- allow editing of components from Deploy page
- persist component metadata to JSON when creating
- expose endpoint to fetch component details
- pre-fill component creation form when editing
- show Edit button on deploy component list

## Testing
- `./mvnw -q -DskipTests package` *(fails: network access required)*
- `./mvnw -q test` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_b_688c7240abd48330a8e1a230d2a869d4