### PR TITLE
Implement template component policy management

### DIFF
--- a/src/main/java/com/aem/builder/controller/TemplatePolicyController.java
+++ b/src/main/java/com/aem/builder/controller/TemplatePolicyController.java
@@ -9,6 +9,9 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Controller
 @RequiredArgsConstructor
 public class TemplatePolicyController {
@@ -38,14 +41,22 @@ public class TemplatePolicyController {
     }
 
     @PostMapping("/{project}/template/{template}/{component}/style")
-    public String addPolicy(@PathVariable String project,
-                            @PathVariable String template,
-                            @PathVariable String component,
-                            @RequestParam String name,
-                            @RequestParam String cssClass,
-                            RedirectAttributes redirectAttributes) {
-        policyService.addPolicy(project, component, new StylePolicy(name, cssClass));
-        redirectAttributes.addFlashAttribute("message", "Style policy added");
+    public String addPolicies(@PathVariable String project,
+                              @PathVariable String template,
+                              @PathVariable String component,
+                              @RequestParam("name") List<String> names,
+                              @RequestParam("cssClass") List<String> classes,
+                              RedirectAttributes redirectAttributes) {
+        List<StylePolicy> list = new ArrayList<>();
+        for (int i = 0; i < names.size(); i++) {
+            String n = names.get(i);
+            String c = i < classes.size() ? classes.get(i) : "";
+            if (!n.isBlank() && !c.isBlank()) {
+                list.add(new StylePolicy(n, c));
+            }
+        }
+        policyService.addPolicies(project, component, list);
+        redirectAttributes.addFlashAttribute("message", "Style policies saved");
         return "redirect:/" + project + "/template/" + template + "/" + component;
     }
 }

--- a/src/main/java/com/aem/builder/controller/TemplatePolicyController.java
+++ b/src/main/java/com/aem/builder/controller/TemplatePolicyController.java
@@ -1,0 +1,51 @@
+package com.aem.builder.controller;
+
+import com.aem.builder.model.StylePolicy;
+import com.aem.builder.service.PolicyService;
+import com.aem.builder.service.TemplateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequiredArgsConstructor
+public class TemplatePolicyController {
+    private final TemplateService templateService;
+    private final PolicyService policyService;
+
+    @GetMapping("/{project}/template/{template}")
+    public String allowedComponents(@PathVariable String project,
+                                    @PathVariable String template,
+                                    Model model) {
+        model.addAttribute("projectName", project);
+        model.addAttribute("templateName", template);
+        model.addAttribute("components", templateService.getAllowedComponents(project, template));
+        return "template-components";
+    }
+
+    @GetMapping("/{project}/template/{template}/{component}")
+    public String componentPolicies(@PathVariable String project,
+                                    @PathVariable String template,
+                                    @PathVariable String component,
+                                    Model model) {
+        model.addAttribute("projectName", project);
+        model.addAttribute("templateName", template);
+        model.addAttribute("componentName", component);
+        model.addAttribute("policies", policyService.getPolicies(project, component));
+        return "component-styles";
+    }
+
+    @PostMapping("/{project}/template/{template}/{component}/style")
+    public String addPolicy(@PathVariable String project,
+                            @PathVariable String template,
+                            @PathVariable String component,
+                            @RequestParam String name,
+                            @RequestParam String cssClass,
+                            RedirectAttributes redirectAttributes) {
+        policyService.addPolicy(project, component, new StylePolicy(name, cssClass));
+        redirectAttributes.addFlashAttribute("message", "Style policy added");
+        return "redirect:/" + project + "/template/" + template + "/" + component;
+    }
+}

--- a/src/main/java/com/aem/builder/model/ComponentPolicy.java
+++ b/src/main/java/com/aem/builder/model/ComponentPolicy.java
@@ -1,0 +1,18 @@
+package com.aem.builder.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ComponentPolicy {
+    private String title;
+    private String description;
+    private String defaultClass;
+    private List<StyleGroup> groups = new ArrayList<>();
+}

--- a/src/main/java/com/aem/builder/model/StyleGroup.java
+++ b/src/main/java/com/aem/builder/model/StyleGroup.java
@@ -1,0 +1,17 @@
+package com.aem.builder.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class StyleGroup {
+    private String name;
+    private boolean combine;
+    private List<StylePolicy> styles = new ArrayList<>();
+}

--- a/src/main/java/com/aem/builder/model/StylePolicy.java
+++ b/src/main/java/com/aem/builder/model/StylePolicy.java
@@ -1,0 +1,13 @@
+package com.aem.builder.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class StylePolicy {
+    private String name;
+    private String cssClass;
+}

--- a/src/main/java/com/aem/builder/service/PolicyService.java
+++ b/src/main/java/com/aem/builder/service/PolicyService.java
@@ -1,0 +1,9 @@
+package com.aem.builder.service;
+
+import com.aem.builder.model.StylePolicy;
+import java.util.List;
+
+public interface PolicyService {
+    List<StylePolicy> getPolicies(String projectName, String componentName);
+    void addPolicy(String projectName, String componentName, StylePolicy policy);
+}

--- a/src/main/java/com/aem/builder/service/PolicyService.java
+++ b/src/main/java/com/aem/builder/service/PolicyService.java
@@ -1,13 +1,14 @@
 package com.aem.builder.service;
 
+import com.aem.builder.model.ComponentPolicy;
 import com.aem.builder.model.StylePolicy;
 import java.util.List;
 
 public interface PolicyService {
-    List<StylePolicy> getPolicies(String projectName, String componentName);
-    void addPolicy(String projectName, String componentName, StylePolicy policy);
-    default void addPolicies(String projectName, String componentName, List<StylePolicy> policies) {
-        for (StylePolicy p : policies) {
+    List<ComponentPolicy> getPolicies(String projectName, String componentName);
+    void addPolicy(String projectName, String componentName, ComponentPolicy policy);
+    default void addPolicies(String projectName, String componentName, List<ComponentPolicy> policies) {
+        for (ComponentPolicy p : policies) {
             addPolicy(projectName, componentName, p);
         }
     }

--- a/src/main/java/com/aem/builder/service/PolicyService.java
+++ b/src/main/java/com/aem/builder/service/PolicyService.java
@@ -6,4 +6,9 @@ import java.util.List;
 public interface PolicyService {
     List<StylePolicy> getPolicies(String projectName, String componentName);
     void addPolicy(String projectName, String componentName, StylePolicy policy);
+    default void addPolicies(String projectName, String componentName, List<StylePolicy> policies) {
+        for (StylePolicy p : policies) {
+            addPolicy(projectName, componentName, p);
+        }
+    }
 }

--- a/src/main/java/com/aem/builder/service/TemplateService.java
+++ b/src/main/java/com/aem/builder/service/TemplateService.java
@@ -35,4 +35,6 @@ public interface TemplateService {
 
 
     public void updateTemplate(TemplateModel updatedModel, String projectName, String oldTemplateName) throws ParserConfigurationException, IOException, SAXException, TransformerException;
+
+    List<String> getAllowedComponents(String projectName, String templateName);
 }

--- a/src/main/java/com/aem/builder/service/impl/PolicyServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/PolicyServiceImpl.java
@@ -1,0 +1,84 @@
+package com.aem.builder.service.impl;
+
+import com.aem.builder.model.StylePolicy;
+import com.aem.builder.service.PolicyService;
+import org.springframework.stereotype.Service;
+import org.w3c.dom.*;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class PolicyServiceImpl implements PolicyService {
+
+    private String getPolicyPath(String project, String component) {
+        return "generated-projects/" + project +
+                "/ui.content/src/main/content/jcr_root/conf/" + project +
+                "/settings/wcm/policies/" + component + "/styles/.content.xml";
+    }
+
+    @Override
+    public List<StylePolicy> getPolicies(String projectName, String componentName) {
+        List<StylePolicy> list = new ArrayList<>();
+        File file = new File(getPolicyPath(projectName, componentName));
+        if (!file.exists()) {
+            return list;
+        }
+        try {
+            DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            Document doc = builder.parse(file);
+            Element root = doc.getDocumentElement();
+            NodeList nodes = root.getChildNodes();
+            for (int i = 0; i < nodes.getLength(); i++) {
+                Node n = nodes.item(i);
+                if (n.getNodeType() == Node.ELEMENT_NODE) {
+                    Element e = (Element) n;
+                    list.add(new StylePolicy(e.getAttribute("name"), e.getAttribute("class")));
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
+    @Override
+    public void addPolicy(String projectName, String componentName, StylePolicy policy) {
+        try {
+            File file = new File(getPolicyPath(projectName, componentName));
+            Document doc;
+            Element root;
+            DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            if (file.exists()) {
+                doc = builder.parse(file);
+                root = doc.getDocumentElement();
+            } else {
+                file.getParentFile().mkdirs();
+                doc = builder.newDocument();
+                root = doc.createElement("jcr:root");
+                root.setAttribute("xmlns:jcr", "http://www.jcp.org/jcr/1.0");
+                root.setAttribute("jcr:primaryType", "nt:unstructured");
+                doc.appendChild(root);
+            }
+            Element style = doc.createElement("style");
+            style.setAttribute("jcr:primaryType", "nt:unstructured");
+            style.setAttribute("name", policy.getName());
+            style.setAttribute("class", policy.getCssClass());
+            root.appendChild(style);
+
+            Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            transformer.transform(new DOMSource(doc), new StreamResult(file));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/aem/builder/service/impl/PolicyServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/PolicyServiceImpl.java
@@ -1,5 +1,7 @@
 package com.aem.builder.service.impl;
 
+import com.aem.builder.model.ComponentPolicy;
+import com.aem.builder.model.StyleGroup;
 import com.aem.builder.model.StylePolicy;
 import com.aem.builder.service.PolicyService;
 import org.springframework.stereotype.Service;
@@ -26,8 +28,8 @@ public class PolicyServiceImpl implements PolicyService {
     }
 
     @Override
-    public List<StylePolicy> getPolicies(String projectName, String componentName) {
-        List<StylePolicy> list = new ArrayList<>();
+    public List<ComponentPolicy> getPolicies(String projectName, String componentName) {
+        List<ComponentPolicy> list = new ArrayList<>();
         File file = new File(getPolicyPath(projectName, componentName));
         if (!file.exists()) {
             return list;
@@ -36,13 +38,31 @@ public class PolicyServiceImpl implements PolicyService {
             DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
             Document doc = builder.parse(file);
             Element root = doc.getDocumentElement();
-            NodeList nodes = root.getChildNodes();
+            NodeList nodes = root.getElementsByTagName("policy");
             for (int i = 0; i < nodes.getLength(); i++) {
-                Node n = nodes.item(i);
-                if (n.getNodeType() == Node.ELEMENT_NODE) {
-                    Element e = (Element) n;
-                    list.add(new StylePolicy(e.getAttribute("name"), e.getAttribute("class")));
+                Element pEl = (Element) nodes.item(i);
+                ComponentPolicy cp = new ComponentPolicy();
+                cp.setTitle(pEl.getAttribute("title"));
+                cp.setDescription(pEl.getAttribute("description"));
+                cp.setDefaultClass(pEl.getAttribute("defaultClass"));
+                List<StyleGroup> groups = new ArrayList<>();
+                NodeList groupNodes = pEl.getElementsByTagName("group");
+                for (int j = 0; j < groupNodes.getLength(); j++) {
+                    Element gEl = (Element) groupNodes.item(j);
+                    StyleGroup sg = new StyleGroup();
+                    sg.setName(gEl.getAttribute("name"));
+                    sg.setCombine(Boolean.parseBoolean(gEl.getAttribute("combine")));
+                    List<StylePolicy> styles = new ArrayList<>();
+                    NodeList styleNodes = gEl.getElementsByTagName("style");
+                    for (int k = 0; k < styleNodes.getLength(); k++) {
+                        Element sEl = (Element) styleNodes.item(k);
+                        styles.add(new StylePolicy(sEl.getAttribute("name"), sEl.getAttribute("class")));
+                    }
+                    sg.setStyles(styles);
+                    groups.add(sg);
                 }
+                cp.setGroups(groups);
+                list.add(cp);
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -51,7 +71,7 @@ public class PolicyServiceImpl implements PolicyService {
     }
 
     @Override
-    public void addPolicy(String projectName, String componentName, StylePolicy policy) {
+    public void addPolicy(String projectName, String componentName, ComponentPolicy policy) {
         try {
             File file = new File(getPolicyPath(projectName, componentName));
             Document doc;
@@ -68,11 +88,30 @@ public class PolicyServiceImpl implements PolicyService {
                 root.setAttribute("jcr:primaryType", "nt:unstructured");
                 doc.appendChild(root);
             }
-            Element style = doc.createElement("style");
-            style.setAttribute("jcr:primaryType", "nt:unstructured");
-            style.setAttribute("name", policy.getName());
-            style.setAttribute("class", policy.getCssClass());
-            root.appendChild(style);
+            Element pEl = doc.createElement("policy");
+            pEl.setAttribute("jcr:primaryType", "nt:unstructured");
+            pEl.setAttribute("title", policy.getTitle());
+            if (policy.getDescription() != null) {
+                pEl.setAttribute("description", policy.getDescription());
+            }
+            if (policy.getDefaultClass() != null) {
+                pEl.setAttribute("defaultClass", policy.getDefaultClass());
+            }
+            for (StyleGroup group : policy.getGroups()) {
+                Element gEl = doc.createElement("group");
+                gEl.setAttribute("jcr:primaryType", "nt:unstructured");
+                gEl.setAttribute("name", group.getName());
+                gEl.setAttribute("combine", String.valueOf(group.isCombine()));
+                for (StylePolicy sp : group.getStyles()) {
+                    Element sEl = doc.createElement("style");
+                    sEl.setAttribute("jcr:primaryType", "nt:unstructured");
+                    sEl.setAttribute("name", sp.getName());
+                    sEl.setAttribute("class", sp.getCssClass());
+                    gEl.appendChild(sEl);
+                }
+                pEl.appendChild(gEl);
+            }
+            root.appendChild(pEl);
 
             Transformer transformer = TransformerFactory.newInstance().newTransformer();
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");

--- a/src/main/resources/templates/component-styles.html
+++ b/src/main/resources/templates/component-styles.html
@@ -10,53 +10,116 @@
     <a th:href="@{'/' + ${projectName} + '/template/' + ${templateName}}" class="btn btn-outline-secondary mb-3">&larr; Back</a>
     <h3 th:text="'Component: ' + ${componentName}"></h3>
 
-    <div class="mt-3">
-        <h5>Existing Style Policies</h5>
-        <table class="table">
-            <thead><tr><th>Name</th><th>CSS Class</th></tr></thead>
-            <tbody>
-            <tr th:each="p : ${policies}">
-                <td th:text="${p.name}"></td>
-                <td th:text="${p.cssClass}"></td>
-            </tr>
-            </tbody>
-        </table>
+    <div class="mt-3" th:if="${policies}">
+        <h5>Existing Policies</h5>
+        <div th:each="p : ${policies}" class="border rounded p-3 mb-3">
+            <h6 th:text="${p.title}"></h6>
+            <p th:text="${p.description}"></p>
+            <p><strong>Default Classes:</strong> <span th:text="${p.defaultClass}"></span></p>
+            <div th:each="g : ${p.groups}" class="ms-3">
+                <div><strong th:text="'Group: ' + ${g.name} + (${g.combine} ? ' (combined)' : '')"></strong></div>
+                <ul>
+                    <li th:each="s : ${g.styles}" th:text="${s.name + ' - ' + s.cssClass}"></li>
+                </ul>
+            </div>
+        </div>
     </div>
 
     <div class="mt-4">
-        <h5>Add Style Policy</h5>
-        <form th:action="@{'/' + ${projectName} + '/template/' + ${templateName} + '/' + ${componentName} + '/style'}" method="post" id="styleForm">
-            <div id="styleList">
-                <div class="row g-2 mb-2 style-item">
-                    <div class="col">
-                        <input type="text" class="form-control" name="name" placeholder="Style Name" required>
-                    </div>
-                    <div class="col">
-                        <input type="text" class="form-control" name="cssClass" placeholder="CSS Class" required>
-                    </div>
-                    <div class="col-auto d-flex align-items-center">
-                        <button type="button" class="btn btn-danger btn-sm remove-btn" onclick="removeRow(this)">Remove</button>
-                    </div>
-                </div>
+        <h5>Add Policy</h5>
+        <form th:action="@{'/' + ${projectName} + '/template/' + ${templateName} + '/' + ${componentName} + '/style'}" method="post" id="policyForm">
+            <div class="mb-3">
+                <label class="form-label">Policy Title *</label>
+                <input type="text" class="form-control" id="policyTitle" required>
             </div>
-            <button type="button" class="btn btn-secondary btn-sm" onclick="addRow()">Add</button>
+            <div class="mb-3">
+                <label class="form-label">Policy Description</label>
+                <input type="text" class="form-control" id="policyDescription">
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Default CSS Classes</label>
+                <input type="text" class="form-control" id="defaultClass">
+            </div>
+            <div id="groupList"></div>
+            <button type="button" class="btn btn-secondary btn-sm" onclick="addGroup()">Add Group</button>
+            <input type="hidden" name="policyJson" id="policyJson"/>
             <button type="submit" class="btn btn-primary ms-2">Save</button>
         </form>
     </div>
 </div>
 <script>
-    function addRow() {
-        const template = document.querySelector('.style-item');
-        const clone = template.cloneNode(true);
-        clone.querySelectorAll('input').forEach(i => i.value = '');
-        document.getElementById('styleList').appendChild(clone);
+    function addGroup() {
+        const group = document.createElement('div');
+        group.className = 'policy-group border p-2 mt-3';
+        group.innerHTML = `
+            <div class="d-flex mb-2">
+                <input type="text" class="form-control me-2 group-name" placeholder="Group Name">
+                <div class="form-check">
+                    <input type="checkbox" class="form-check-input group-combine">
+                    <label class="form-check-label">Styles can be combined</label>
+                </div>
+                <button type="button" class="btn btn-danger btn-sm ms-2" onclick="removeGroup(this)">Remove Group</button>
+            </div>
+            <div class="style-list"></div>
+            <button type="button" class="btn btn-outline-secondary btn-sm mt-2" onclick="addStyle(this)">Add Style</button>
+        `;
+        document.getElementById('groupList').appendChild(group);
+        addStyle(group.querySelector('button.btn-outline-secondary'));
     }
-    function removeRow(btn) {
-        const rows = document.querySelectorAll('.style-item');
-        if (rows.length > 1) {
-            btn.closest('.style-item').remove();
+    function removeGroup(btn){
+        btn.closest('.policy-group').remove();
+    }
+    function addStyle(btn){
+        const groupEl = btn.closest('.policy-group');
+        const styleList = groupEl.querySelector('.style-list');
+        const div = document.createElement('div');
+        div.className = 'row g-2 mb-2 style-row';
+        div.innerHTML = `
+            <div class="col">
+                <input type="text" class="form-control style-name" placeholder="Style Name">
+            </div>
+            <div class="col">
+                <input type="text" class="form-control style-class" placeholder="CSS Classes">
+            </div>
+            <div class="col-auto d-flex align-items-center">
+                <button type="button" class="btn btn-danger btn-sm" onclick="removeStyle(this)">Remove</button>
+            </div>`;
+        styleList.appendChild(div);
+    }
+    function removeStyle(btn){
+        const list = btn.closest('.style-list');
+        const rows = list.querySelectorAll('.style-row');
+        if(rows.length > 1){
+            btn.closest('.style-row').remove();
         }
     }
+    document.addEventListener('DOMContentLoaded', () => {
+        addGroup();
+        document.getElementById('policyForm').addEventListener('submit', (e) => {
+            const policy = {
+                title: document.getElementById('policyTitle').value,
+                description: document.getElementById('policyDescription').value,
+                defaultClass: document.getElementById('defaultClass').value,
+                groups: []
+            };
+            document.querySelectorAll('.policy-group').forEach(g => {
+                const group = {
+                    name: g.querySelector('.group-name').value,
+                    combine: g.querySelector('.group-combine').checked,
+                    styles: []
+                };
+                g.querySelectorAll('.style-row').forEach(r => {
+                    const name = r.querySelector('.style-name').value;
+                    const clazz = r.querySelector('.style-class').value;
+                    if(name && clazz){
+                        group.styles.push({name: name, cssClass: clazz});
+                    }
+                });
+                policy.groups.push(group);
+            });
+            document.getElementById('policyJson').value = JSON.stringify(policy);
+        });
+    });
 </script>
 </body>
 </html>

--- a/src/main/resources/templates/component-styles.html
+++ b/src/main/resources/templates/component-styles.html
@@ -25,18 +25,38 @@
 
     <div class="mt-4">
         <h5>Add Style Policy</h5>
-        <form th:action="@{'/' + ${projectName} + '/template/' + ${templateName} + '/' + ${componentName} + '/style'}" method="post">
-            <div class="mb-3">
-                <label class="form-label">Style Name</label>
-                <input type="text" class="form-control" name="name" required>
+        <form th:action="@{'/' + ${projectName} + '/template/' + ${templateName} + '/' + ${componentName} + '/style'}" method="post" id="styleForm">
+            <div id="styleList">
+                <div class="row g-2 mb-2 style-item">
+                    <div class="col">
+                        <input type="text" class="form-control" name="name" placeholder="Style Name" required>
+                    </div>
+                    <div class="col">
+                        <input type="text" class="form-control" name="cssClass" placeholder="CSS Class" required>
+                    </div>
+                    <div class="col-auto d-flex align-items-center">
+                        <button type="button" class="btn btn-danger btn-sm remove-btn" onclick="removeRow(this)">Remove</button>
+                    </div>
+                </div>
             </div>
-            <div class="mb-3">
-                <label class="form-label">CSS Class Name</label>
-                <input type="text" class="form-control" name="cssClass" required>
-            </div>
-            <button type="submit" class="btn btn-primary">Add</button>
+            <button type="button" class="btn btn-secondary btn-sm" onclick="addRow()">Add</button>
+            <button type="submit" class="btn btn-primary ms-2">Save</button>
         </form>
     </div>
 </div>
+<script>
+    function addRow() {
+        const template = document.querySelector('.style-item');
+        const clone = template.cloneNode(true);
+        clone.querySelectorAll('input').forEach(i => i.value = '');
+        document.getElementById('styleList').appendChild(clone);
+    }
+    function removeRow(btn) {
+        const rows = document.querySelectorAll('.style-item');
+        if (rows.length > 1) {
+            btn.closest('.style-item').remove();
+        }
+    }
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/component-styles.html
+++ b/src/main/resources/templates/component-styles.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Component Styles</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body>
+<div th:replace="fragments/navbar :: navbar"></div>
+<div class="container mt-4">
+    <a th:href="@{'/' + ${projectName} + '/template/' + ${templateName}}" class="btn btn-outline-secondary mb-3">&larr; Back</a>
+    <h3 th:text="'Component: ' + ${componentName}"></h3>
+
+    <div class="mt-3">
+        <h5>Existing Style Policies</h5>
+        <table class="table">
+            <thead><tr><th>Name</th><th>CSS Class</th></tr></thead>
+            <tbody>
+            <tr th:each="p : ${policies}">
+                <td th:text="${p.name}"></td>
+                <td th:text="${p.cssClass}"></td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="mt-4">
+        <h5>Add Style Policy</h5>
+        <form th:action="@{'/' + ${projectName} + '/template/' + ${templateName} + '/' + ${componentName} + '/style'}" method="post">
+            <div class="mb-3">
+                <label class="form-label">Style Name</label>
+                <input type="text" class="form-control" name="name" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">CSS Class Name</label>
+                <input type="text" class="form-control" name="cssClass" required>
+            </div>
+            <button type="submit" class="btn btn-primary">Add</button>
+        </form>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/deploy.html
+++ b/src/main/resources/templates/deploy.html
@@ -63,7 +63,7 @@
                 <div id="templatesList" class="row row-cols-1 row-cols-sm-2 g-2">
                     <div class="col" th:each="template : ${templates}">
                         <div class="border rounded p-2 bg-light text-center shadow-sm d-flex justify-content-between align-items-center">
-                            <span th:text="${template}"></span>
+                            <a th:href="@{'/' + ${projectName} + '/template/' + ${template}}" th:text="${template}"></a>
 
                             <!-- Show Edit button only if template is NOT page-content or xf-web-variation -->
                             <a th:if="${template != 'page-content' and template != 'xf-web-variation'}"

--- a/src/main/resources/templates/template-components.html
+++ b/src/main/resources/templates/template-components.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Allowed Components</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body>
+<div th:replace="fragments/navbar :: navbar"></div>
+<div class="container mt-4">
+    <a th:href="@{'/' + ${projectName}}" class="btn btn-outline-secondary mb-3">&larr; Back</a>
+    <h3 th:text="'Template: ' + ${templateName}"></h3>
+    <ul class="list-group mt-3">
+        <li class="list-group-item" th:each="c : ${components}">
+            <a th:href="@{'/' + ${projectName} + '/template/' + ${templateName} + '/' + ${c}}" th:text="${c}"></a>
+        </li>
+    </ul>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow finding allowed components for each template
- manage style policies for components
- add controller and Thymeleaf views
- make template names link to component list in deploy page

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_688c848759d883308cd1e0aa92f3fbe4