### PR TITLE
Add component edit option on deploy page

### DIFF
--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -104,6 +104,15 @@ public class ComponentController {
         return "create-component"; // Thymeleaf template
     }
 
+    @GetMapping("/{project}/editcomponent")
+    public String editComponent(@RequestParam String componentName,
+                                @PathVariable String project,
+                                Model model) {
+        model.addAttribute("projectName", project);
+        model.addAttribute("componentName", componentName);
+        return "edit-component";
+    }
+
     @PostMapping("/component/create/{project}")
     public String createComponent(@PathVariable String project,
                                   @ModelAttribute ComponentRequest request,

--- a/src/main/java/com/aem/builder/controller/DeployController.java
+++ b/src/main/java/com/aem/builder/controller/DeployController.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import java.util.List;
+import java.util.Map;
+import java.util.LinkedHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +31,23 @@ public class DeployController {
         logger.info("DEPLOY: Fetching project details for project: {}", projectName);
         List<String> components = componentService.fetchComponentsFromGeneratedProjects(projectName);
         List<String> templates = templateService.fetchTemplatesFromGeneratedProjects(projectName);
+
+        Map<String, Boolean> componentEditMap = new LinkedHashMap<>();
+        for (String comp : components) {
+            String group = componentService.getComponentGroup(projectName, comp);
+            boolean editable = true;
+            if (group != null) {
+                if (group.equals(projectName + " - Content") ||
+                        group.equals(projectName + " - Structure") ||
+                        group.equals(".hidden")) {
+                    editable = false;
+                }
+            }
+            componentEditMap.put(comp, editable);
+        }
+
         model.addAttribute("components", components);
+        model.addAttribute("componentEditMap", componentEditMap);
         model.addAttribute("templates", templates);
         model.addAttribute("canDeploy", true);
         logger.debug("DEPLOY: Added attributes to model for project: {}", projectName);

--- a/src/main/java/com/aem/builder/service/ComponentService.java
+++ b/src/main/java/com/aem/builder/service/ComponentService.java
@@ -30,4 +30,13 @@ public interface ComponentService {
     //component checking
     boolean isComponentNameAvailable(String projectName, String componentName);
 
+    /**
+     * Returns the component group for a given component within a project.
+     *
+     * @param projectName    the project name
+     * @param componentName  the component to inspect
+     * @return the component group or {@code null} if not found
+     */
+    String getComponentGroup(String projectName, String componentName);
+
 }

--- a/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
@@ -372,4 +372,25 @@ public class ComponentServiceImpl implements ComponentService {
 
         return true; // Available if no exact case-sensitive match found
     }
+
+    @Override
+    public String getComponentGroup(String projectName, String componentName) {
+        String path = PROJECTS_DIR + "/" + projectName + "/ui.apps/src/main/content/jcr_root/apps/" +
+                projectName + "/components/" + componentName + "/.content.xml";
+        File contentXml = new File(path);
+        if (!contentXml.exists()) {
+            return null;
+        }
+        try {
+            String content = FileGenerationUtil.readFile(contentXml);
+            Pattern pattern = Pattern.compile("componentGroup=\"([^\"]+)\"");
+            Matcher matcher = pattern.matcher(content);
+            if (matcher.find()) {
+                return matcher.group(1);
+            }
+        } catch (Exception e) {
+            log.error("Failed to read component group for {}", componentName, e);
+        }
+        return null;
+    }
 }

--- a/src/main/resources/templates/deploy.html
+++ b/src/main/resources/templates/deploy.html
@@ -45,7 +45,12 @@
                 </div>
                 <div id="componentsList" class="row row-cols-1 row-cols-sm-2 g-2">
                     <div class="col" th:each="component : ${components}">
-                        <div class="border rounded p-2 bg-light text-center shadow-sm" th:text="${component}"></div>
+                        <div class="border rounded p-2 bg-light text-center shadow-sm d-flex justify-content-between align-items-center">
+                            <span th:text="${component}"></span>
+                            <a th:if="${componentEditMap[component]}"
+                               th:href="@{/{projectName}/editcomponent(componentName=${component}, projectName=${projectName})}"
+                               class="btn btn-sm btn-outline-secondary ms-2">Edit</a>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/main/resources/templates/edit-component.html
+++ b/src/main/resources/templates/edit-component.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Edit Component</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div th:replace="fragments/navbar :: navbar"></div>
+<div class="container mt-4">
+    <a th:href="@{'/' + ${projectName}}" class="btn btn-outline-secondary mb-3">← Back to DeployPage</a>
+    <h2>Edit Component</h2>
+    <p th:text="'Component: ' + ${componentName}"></p>
+    <!-- Placeholder for future editing form -->
+</div>
+<div th:replace="fragments/navbar :: footer"></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- enable retrieval of component group
- evaluate whether each component should display an Edit button
- show Edit button in deploy view when component is user‑created
- add endpoint and placeholder page for editing components

## Testing
- `mvnw -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_688c8edc756c8330991a1dfb82016cf3