### PR TITLE
Add policy service

### DIFF
--- a/src/main/java/com/aem/builder/controller/PolicyController.java
+++ b/src/main/java/com/aem/builder/controller/PolicyController.java
@@ -1,0 +1,34 @@
+package com.aem.builder.controller;
+
+import com.aem.builder.service.PolicyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/policy")
+public class PolicyController {
+
+    private final PolicyService policyService;
+
+    @GetMapping("/{project}/{template}/components")
+    public ResponseEntity<List<String>> getAllowedComponents(@PathVariable String project,
+                                                             @PathVariable String template) {
+        List<String> comps = policyService.getAllowedComponents(project, template);
+        return ResponseEntity.ok(comps);
+    }
+
+    @GetMapping("/{project}/{template}/map")
+    public ResponseEntity<Map<String, String>> getPolicyMap(@PathVariable String project,
+                                                            @PathVariable String template) {
+        Map<String, String> map = policyService.getComponentPolicies(project, template);
+        return ResponseEntity.ok(map);
+    }
+}

--- a/src/main/java/com/aem/builder/service/PolicyService.java
+++ b/src/main/java/com/aem/builder/service/PolicyService.java
@@ -1,0 +1,16 @@
+package com.aem.builder.service;
+
+import java.util.List;
+import java.util.Map;
+
+public interface PolicyService {
+    /**
+     * Return a list of component names allowed in the given template.
+     */
+    List<String> getAllowedComponents(String projectName, String templateName);
+
+    /**
+     * Return mapping of component name to policy path for the given template.
+     */
+    Map<String, String> getComponentPolicies(String projectName, String templateName);
+}

--- a/src/main/java/com/aem/builder/service/impl/PolicyServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/PolicyServiceImpl.java
@@ -1,0 +1,76 @@
+package com.aem.builder.service.impl;
+
+import com.aem.builder.service.PolicyService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.File;
+import java.util.*;
+
+@Service
+@Slf4j
+public class PolicyServiceImpl implements PolicyService {
+
+    private static final String PROJECTS_DIR = "generated-projects";
+
+    @Override
+    public List<String> getAllowedComponents(String projectName, String templateName) {
+        Map<String, String> map = getComponentPolicies(projectName, templateName);
+        return new ArrayList<>(map.keySet());
+    }
+
+    @Override
+    public Map<String, String> getComponentPolicies(String projectName, String templateName) {
+        String path = PROJECTS_DIR + "/" + projectName +
+                "/ui.content/src/main/content/jcr_root/conf/" + projectName +
+                "/settings/wcm/templates/" + templateName + "/policies/.content.xml";
+        File file = new File(path);
+        // Fallback to classpath templates if not found in generated project
+        if (!file.exists()) {
+            file = new File("src/main/resources/aem-templates/" + templateName + "/policies/.content.xml");
+        }
+        Map<String, String> result = new LinkedHashMap<>();
+        if (!file.exists()) {
+            log.warn("Policy file not found: {}", file.getAbsolutePath());
+            return result;
+        }
+        try {
+            Document doc = DocumentBuilderFactory.newInstance()
+                    .newDocumentBuilder().parse(file);
+            Element root = doc.getDocumentElement();
+            traverse(root, result);
+        } catch (Exception e) {
+            log.error("Failed to parse policy file", e);
+        }
+        return result;
+    }
+
+    private void traverse(Node node, Map<String, String> result) {
+        if (node.getNodeType() == Node.ELEMENT_NODE) {
+            Element el = (Element) node;
+            if (el.hasAttribute("sling:resourceType")) {
+                String rt = el.getAttribute("sling:resourceType");
+                int idx = rt.indexOf("/components/");
+                if (idx != -1) {
+                    String comp = rt.substring(idx + "/components/".length());
+                    int slash = comp.indexOf('/');
+                    if (slash != -1) comp = comp.substring(slash + 1);
+                    if (el.hasAttribute("cq:policy")) {
+                        result.putIfAbsent(comp, el.getAttribute("cq:policy"));
+                    } else {
+                        result.putIfAbsent(comp, "");
+                    }
+                }
+            }
+            NodeList list = el.getChildNodes();
+            for (int i = 0; i < list.getLength(); i++) {
+                traverse(list.item(i), result);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `PolicyService` to parse template policy XML
- expose new endpoints via `PolicyController`

## Testing
- `mvn test` *(fails: unable to resolve parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_688c9b2a3968833083065bf39f4761e0