### PR TITLE
Add basic editable template policy UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,7 @@ git clone https://github.com/your-org/aem-project-generator.git
 cd aem-project-generator
 ./mvnw spring-boot:run
  
+
+
+### Policy Editor
+Access `/{{projectName}}/policies` to manage component policies for any template. The page lists templates, allowed components, and existing policies. New or updated policies are saved back into the corresponding `.content.xml` files under `conf/<project>/settings/wcm`.

--- a/src/main/java/com/aem/builder/controller/TemplateController.java
+++ b/src/main/java/com/aem/builder/controller/TemplateController.java
@@ -134,6 +134,12 @@ public class TemplateController {
         }
     }
 
+    @GetMapping("/{projectName}/policies")
+    public String showPolicyEditor(@PathVariable String projectName, Model model) {
+        model.addAttribute("projectName", projectName);
+        return "policy-ui";
+    }
+
 
 
 }

--- a/src/main/java/com/aem/builder/controller/policy/PolicyController.java
+++ b/src/main/java/com/aem/builder/controller/policy/PolicyController.java
@@ -1,0 +1,50 @@
+package com.aem.builder.controller.policy;
+
+import com.aem.builder.model.policy.PolicyModel;
+import com.aem.builder.service.policy.PolicyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/policy")
+@RequiredArgsConstructor
+public class PolicyController {
+
+    private final PolicyService policyService;
+
+    @GetMapping("/{project}/{template}/components")
+    public List<String> getComponents(@PathVariable String project, @PathVariable String template) {
+        return policyService.getAllowedComponents(project, template);
+    }
+
+    @GetMapping("/{project}/component/{component}")
+    public List<String> getPolicies(@PathVariable String project, @PathVariable String component) {
+        return policyService.getPoliciesForComponent(project, component);
+    }
+
+    @GetMapping("/{project}/component/{component}/{policy}")
+    public PolicyModel loadPolicy(@PathVariable String project, @PathVariable String component, @PathVariable String policy) {
+        return policyService.readPolicy(project, component, policy);
+    }
+
+    @PostMapping("/{project}/{template}/component/{component}")
+    public ResponseEntity<Void> savePolicy(@PathVariable String project,
+                                           @PathVariable String template,
+                                           @PathVariable String component,
+                                           @RequestBody PolicyModel model) {
+        policyService.savePolicy(project, template, component, model);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{project}/{template}/component/{component}/{policy}")
+    public ResponseEntity<Void> deletePolicy(@PathVariable String project,
+                                             @PathVariable String template,
+                                             @PathVariable String component,
+                                             @PathVariable String policy) {
+        policyService.deletePolicy(project, template, component, policy);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/aem/builder/model/policy/PolicyModel.java
+++ b/src/main/java/com/aem/builder/model/policy/PolicyModel.java
@@ -1,0 +1,17 @@
+package com.aem.builder.model.policy;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PolicyModel {
+    private String policyName;
+    private String styleDefaultClasses;
+    private List<StyleGroup> styleGroups = new ArrayList<>();
+}

--- a/src/main/java/com/aem/builder/model/policy/Style.java
+++ b/src/main/java/com/aem/builder/model/policy/Style.java
@@ -1,0 +1,15 @@
+package com.aem.builder.model.policy;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Style {
+    private String name;
+    private String className;
+    private String title;
+    private boolean defaultStyle;
+}

--- a/src/main/java/com/aem/builder/model/policy/StyleGroup.java
+++ b/src/main/java/com/aem/builder/model/policy/StyleGroup.java
@@ -1,0 +1,16 @@
+package com.aem.builder.model.policy;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class StyleGroup {
+    private String name;
+    private List<Style> styles = new ArrayList<>();
+}

--- a/src/main/java/com/aem/builder/service/policy/PolicyService.java
+++ b/src/main/java/com/aem/builder/service/policy/PolicyService.java
@@ -1,0 +1,17 @@
+package com.aem.builder.service.policy;
+
+import com.aem.builder.model.policy.PolicyModel;
+
+import java.util.List;
+
+public interface PolicyService {
+    List<String> getAllowedComponents(String projectName, String templateName);
+
+    List<String> getPoliciesForComponent(String projectName, String componentName);
+
+    PolicyModel readPolicy(String projectName, String componentName, String policyName);
+
+    void savePolicy(String projectName, String templateName, String componentName, PolicyModel policy);
+
+    void deletePolicy(String projectName, String templateName, String componentName, String policyName);
+}

--- a/src/main/java/com/aem/builder/service/policy/impl/PolicyServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/policy/impl/PolicyServiceImpl.java
@@ -1,0 +1,263 @@
+package com.aem.builder.service.policy.impl;
+
+import com.aem.builder.model.policy.PolicyModel;
+import com.aem.builder.model.policy.Style;
+import com.aem.builder.model.policy.StyleGroup;
+import com.aem.builder.service.policy.PolicyService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@Slf4j
+public class PolicyServiceImpl implements PolicyService {
+    private static final String BASE = "generated-projects";
+
+    private Path getTemplateStructurePath(String project, String template) {
+        return Paths.get(BASE, project,
+                "ui.content/src/main/content/jcr_root/conf/" + project +
+                        "/settings/wcm/templates/" + template + "/structure/.content.xml");
+    }
+
+    private Path getTemplatePoliciesPath(String project, String template) {
+        return Paths.get(BASE, project,
+                "ui.content/src/main/content/jcr_root/conf/" + project +
+                        "/settings/wcm/templates/" + template + "/policies/.content.xml");
+    }
+
+    private Path getComponentPolicyFolder(String project, String component) {
+        return Paths.get(BASE, project,
+                "ui.content/src/main/content/jcr_root/conf/" + project +
+                        "/settings/wcm/policies/" + component);
+    }
+
+    @Override
+    public List<String> getAllowedComponents(String projectName, String templateName) {
+        List<String> components = new ArrayList<>();
+        Path p = getTemplateStructurePath(projectName, templateName);
+        if (!Files.exists(p)) return components;
+        try {
+            DocumentBuilderFactory f = DocumentBuilderFactory.newInstance();
+            DocumentBuilder b = f.newDocumentBuilder();
+            Document doc = b.parse(p.toFile());
+            NodeList nodes = doc.getElementsByTagName("*");
+            Set<String> set = new HashSet<>();
+            for (int i = 0; i < nodes.getLength(); i++) {
+                Node n = nodes.item(i);
+                if (n.getNodeType() == Node.ELEMENT_NODE) {
+                    Element e = (Element) n;
+                    String rt = e.getAttribute("sling:resourceType");
+                    String prefix = projectName + "/components/";
+                    if (rt != null && rt.startsWith(prefix)) {
+                        String comp = rt.substring(prefix.length());
+                        set.add(comp);
+                    }
+                }
+            }
+            components.addAll(set);
+        } catch (Exception e) {
+            log.error("Error reading allowed components", e);
+        }
+        return components;
+    }
+
+    @Override
+    public List<String> getPoliciesForComponent(String projectName, String componentName) {
+        List<String> policies = new ArrayList<>();
+        Path folder = getComponentPolicyFolder(projectName, componentName);
+        if (!Files.isDirectory(folder)) return policies;
+        File[] files = folder.toFile().listFiles((dir, name) -> name.endsWith(".content.xml"));
+        if (files != null) {
+            for (File f : files) {
+                String name = f.getName().replace(".content.xml", "");
+                policies.add(name);
+            }
+        }
+        return policies;
+    }
+
+    @Override
+    public PolicyModel readPolicy(String projectName, String componentName, String policyName) {
+        Path file = getComponentPolicyFolder(projectName, componentName)
+                .resolve(policyName + ".content.xml");
+        if (!Files.exists(file)) return null;
+        try {
+            DocumentBuilderFactory f = DocumentBuilderFactory.newInstance();
+            DocumentBuilder b = f.newDocumentBuilder();
+            Document doc = b.parse(file.toFile());
+            Element root = doc.getDocumentElement();
+            PolicyModel model = new PolicyModel();
+            model.setPolicyName(policyName);
+            model.setStyleDefaultClasses(root.getAttribute("cq:styleDefaultClasses"));
+            NodeList groups = root.getElementsByTagName("cq:styleGroups");
+            if (groups.getLength() > 0) {
+                Element groupsEl = (Element) groups.item(0);
+                NodeList groupNodes = groupsEl.getChildNodes();
+                for (int i = 0; i < groupNodes.getLength(); i++) {
+                    Node g = groupNodes.item(i);
+                    if (g.getNodeType() == Node.ELEMENT_NODE) {
+                        Element ge = (Element) g;
+                        StyleGroup sg = new StyleGroup();
+                        sg.setName(ge.getNodeName());
+                        NodeList styleNodes = ge.getElementsByTagName("styles");
+                        if (styleNodes.getLength() > 0) {
+                            Element stylesEl = (Element) styleNodes.item(0);
+                            NodeList sNodes = stylesEl.getChildNodes();
+                            for (int j = 0; j < sNodes.getLength(); j++) {
+                                Node sn = sNodes.item(j);
+                                if (sn.getNodeType() == Node.ELEMENT_NODE) {
+                                    Element se = (Element) sn;
+                                    Style st = new Style();
+                                    st.setName(se.getNodeName());
+                                    st.setClassName(se.getAttribute("cq:styleClasses"));
+                                    st.setTitle(se.getAttribute("jcr:title"));
+                                    st.setDefaultStyle("true".equals(se.getAttribute("cq:default")));
+                                    sg.getStyles().add(st);
+                                }
+                            }
+                        }
+                        model.getStyleGroups().add(sg);
+                    }
+                }
+            }
+            return model;
+        } catch (Exception e) {
+            log.error("Error reading policy", e);
+            return null;
+        }
+    }
+
+    @Override
+    public void savePolicy(String projectName, String templateName, String componentName, PolicyModel policy) {
+        try {
+            Path folder = getComponentPolicyFolder(projectName, componentName);
+            Files.createDirectories(folder);
+            Path file = folder.resolve(policy.getPolicyName() + ".content.xml");
+
+            DocumentBuilderFactory f = DocumentBuilderFactory.newInstance();
+            DocumentBuilder b = f.newDocumentBuilder();
+            Document doc = b.newDocument();
+            Element root = doc.createElement("jcr:root");
+            root.setAttribute("xmlns:sling", "http://sling.apache.org/jcr/sling/1.0");
+            root.setAttribute("xmlns:cq", "http://www.day.com/jcr/cq/1.0");
+            root.setAttribute("xmlns:jcr", "http://www.jcp.org/jcr/1.0");
+            root.setAttribute("jcr:primaryType", "nt:unstructured");
+            if (policy.getStyleDefaultClasses() != null) {
+                root.setAttribute("cq:styleDefaultClasses", policy.getStyleDefaultClasses());
+            }
+            if (!policy.getStyleGroups().isEmpty()) {
+                Element groupsEl = doc.createElement("cq:styleGroups");
+                groupsEl.setAttribute("jcr:primaryType", "nt:unstructured");
+                for (StyleGroup sg : policy.getStyleGroups()) {
+                    Element gEl = doc.createElement(sg.getName());
+                    gEl.setAttribute("jcr:primaryType", "nt:unstructured");
+                    if (!sg.getStyles().isEmpty()) {
+                        Element stylesEl = doc.createElement("styles");
+                        stylesEl.setAttribute("jcr:primaryType", "nt:unstructured");
+                        for (Style st : sg.getStyles()) {
+                            Element stEl = doc.createElement(st.getName());
+                            stEl.setAttribute("jcr:primaryType", "nt:unstructured");
+                            if (st.getClassName() != null) stEl.setAttribute("cq:styleClasses", st.getClassName());
+                            if (st.getTitle() != null) stEl.setAttribute("jcr:title", st.getTitle());
+                            if (st.isDefaultStyle()) stEl.setAttribute("cq:default", "true");
+                            stylesEl.appendChild(stEl);
+                        }
+                        gEl.appendChild(stylesEl);
+                    }
+                    groupsEl.appendChild(gEl);
+                }
+                root.appendChild(groupsEl);
+            }
+            doc.appendChild(root);
+            TransformerFactory tf = TransformerFactory.newInstance();
+            Transformer tr = tf.newTransformer();
+            tr.setOutputProperty(OutputKeys.INDENT, "yes");
+            tr.transform(new DOMSource(doc), new StreamResult(file.toFile()));
+
+            // update mapping file
+            Path mapping = getTemplatePoliciesPath(projectName, templateName);
+            Files.createDirectories(mapping.getParent());
+            Document mappingDoc;
+            if (Files.exists(mapping)) {
+                mappingDoc = b.parse(mapping.toFile());
+            } else {
+                mappingDoc = b.newDocument();
+                Element rootMapping = mappingDoc.createElement("jcr:root");
+                rootMapping.setAttribute("xmlns:sling", "http://sling.apache.org/jcr/sling/1.0");
+                rootMapping.setAttribute("xmlns:cq", "http://www.day.com/jcr/cq/1.0");
+                rootMapping.setAttribute("xmlns:jcr", "http://www.jcp.org/jcr/1.0");
+                rootMapping.setAttribute("xmlns:nt", "http://www.jcp.org/jcr/nt/1.0");
+                rootMapping.setAttribute("jcr:primaryType", "cq:Page");
+                Element jcrContent = mappingDoc.createElement("jcr:content");
+                jcrContent.setAttribute("jcr:primaryType", "nt:unstructured");
+                jcrContent.setAttribute("sling:resourceType", "wcm/core/components/policies/mappings");
+                rootMapping.appendChild(jcrContent);
+                mappingDoc.appendChild(rootMapping);
+            }
+            Element rootEl = mappingDoc.getDocumentElement();
+            Element jcrContent = (Element) rootEl.getElementsByTagName("jcr:content").item(0);
+            Element componentEl = mappingDoc.createElement(componentName);
+            componentEl.setAttribute("cq:policy", projectName + "/components/" + componentName + "/" + policy.getPolicyName());
+            componentEl.setAttribute("jcr:primaryType", "nt:unstructured");
+            componentEl.setAttribute("sling:resourceType", "wcm/core/components/policies/mapping");
+            jcrContent.appendChild(componentEl);
+            Transformer tr2 = TransformerFactory.newInstance().newTransformer();
+            tr2.setOutputProperty(OutputKeys.INDENT, "yes");
+            tr2.transform(new DOMSource(mappingDoc), new StreamResult(mapping.toFile()));
+        } catch (Exception e) {
+            log.error("Error saving policy", e);
+        }
+    }
+
+    @Override
+    public void deletePolicy(String projectName, String templateName, String componentName, String policyName) {
+        try {
+            Path file = getComponentPolicyFolder(projectName, componentName)
+                    .resolve(policyName + ".content.xml");
+            Files.deleteIfExists(file);
+            Path mapping = getTemplatePoliciesPath(projectName, templateName);
+            if (Files.exists(mapping)) {
+                DocumentBuilder b = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+                Document doc = b.parse(mapping.toFile());
+                Element root = doc.getDocumentElement();
+                Element jcrContent = (Element) root.getElementsByTagName("jcr:content").item(0);
+                NodeList children = jcrContent.getChildNodes();
+                for (int i = 0; i < children.getLength(); i++) {
+                    Node n = children.item(i);
+                    if (n.getNodeType() == Node.ELEMENT_NODE && n.getNodeName().equals(componentName)) {
+                        Element e = (Element) n;
+                        String pol = e.getAttribute("cq:policy");
+                        if (pol != null && pol.endsWith("/" + policyName)) {
+                            jcrContent.removeChild(e);
+                            break;
+                        }
+                    }
+                }
+                Transformer tr = TransformerFactory.newInstance().newTransformer();
+                tr.setOutputProperty(OutputKeys.INDENT, "yes");
+                tr.transform(new DOMSource(doc), new StreamResult(mapping.toFile()));
+            }
+        } catch (Exception e) {
+            log.error("Error deleting policy", e);
+        }
+    }
+}

--- a/src/main/resources/static/js/policy-ui.js
+++ b/src/main/resources/static/js/policy-ui.js
@@ -1,0 +1,77 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const projectName = document.getElementById('projectName').value;
+    const templateList = document.getElementById('templateList');
+    const componentList = document.getElementById('componentList');
+    const policyList = document.getElementById('policyList');
+    const policyForm = document.getElementById('policyForm');
+
+    fetch(`/templates/list/${projectName}`)
+        .then(r => r.json())
+        .then(templates => {
+            templates.forEach(t => {
+                const li = document.createElement('li');
+                li.textContent = t;
+                li.className = 'list-group-item list-group-item-action';
+                li.addEventListener('click', () => loadComponents(t));
+                templateList.appendChild(li);
+            });
+        });
+
+    function loadComponents(template) {
+        document.getElementById('templateName').value = template;
+        componentList.innerHTML = '';
+        policyList.innerHTML = '';
+        fetch(`/api/policy/${projectName}/${template}/components`)
+            .then(r => r.json())
+            .then(comps => {
+                comps.forEach(c => {
+                    const li = document.createElement('li');
+                    li.textContent = c;
+                    li.className = 'list-group-item list-group-item-action';
+                    li.addEventListener('click', () => loadPolicies(c));
+                    componentList.appendChild(li);
+                });
+            });
+    }
+
+    function loadPolicies(component) {
+        document.getElementById('componentName').value = component;
+        policyList.innerHTML = '';
+        fetch(`/api/policy/${projectName}/component/${component}`)
+            .then(r => r.json())
+            .then(policies => {
+                policies.forEach(p => {
+                    const li = document.createElement('li');
+                    li.textContent = p;
+                    li.className = 'list-group-item list-group-item-action';
+                    li.addEventListener('click', () => loadPolicyDetail(component, p));
+                    policyList.appendChild(li);
+                });
+            });
+    }
+
+    function loadPolicyDetail(component, policy) {
+        document.getElementById('policyName').value = policy;
+        fetch(`/api/policy/${projectName}/component/${component}/${policy}`)
+            .then(r => r.json())
+            .then(data => {
+                if (data) {
+                    document.getElementById('defaultClasses').value = data.styleDefaultClasses || '';
+                }
+            });
+    }
+
+    policyForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const template = document.getElementById('templateName').value;
+        const component = document.getElementById('componentName').value;
+        const name = document.getElementById('policyName').value;
+        const def = document.getElementById('defaultClasses').value;
+        const body = { policyName: name, styleDefaultClasses: def, styleGroups: [] };
+        fetch(`/api/policy/${projectName}/${template}/component/${component}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+        }).then(() => loadPolicies(component));
+    });
+});

--- a/src/main/resources/static/js/policy-ui.js
+++ b/src/main/resources/static/js/policy-ui.js
@@ -4,6 +4,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const componentList = document.getElementById('componentList');
     const policyList = document.getElementById('policyList');
     const policyForm = document.getElementById('policyForm');
+    const styleGroupsDiv = document.getElementById('styleGroups');
+    const addGroupBtn = document.getElementById('addGroup');
+    const deleteBtn = document.getElementById('deletePolicy');
+    let loadedPolicy = null;
 
     fetch(`/templates/list/${projectName}`)
         .then(r => r.json())
@@ -17,10 +21,18 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         });
 
+    function clearForm() {
+        policyForm.reset();
+        styleGroupsDiv.innerHTML = '';
+        deleteBtn.classList.add('d-none');
+        loadedPolicy = null;
+    }
+
     function loadComponents(template) {
         document.getElementById('templateName').value = template;
         componentList.innerHTML = '';
         policyList.innerHTML = '';
+        clearForm();
         fetch(`/api/policy/${projectName}/${template}/components`)
             .then(r => r.json())
             .then(comps => {
@@ -37,6 +49,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function loadPolicies(component) {
         document.getElementById('componentName').value = component;
         policyList.innerHTML = '';
+        clearForm();
         fetch(`/api/policy/${projectName}/component/${component}`)
             .then(r => r.json())
             .then(policies => {
@@ -50,13 +63,56 @@ document.addEventListener('DOMContentLoaded', () => {
             });
     }
 
+    function createStyleRow(style = {}) {
+        const row = document.createElement('div');
+        row.className = 'style-row input-group mb-1';
+        row.innerHTML = `
+            <input type="text" class="form-control form-control-sm style-name" placeholder="Style Name" value="${style.name || ''}">
+            <input type="text" class="form-control form-control-sm style-class" placeholder="Classes" value="${style.className || ''}">
+            <input type="text" class="form-control form-control-sm style-title" placeholder="Title" value="${style.title || ''}">
+            <div class="input-group-text">
+                <input type="checkbox" class="form-check-input mt-0 style-default" ${style.defaultStyle ? 'checked' : ''}>
+            </div>
+            <button type="button" class="btn btn-sm btn-outline-danger remove-style">×</button>
+        `;
+        row.querySelector('.remove-style').addEventListener('click', () => row.remove());
+        return row;
+    }
+
+    function createGroup(name = '', styles = []) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'border p-2 mb-2 style-group';
+        const header = document.createElement('div');
+        header.className = 'd-flex mb-1';
+        header.innerHTML = `
+            <input type="text" class="form-control form-control-sm group-name" placeholder="Group Name" value="${name}">
+            <button type="button" class="btn btn-sm btn-outline-secondary ms-2 add-style">Add Style</button>
+            <button type="button" class="btn btn-sm btn-outline-danger ms-2 remove-group">×</button>
+        `;
+        wrapper.appendChild(header);
+        const list = document.createElement('div');
+        list.className = 'style-list';
+        wrapper.appendChild(list);
+        header.querySelector('.add-style').addEventListener('click', () => list.appendChild(createStyleRow()));
+        header.querySelector('.remove-group').addEventListener('click', () => wrapper.remove());
+        styles.forEach(st => list.appendChild(createStyleRow(st)));
+        return wrapper;
+    }
+
     function loadPolicyDetail(component, policy) {
+        document.getElementById('policyName').value = policy;
+        clearForm();
         document.getElementById('policyName').value = policy;
         fetch(`/api/policy/${projectName}/component/${component}/${policy}`)
             .then(r => r.json())
             .then(data => {
                 if (data) {
+                    loadedPolicy = policy;
+                    deleteBtn.classList.remove('d-none');
                     document.getElementById('defaultClasses').value = data.styleDefaultClasses || '';
+                    data.styleGroups.forEach(g => {
+                        styleGroupsDiv.appendChild(createGroup(g.name, g.styles));
+                    });
                 }
             });
     }
@@ -67,11 +123,43 @@ document.addEventListener('DOMContentLoaded', () => {
         const component = document.getElementById('componentName').value;
         const name = document.getElementById('policyName').value;
         const def = document.getElementById('defaultClasses').value;
-        const body = { policyName: name, styleDefaultClasses: def, styleGroups: [] };
+        const groups = [];
+        styleGroupsDiv.querySelectorAll('.style-group').forEach(g => {
+            const gName = g.querySelector('.group-name').value;
+            const styles = [];
+            g.querySelectorAll('.style-row').forEach(r => {
+                const sName = r.querySelector('.style-name').value;
+                if (!sName) return;
+                styles.push({
+                    name: sName,
+                    className: r.querySelector('.style-class').value,
+                    title: r.querySelector('.style-title').value,
+                    defaultStyle: r.querySelector('.style-default').checked
+                });
+            });
+            if (gName) {
+                groups.push({ name: gName, styles });
+            }
+        });
+        const body = { policyName: name, styleDefaultClasses: def, styleGroups: groups };
         fetch(`/api/policy/${projectName}/${template}/component/${component}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(body)
         }).then(() => loadPolicies(component));
+    });
+
+    addGroupBtn.addEventListener('click', () => {
+        styleGroupsDiv.appendChild(createGroup());
+    });
+
+    deleteBtn.addEventListener('click', () => {
+        const template = document.getElementById('templateName').value;
+        const component = document.getElementById('componentName').value;
+        if (loadedPolicy) {
+            fetch(`/api/policy/${projectName}/${template}/component/${component}/${loadedPolicy}`, {
+                method: 'DELETE'
+            }).then(() => { loadPolicies(component); clearForm(); });
+        }
     });
 });

--- a/src/main/resources/templates/policy-ui.html
+++ b/src/main/resources/templates/policy-ui.html
@@ -32,7 +32,10 @@
                 <div class="mb-2">
                     <input class="form-control" id="defaultClasses" placeholder="cq:styleDefaultClasses">
                 </div>
+                <div id="styleGroups" class="mb-2"></div>
+                <button type="button" id="addGroup" class="btn btn-sm btn-secondary mb-2">Add Style Group</button>
                 <button type="submit" class="btn btn-primary">Save Policy</button>
+                <button type="button" id="deletePolicy" class="btn btn-danger ms-2 d-none">Delete</button>
             </form>
         </div>
     </div>

--- a/src/main/resources/templates/policy-ui.html
+++ b/src/main/resources/templates/policy-ui.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Policy Editor</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body>
+<div class="container mt-4">
+    <a th:href="@{'/' + ${projectName}}" class="btn btn-outline-secondary mb-3">← Back</a>
+    <h2>Manage Policies for [[${projectName}]]</h2>
+    <input type="hidden" id="projectName" th:value="${projectName}">
+
+    <div class="row">
+        <div class="col-md-4">
+            <h5>Templates</h5>
+            <ul id="templateList" class="list-group"></ul>
+        </div>
+        <div class="col-md-4">
+            <h5>Components</h5>
+            <ul id="componentList" class="list-group"></ul>
+        </div>
+        <div class="col-md-4">
+            <h5>Policies</h5>
+            <ul id="policyList" class="list-group mb-3"></ul>
+            <form id="policyForm">
+                <input type="hidden" id="templateName">
+                <input type="hidden" id="componentName">
+                <div class="mb-2">
+                    <input class="form-control" id="policyName" placeholder="Policy Name">
+                </div>
+                <div class="mb-2">
+                    <input class="form-control" id="defaultClasses" placeholder="cq:styleDefaultClasses">
+                </div>
+                <button type="submit" class="btn btn-primary">Save Policy</button>
+            </form>
+        </div>
+    </div>
+</div>
+<script th:src="@{/js/policy-ui.js}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Policy service, controller, and models
- show policy editor page
- provide JS for dynamic loading of templates, components and policies
- expose route `/api/policy` and `/projectName/policies`
- document policy editor usage

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_688c9e89f1908330888d470e402e53a0