### PR TITLE
Add basic AEM policy UI

### DIFF
--- a/src/main/java/com/aem/builder/controller/PolicyController.java
+++ b/src/main/java/com/aem/builder/controller/PolicyController.java
@@ -1,0 +1,52 @@
+package com.aem.builder.controller;
+
+import com.aem.builder.model.PolicyModel;
+import com.aem.builder.service.PolicyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.io.IOException;
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class PolicyController {
+    private final PolicyService policyService;
+
+    @GetMapping("/template-components/{project}/{template}")
+    @ResponseBody
+    public List<String> getTemplateComponents(@PathVariable String project, @PathVariable String template) {
+        return policyService.getAllowedComponents(project, template);
+    }
+
+    @GetMapping("/{project}/policy/{template}/{component}")
+    public String showPolicyForm(@PathVariable String project,
+                                 @PathVariable String template,
+                                 @PathVariable String component,
+                                 Model model) {
+        model.addAttribute("projectName", project);
+        model.addAttribute("templateName", template);
+        model.addAttribute("componentName", component);
+        model.addAttribute("policy", new PolicyModel());
+        return "policy-ui";
+    }
+
+    @PostMapping("/{project}/policy/{template}/{component}")
+    public String createPolicy(@PathVariable String project,
+                               @PathVariable String template,
+                               @PathVariable String component,
+                               @ModelAttribute PolicyModel policy,
+                               RedirectAttributes redirectAttributes) {
+        try {
+            policyService.createPolicy(project, template, component, policy);
+            redirectAttributes.addFlashAttribute("message", "Policy created successfully");
+        } catch (IOException e) {
+            redirectAttributes.addFlashAttribute("error", "Failed to create policy");
+        }
+        return "redirect:/" + project;
+    }
+}

--- a/src/main/java/com/aem/builder/model/PolicyModel.java
+++ b/src/main/java/com/aem/builder/model/PolicyModel.java
@@ -1,0 +1,20 @@
+package com.aem.builder.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PolicyModel {
+    private String title;
+    private String description;
+    private String defaultCssClasses;
+    private List<String> styleNames;
+    private List<String> styleClasses;
+}

--- a/src/main/java/com/aem/builder/service/PolicyService.java
+++ b/src/main/java/com/aem/builder/service/PolicyService.java
@@ -1,0 +1,11 @@
+package com.aem.builder.service;
+
+import com.aem.builder.model.PolicyModel;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface PolicyService {
+    List<String> getAllowedComponents(String projectName, String templateName);
+    void createPolicy(String projectName, String templateName, String componentName, PolicyModel policy) throws IOException;
+}

--- a/src/main/java/com/aem/builder/service/impl/PolicyServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/PolicyServiceImpl.java
@@ -1,0 +1,61 @@
+package com.aem.builder.service.impl;
+
+import com.aem.builder.model.PolicyModel;
+import com.aem.builder.service.PolicyService;
+import org.apache.commons.io.FileUtils;
+import org.springframework.stereotype.Service;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class PolicyServiceImpl implements PolicyService {
+    @Override
+    public List<String> getAllowedComponents(String projectName, String templateName) {
+        List<String> components = new ArrayList<>();
+        String path = "generated-projects/" + projectName +
+                "/ui.content/src/main/content/jcr_root/conf/" + projectName +
+                "/settings/wcm/templates/" + templateName + "/policies/.content.xml";
+        File file = new File(path);
+        if (!file.exists()) {
+            return components;
+        }
+        try {
+            DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            Document doc = builder.parse(file);
+            NodeList roots = doc.getElementsByTagName("root");
+            if (roots.getLength() > 0) {
+                NodeList children = roots.item(0).getChildNodes();
+                for (int i = 0; i < children.getLength(); i++) {
+                    Node n = children.item(i);
+                    if (n.getNodeType() == Node.ELEMENT_NODE) {
+                        components.add(n.getNodeName());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return components;
+    }
+
+    @Override
+    public void createPolicy(String projectName, String templateName, String componentName, PolicyModel policy) throws IOException {
+        String folder = "generated-projects/" + projectName +
+                "/ui.content/src/main/content/jcr_root/conf/" + projectName +
+                "/settings/wcm/templates/" + templateName + "/policies";
+        FileUtils.forceMkdir(new File(folder));
+        File file = new File(folder, componentName + "-policy.xml");
+        String xml = String.format("<policy><title>%s</title><description>%s</description></policy>",
+                policy.getTitle(), policy.getDescription());
+        FileUtils.writeStringToFile(file, xml, StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/resources/static/js/deploy.js
+++ b/src/main/resources/static/js/deploy.js
@@ -157,3 +157,33 @@
         document.getElementById('deployBtn').disabled = true;
         return true;
     }
+
+    // Template item click to show allowed components
+    let currentTemplate = null;
+    document.addEventListener('DOMContentLoaded', () => {
+        document.querySelectorAll('.template-item').forEach(el => {
+            el.addEventListener('click', () => {
+                currentTemplate = el.getAttribute('data-template');
+                const projectName = getProjectName();
+                fetch(`/template-components/${projectName}/${currentTemplate}`)
+                    .then(res => res.json())
+                    .then(list => {
+                        const title = document.getElementById('templateComponentsTitle');
+                        title.textContent = `Components of ${currentTemplate}`;
+                        const container = document.getElementById('templateComponentsList');
+                        container.innerHTML = '';
+                        list.forEach(c => {
+                            const btn = document.createElement('button');
+                            btn.type = 'button';
+                            btn.className = 'list-group-item list-group-item-action';
+                            btn.textContent = c;
+                            btn.addEventListener('click', () => {
+                                window.location.href = `/${projectName}/policy/${currentTemplate}/${c}`;
+                            });
+                            container.appendChild(btn);
+                        });
+                        new bootstrap.Modal(document.getElementById('templateComponentsModal')).show();
+                    });
+            });
+        });
+    });

--- a/src/main/resources/templates/deploy.html
+++ b/src/main/resources/templates/deploy.html
@@ -62,7 +62,7 @@
                 </div>
                 <div id="templatesList" class="row row-cols-1 row-cols-sm-2 g-2">
                     <div class="col" th:each="template : ${templates}">
-                        <div class="border rounded p-2 bg-light text-center shadow-sm d-flex justify-content-between align-items-center">
+                        <div class="border rounded p-2 bg-light text-center shadow-sm d-flex justify-content-between align-items-center template-item" th:attr="data-template=${template}">
                             <span th:text="${template}"></span>
 
                             <!-- Show Edit button only if template is NOT page-content or xf-web-variation -->
@@ -109,6 +109,20 @@
             </div>
             <div class="modal-footer">
                 <button class="btn btn-primary" onclick="addSelectedTemplates()">Add Selected</button>
+            </div>
+        </div>
+    </div>
+</div>
+<!-- Template Components Modal -->
+<div class="modal fade" id="templateComponentsModal" tabindex="-1">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 id="templateComponentsTitle">Template Components</h5>
+                <button class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <div id="templateComponentsList" class="list-group"></div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/policy-ui.html
+++ b/src/main/resources/templates/policy-ui.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Create Policy</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body>
+<div class="container mt-4">
+    <a th:href="@{'/' + ${projectName}}" class="btn btn-outline-secondary mb-3">← Back to DeployPage</a>
+    <h2>Create Policy for <span th:text="${componentName}"></span></h2>
+    <form th:action="@{'/' + ${projectName} + '/policy/' + ${templateName} + '/' + ${componentName}}" method="post" th:object="${policy}">
+        <div class="mb-3">
+            <label class="form-label">Policy Title</label>
+            <input type="text" class="form-control" th:field="*{title}" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Policy Description</label>
+            <input type="text" class="form-control" th:field="*{description}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Default CSS Classes</label>
+            <input type="text" class="form-control" th:field="*{defaultCssClasses}">
+        </div>
+        <div id="stylesContainer" class="mb-3">
+            <label class="form-label">Allowed Styles</label>
+        </div>
+        <button type="button" class="btn btn-secondary mb-2" onclick="addStyleRow()">Add Style</button>
+        <br/>
+        <button type="submit" class="btn btn-primary">Save Policy</button>
+    </form>
+</div>
+<script>
+function addStyleRow(){
+    const container = document.getElementById('stylesContainer');
+    const index = container.children.length / 2;
+    const div = document.createElement('div');
+    div.className = 'row g-2 mb-2';
+    div.innerHTML = `<div class="col"><input type="text" class="form-control" name="styleNames[${index}]" placeholder="Style Name"></div>` +
+                    `<div class="col"><input type="text" class="form-control" name="styleClasses[${index}]" placeholder="CSS Classes"></div>`;
+    container.appendChild(div);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- list templates as clickable items
- show allowed components for a template in a modal
- allow creating policies for a component

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_688cafddcb648330bfa942104ddfb482