### PR TITLE
Add template policy management UI

### DIFF
--- a/src/main/content/policies/.content.xml
+++ b/src/main/content/policies/.content.xml
@@ -1,0 +1,7 @@
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" jcr:primaryType="sling:Folder">
+    <example xmlns:cq="http://www.day.com/jcr/cq/1.0" jcr:primaryType="sling:Folder">
+        <components jcr:primaryType="sling:Folder">
+            <text jcr:primaryType="cq:Policy" cq:policyTitle="Default Text Policy"/>
+        </components>
+    </example>
+</jcr:root>

--- a/src/main/content/templates/.content.xml
+++ b/src/main/content/templates/.content.xml
@@ -1,0 +1,3 @@
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" jcr:primaryType="sling:Folder">
+    <example-template jcr:primaryType="cq:Template"/>
+</jcr:root>

--- a/src/main/content/templates/example-template/policies/.content.xml
+++ b/src/main/content/templates/example-template/policies/.content.xml
@@ -1,0 +1,3 @@
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" jcr:primaryType="sling:Folder">
+    <text jcr:primaryType="sling:Mapping" sling:resourceType="example/components/text" cq:policy="policies/example/components/text"/>
+</jcr:root>

--- a/src/main/java/com/aem/builder/controller/PolicyApiController.java
+++ b/src/main/java/com/aem/builder/controller/PolicyApiController.java
@@ -1,0 +1,53 @@
+package com.aem.builder.controller;
+
+import com.aem.builder.model.*;
+import com.aem.builder.service.PolicyService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/templates")
+public class PolicyApiController {
+    private final PolicyService policyService;
+
+    public PolicyApiController(PolicyService policyService) {
+        this.policyService = policyService;
+    }
+
+    @GetMapping
+    public List<Template> listTemplates() {
+        return policyService.getTemplates();
+    }
+
+    @GetMapping("/{templateId}/components")
+    public List<Component> listComponents(@PathVariable String templateId) {
+        return policyService.getComponents(templateId);
+    }
+
+    @GetMapping("/{templateId}/components/{componentId}/policies")
+    public List<Policy> listPolicies(@PathVariable String templateId, @PathVariable String componentId) {
+        return policyService.getPolicies(templateId, componentId);
+    }
+
+    @GetMapping("/{templateId}/components/{componentId}/policies/{policyId}")
+    public ResponseEntity<Policy> getPolicy(@PathVariable String templateId, @PathVariable String componentId, @PathVariable String policyId) {
+        Policy policy = policyService.getPolicy(templateId, componentId, policyId);
+        if (policy == null) return ResponseEntity.notFound().build();
+        return ResponseEntity.ok(policy);
+    }
+
+    @PostMapping("/{templateId}/components/{componentId}/policies")
+    public Policy createPolicy(@PathVariable String templateId, @PathVariable String componentId, @RequestBody Policy policy) {
+        return policyService.savePolicy(templateId, componentId, policy);
+    }
+
+    @PutMapping("/{templateId}/components/{componentId}/policies/{policyId}")
+    public ResponseEntity<Policy> updatePolicy(@PathVariable String templateId, @PathVariable String componentId, @PathVariable String policyId, @RequestBody Policy policy) {
+        policy.setId(policyId);
+        Policy saved = policyService.savePolicy(templateId, componentId, policy);
+        if (saved == null) return ResponseEntity.notFound().build();
+        return ResponseEntity.ok(saved);
+    }
+}

--- a/src/main/java/com/aem/builder/controller/ViewController.java
+++ b/src/main/java/com/aem/builder/controller/ViewController.java
@@ -1,0 +1,28 @@
+package com.aem.builder.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Controller
+public class ViewController {
+
+    @GetMapping("/deploy")
+    public String deploy() {
+        return "deploy";
+    }
+
+    @GetMapping("/template/{templateId}/components")
+    public String components(@PathVariable String templateId, Model model) {
+        model.addAttribute("templateId", templateId);
+        return "components";
+    }
+
+    @GetMapping("/template/{templateId}/component/{componentId}/policy")
+    public String policy(@PathVariable String templateId, @PathVariable String componentId, Model model) {
+        model.addAttribute("templateId", templateId);
+        model.addAttribute("componentId", componentId);
+        return "policy";
+    }
+}

--- a/src/main/java/com/aem/builder/model/Component.java
+++ b/src/main/java/com/aem/builder/model/Component.java
@@ -1,0 +1,16 @@
+package com.aem.builder.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Component {
+    private String id;
+    private String name;
+    private List<Policy> policies;
+}

--- a/src/main/java/com/aem/builder/model/Policy.java
+++ b/src/main/java/com/aem/builder/model/Policy.java
@@ -1,0 +1,19 @@
+package com.aem.builder.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Policy {
+    private String id;
+    private String name;
+    private String title;
+    private String defaultClass;
+    private List<StyleGroup> groups = new ArrayList<>();
+}

--- a/src/main/java/com/aem/builder/model/Style.java
+++ b/src/main/java/com/aem/builder/model/Style.java
@@ -1,0 +1,13 @@
+package com.aem.builder.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Style {
+    private String name;
+    private String className;
+}

--- a/src/main/java/com/aem/builder/model/StyleGroup.java
+++ b/src/main/java/com/aem/builder/model/StyleGroup.java
@@ -1,0 +1,16 @@
+package com.aem.builder.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class StyleGroup {
+    private String name;
+    private List<Style> styles = new ArrayList<>();
+}

--- a/src/main/java/com/aem/builder/model/Template.java
+++ b/src/main/java/com/aem/builder/model/Template.java
@@ -1,0 +1,16 @@
+package com.aem.builder.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Template {
+    private String id;
+    private String name;
+    private List<Component> components;
+}

--- a/src/main/java/com/aem/builder/service/PolicyService.java
+++ b/src/main/java/com/aem/builder/service/PolicyService.java
@@ -1,0 +1,62 @@
+package com.aem.builder.service;
+
+import com.aem.builder.model.*;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class PolicyService {
+    private final Map<String, Template> templates = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    public void init() {
+        Style defaultStyle = new Style("Default", "cmp-default");
+        StyleGroup group = new StyleGroup("Basic", new ArrayList<>(List.of(defaultStyle)));
+        Policy textPolicy = new Policy(UUID.randomUUID().toString(), "text-default", "Text Policy", "cmp-text", new ArrayList<>(List.of(group)));
+        Component textComponent = new Component("text", "Text", new ArrayList<>(List.of(textPolicy)));
+        Template template = new Template("template1", "Example Template", new ArrayList<>(List.of(textComponent)));
+        templates.put(template.getId(), template);
+    }
+
+    public List<Template> getTemplates() {
+        return new ArrayList<>(templates.values());
+    }
+
+    public Template getTemplate(String id) {
+        return templates.get(id);
+    }
+
+    public List<Component> getComponents(String templateId) {
+        Template template = getTemplate(templateId);
+        return template != null ? template.getComponents() : Collections.emptyList();
+    }
+
+    public Component getComponent(String templateId, String componentId) {
+        return getComponents(templateId).stream().filter(c -> c.getId().equals(componentId)).findFirst().orElse(null);
+    }
+
+    public List<Policy> getPolicies(String templateId, String componentId) {
+        Component component = getComponent(templateId, componentId);
+        return component != null ? component.getPolicies() : Collections.emptyList();
+    }
+
+    public Policy getPolicy(String templateId, String componentId, String policyId) {
+        return getPolicies(templateId, componentId).stream().filter(p -> p.getId().equals(policyId)).findFirst().orElse(null);
+    }
+
+    public Policy savePolicy(String templateId, String componentId, Policy policy) {
+        Component component = getComponent(templateId, componentId);
+        if (component == null) return null;
+        if (policy.getId() == null || policy.getId().isEmpty()) {
+            policy.setId(UUID.randomUUID().toString());
+            component.getPolicies().add(policy);
+        } else {
+            component.getPolicies().removeIf(p -> p.getId().equals(policy.getId()));
+            component.getPolicies().add(policy);
+        }
+        return policy;
+    }
+}

--- a/src/main/resources/templates/components.html
+++ b/src/main/resources/templates/components.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Templates</title>
+    <title>Components</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 2rem; }
         ul { list-style: none; padding: 0; }
@@ -12,18 +12,19 @@
     </style>
 </head>
 <body>
-<h1>Available Templates</h1>
-<ul id="templates"></ul>
-<script>
-    fetch('/api/templates')
+<h1>Components</h1>
+<ul id="components"></ul>
+<script th:inline="javascript">
+    const templateId = [[${templateId}]];
+    fetch(`/api/templates/${templateId}/components`)
         .then(r => r.json())
         .then(data => {
-            const list = document.getElementById('templates');
-            data.forEach(t => {
+            const list = document.getElementById('components');
+            data.forEach(c => {
                 const li = document.createElement('li');
                 const a = document.createElement('a');
-                a.href = `/template/${t.id}/components`;
-                a.innerText = t.name;
+                a.href = `/template/${templateId}/component/${c.id}/policy`;
+                a.innerText = c.name;
                 li.appendChild(a);
                 list.appendChild(li);
             });

--- a/src/main/resources/templates/policy.html
+++ b/src/main/resources/templates/policy.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Policy Editor</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2rem; }
+        .group { border: 1px solid #ccc; padding: 1rem; margin-bottom: 1rem; }
+        .styles { margin-left: 1rem; }
+        label { display: block; margin-top: .5rem; }
+        button { margin-top: .5rem; }
+    </style>
+</head>
+<body>
+<h1>Component Policy</h1>
+<label>Existing Policies
+    <select id="policySelect"></select>
+</label>
+<label>Policy Name <input id="policyName"></label>
+<label>Title <input id="policyTitle"></label>
+<label>Default Class <input id="defaultClass"></label>
+<div id="groups"></div>
+<button type="button" id="addGroup">Add Group</button>
+<br><br>
+<button type="button" id="savePolicy">Save Policy</button>
+<script th:inline="javascript">
+    const templateId = [[${templateId}]];
+    const componentId = [[${componentId}]];
+
+    function createStyleRow(style) {
+        const div = document.createElement('div');
+        div.className = 'style-row';
+        const name = document.createElement('input');
+        name.placeholder = 'Style name';
+        name.value = style?.name || '';
+        const className = document.createElement('input');
+        className.placeholder = 'Class name';
+        className.value = style?.className || '';
+        const remove = document.createElement('button');
+        remove.type = 'button';
+        remove.innerText = 'Remove Style';
+        remove.onclick = () => div.remove();
+        div.appendChild(name);
+        div.appendChild(className);
+        div.appendChild(remove);
+        return div;
+    }
+
+    function createGroup(group) {
+        const container = document.createElement('div');
+        container.className = 'group';
+        const nameLabel = document.createElement('label');
+        nameLabel.innerText = 'Group Name';
+        const name = document.createElement('input');
+        name.value = group?.name || '';
+        nameLabel.appendChild(name);
+        const stylesDiv = document.createElement('div');
+        stylesDiv.className = 'styles';
+        (group?.styles || []).forEach(s => stylesDiv.appendChild(createStyleRow(s)));
+        const addStyle = document.createElement('button');
+        addStyle.type = 'button';
+        addStyle.innerText = 'Add Style';
+        addStyle.onclick = () => stylesDiv.appendChild(createStyleRow());
+        const removeGroup = document.createElement('button');
+        removeGroup.type = 'button';
+        removeGroup.innerText = 'Remove Group';
+        removeGroup.onclick = () => container.remove();
+        container.appendChild(nameLabel);
+        container.appendChild(stylesDiv);
+        container.appendChild(addStyle);
+        container.appendChild(removeGroup);
+        return container;
+    }
+
+    const groupsDiv = document.getElementById('groups');
+    document.getElementById('addGroup').onclick = () => groupsDiv.appendChild(createGroup());
+
+    function loadPolicies() {
+        fetch(`/api/templates/${templateId}/components/${componentId}/policies`)
+            .then(r => r.json())
+            .then(policies => {
+                const select = document.getElementById('policySelect');
+                select.innerHTML = '<option value="">--New Policy--</option>';
+                policies.forEach(p => {
+                    const opt = document.createElement('option');
+                    opt.value = p.id;
+                    opt.innerText = p.name;
+                    select.appendChild(opt);
+                });
+                select.onchange = () => {
+                    const id = select.value;
+                    if (id) {
+                        fetch(`/api/templates/${templateId}/components/${componentId}/policies/${id}`)
+                            .then(r => r.json())
+                            .then(setForm);
+                    } else {
+                        setForm({});
+                    }
+                };
+            });
+    }
+
+    function setForm(policy) {
+        document.getElementById('policyName').value = policy.name || '';
+        document.getElementById('policyTitle').value = policy.title || '';
+        document.getElementById('defaultClass').value = policy.defaultClass || '';
+        groupsDiv.innerHTML = '';
+        (policy.groups || []).forEach(g => groupsDiv.appendChild(createGroup(g)));
+    }
+
+    document.getElementById('savePolicy').onclick = () => {
+        const select = document.getElementById('policySelect');
+        const policy = {
+            id: select.value || null,
+            name: document.getElementById('policyName').value,
+            title: document.getElementById('policyTitle').value,
+            defaultClass: document.getElementById('defaultClass').value,
+            groups: Array.from(groupsDiv.children).map(g => ({
+                name: g.querySelector('input').value,
+                styles: Array.from(g.querySelector('.styles').children).map(s => ({
+                    name: s.children[0].value,
+                    className: s.children[1].value
+                }))
+            }))
+        };
+        const method = policy.id ? 'PUT' : 'POST';
+        const url = `/api/templates/${templateId}/components/${componentId}/policies` + (policy.id ? `/${policy.id}` : '');
+        fetch(url, {
+            method,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(policy)
+        }).then(() => loadPolicies());
+    };
+
+    loadPolicies();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow navigation from Deploy page to components and policy editor
- manage component policies with groups and styles
- include sample AEM content policy definitions

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68902c2019648330b3f5bbaf16f1b055