### PR TITLE
feat: enable template policy editing

### DIFF
--- a/src/main/java/com/aem/builder/controller/TemplateController.java
+++ b/src/main/java/com/aem/builder/controller/TemplateController.java
@@ -1,6 +1,7 @@
   package com.aem.builder.controller;
 
 
+import com.aem.builder.model.PolicyModel;
 import com.aem.builder.model.TemplateModel;
 import com.aem.builder.service.ComponentService;
 import com.aem.builder.service.TemplateService;
@@ -132,6 +133,38 @@ public class TemplateController {
             model.addAttribute("error", "Template update failed: " + e.getMessage());
             return "createtemplate";
         }
+    }
+
+    @GetMapping("/{projectName}/templates/{templateName}")
+    public String showTemplateComponents(@PathVariable String projectName,
+                                         @PathVariable String templateName,
+                                         Model model) {
+        List<String> components = templateService.getAllowedComponents(projectName, templateName);
+        model.addAttribute("projectName", projectName);
+        model.addAttribute("templateName", templateName);
+        model.addAttribute("components", components);
+        return "template-components";
+    }
+
+    @GetMapping("/{projectName}/templates/{templateName}/{component}")
+    public String showComponentPolicy(@PathVariable String projectName,
+                                      @PathVariable String templateName,
+                                      @PathVariable String component,
+                                      Model model) {
+        model.addAttribute("projectName", projectName);
+        model.addAttribute("templateName", templateName);
+        model.addAttribute("component", component);
+        model.addAttribute("policy", new PolicyModel());
+        return "template-policy";
+    }
+
+    @PostMapping("/{projectName}/templates/{templateName}/{component}")
+    public String saveComponentPolicy(@PathVariable String projectName,
+                                      @PathVariable String templateName,
+                                      @PathVariable String component,
+                                      @ModelAttribute("policy") PolicyModel policyModel) {
+        templateService.savePolicy(projectName, templateName, component, policyModel);
+        return "redirect:/" + projectName + "/templates/" + templateName;
     }
 
 

--- a/src/main/java/com/aem/builder/model/PolicyModel.java
+++ b/src/main/java/com/aem/builder/model/PolicyModel.java
@@ -1,0 +1,30 @@
+package com.aem.builder.model;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Model representing policy configuration for a component within a template.
+ */
+@Data
+public class PolicyModel {
+    private String policyName;
+    private String title;
+    private String defaultClass;
+    private List<StyleGroup> groups = new ArrayList<>();
+
+    @Data
+    public static class StyleGroup {
+        private String name;
+        private List<Style> styles = new ArrayList<>();
+    }
+
+    @Data
+    public static class Style {
+        private String name;
+        private String className;
+    }
+}
+

--- a/src/main/java/com/aem/builder/service/TemplateService.java
+++ b/src/main/java/com/aem/builder/service/TemplateService.java
@@ -9,6 +9,8 @@ import javax.xml.transform.TransformerException;
 import java.io.IOException;
 import java.util.List;
 
+import com.aem.builder.model.PolicyModel;
+
 
 
 public interface TemplateService {
@@ -35,4 +37,12 @@ public interface TemplateService {
 
 
     public void updateTemplate(TemplateModel updatedModel, String projectName, String oldTemplateName) throws ParserConfigurationException, IOException, SAXException, TransformerException;
+
+    /**
+     * Returns a list of component names that are configured in the structure of the given template.
+     * This is used by the UI to show which components are available in the template's root layout container.
+     */
+    List<String> getAllowedComponents(String projectName, String templateName);
+
+    void savePolicy(String projectName, String templateName, String component, PolicyModel policy);
 }

--- a/src/main/resources/templates/deploy.html
+++ b/src/main/resources/templates/deploy.html
@@ -60,18 +60,20 @@
 
                     <a th:href="@{/{projectName}/createtemplate(projectName=${projectName})}" class="btn btn-sm btn-outline-primary">Create Template</a>
                 </div>
-                <div id="templatesList" class="row row-cols-1 row-cols-sm-2 g-2">
-                    <div class="col" th:each="template : ${templates}">
+                    <div id="templatesList" class="row row-cols-1 row-cols-sm-2 g-2">
+                        <div class="col" th:each="template : ${templates}">
                         <div class="border rounded p-2 bg-light text-center shadow-sm d-flex justify-content-between align-items-center">
-                            <span th:text="${template}"></span>
+                            <a th:text="${template}"
+                               th:href="@{/{projectName}/templates/{t}(projectName=${projectName},t=${template})}"
+                               class="flex-grow-1 text-decoration-none text-dark"></a>
 
                             <!-- Show Edit button only if template is NOT page-content or xf-web-variation -->
                             <a th:if="${template != 'page-content' and template != 'xf-web-variation'}"
                                th:href="@{/{projectName}/edittemplate(templateName=${template}, projectName=${projectName})}"
                                class="btn btn-sm btn-outline-secondary ms-2">Edit</a>
                         </div>
+                        </div>
                     </div>
-                </div>
 
             </div>
         </div>

--- a/src/main/resources/templates/template-components.html
+++ b/src/main/resources/templates/template-components.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Template Components</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container mt-4">
+    <h2 th:text="'Template: ' + ${templateName}"></h2>
+    <a th:href="@{'/' + ${projectName}}" class="btn btn-outline-secondary mb-3">&larr; Back</a>
+    <div class="list-group">
+        <a th:each="comp : ${components}"
+           th:text="${comp}"
+           th:href="@{'/' + ${projectName} + '/templates/' + ${templateName} + '/' + ${comp}}"
+           class="list-group-item list-group-item-action"></a>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/template-policy.html
+++ b/src/main/resources/templates/template-policy.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Component Policy</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container mt-4">
+    <h2 th:text="${component} + ' Policy'"></h2>
+    <a th:href="@{'/' + ${projectName} + '/templates/' + ${templateName}}" class="btn btn-outline-secondary mb-3">&larr; Back</a>
+    <form th:action="@{'/' + ${projectName} + '/templates/' + ${templateName} + '/' + ${component}}" method="post" th:object="${policy}">
+        <div class="mb-3">
+            <label class="form-label">Policy Name</label>
+            <input type="text" th:field="*{policyName}" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Title</label>
+            <input type="text" th:field="*{title}" class="form-control">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Default Class Name</label>
+            <input type="text" th:field="*{defaultClass}" class="form-control">
+        </div>
+        <div id="groups"></div>
+        <button type="button" class="btn btn-secondary" onclick="addGroup()">Add Group</button>
+        <div class="mt-3">
+            <button type="submit" class="btn btn-primary">Save</button>
+        </div>
+    </form>
+</div>
+<script>
+function addGroup(){
+    const container=document.getElementById('groups');
+    const idx=container.children.length;
+    const wrapper=document.createElement('div');
+    wrapper.className='border p-2 mb-2';
+    wrapper.innerHTML=`<input class='form-control mb-2' name='groups[${idx}].name' placeholder='Group name'>
+    <div class='styles'></div>
+    <button type='button' class='btn btn-sm btn-outline-secondary' onclick='addStyle(this,${idx})'>Add Style</button>`;
+    container.appendChild(wrapper);
+}
+function addStyle(btn, groupIdx){
+    const styles=btn.previousElementSibling;
+    const idx=styles.children.length;
+    const div=document.createElement('div');
+    div.className='input-group mb-2';
+    div.innerHTML=`<input class='form-control' name='groups[${groupIdx}].styles[${idx}].name' placeholder='Style name'>
+    <span class='input-group-text'>Class</span>
+    <input class='form-control' name='groups[${groupIdx}].styles[${idx}].className' placeholder='Class name'>`;
+    styles.appendChild(div);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- make templates on deploy page clickable and show components within each template
- add UI and backend to configure simple component policies with style groups
- persist policies to template and project policy `.content.xml` files

## Testing
- `./mvnw -q test` *(fails: Failed to fetch maven distribution)*

------
https://chatgpt.com/codex/tasks/task_b_68902ef23a0c8330b5fe49cd3816c332