### PR TITLE
feat: add policy editor

### DIFF
--- a/src/main/java/com/aem/builder/controller/PolicyController.java
+++ b/src/main/java/com/aem/builder/controller/PolicyController.java
@@ -1,0 +1,18 @@
+package com.aem.builder.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Controller
+@RequiredArgsConstructor
+public class PolicyController {
+
+    @GetMapping("/{projectName}/policies")
+    public String policyEditor(@PathVariable String projectName, Model model) {
+        model.addAttribute("projectName", projectName);
+        return "policy-editor";
+    }
+}

--- a/src/main/java/com/aem/builder/controller/PolicyRestController.java
+++ b/src/main/java/com/aem/builder/controller/PolicyRestController.java
@@ -1,0 +1,48 @@
+package com.aem.builder.controller;
+
+import com.aem.builder.model.PolicyModel;
+import com.aem.builder.service.ComponentService;
+import com.aem.builder.service.PolicyService;
+import com.aem.builder.service.TemplateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/{projectName}/policy")
+public class PolicyRestController {
+
+    private final TemplateService templateService;
+    private final ComponentService componentService;
+    private final PolicyService policyService;
+
+    @GetMapping("/templates")
+    public List<String> listTemplates(@PathVariable String projectName) {
+        return templateService.getTemplateNamesFromDestination(projectName);
+    }
+
+    @GetMapping("/{template}/components")
+    public List<String> listComponents(@PathVariable String projectName, @PathVariable String template) throws IOException {
+        return componentService.getAllComponents();
+    }
+
+    @GetMapping("/{template}/{component}")
+    public PolicyModel getPolicy(@PathVariable String projectName,
+                                 @PathVariable String template,
+                                 @PathVariable String component) {
+        return policyService.getPolicy(projectName, template, component);
+    }
+
+    @PostMapping("/{template}/{component}")
+    public ResponseEntity<String> savePolicy(@PathVariable String projectName,
+                                             @PathVariable String template,
+                                             @PathVariable String component,
+                                             @RequestBody PolicyModel policy) {
+        policyService.savePolicy(projectName, template, component, policy);
+        return ResponseEntity.ok("Policy saved");
+    }
+}

--- a/src/main/java/com/aem/builder/model/PolicyModel.java
+++ b/src/main/java/com/aem/builder/model/PolicyModel.java
@@ -1,0 +1,19 @@
+package com.aem.builder.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PolicyModel {
+    private String name;
+    private String title;
+    private String description;
+    private String defaultCssClass;
+    private List<StyleGroupModel> styleGroups = new ArrayList<>();
+}

--- a/src/main/java/com/aem/builder/model/StyleGroupModel.java
+++ b/src/main/java/com/aem/builder/model/StyleGroupModel.java
@@ -1,0 +1,17 @@
+package com.aem.builder.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class StyleGroupModel {
+    private String name;
+    private boolean combine;
+    private List<StyleModel> styles = new ArrayList<>();
+}

--- a/src/main/java/com/aem/builder/model/StyleModel.java
+++ b/src/main/java/com/aem/builder/model/StyleModel.java
@@ -1,0 +1,13 @@
+package com.aem.builder.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class StyleModel {
+    private String name;
+    private String cssClass;
+}

--- a/src/main/java/com/aem/builder/service/PolicyService.java
+++ b/src/main/java/com/aem/builder/service/PolicyService.java
@@ -1,0 +1,8 @@
+package com.aem.builder.service;
+
+import com.aem.builder.model.PolicyModel;
+
+public interface PolicyService {
+    PolicyModel getPolicy(String project, String template, String component);
+    void savePolicy(String project, String template, String component, PolicyModel policy);
+}

--- a/src/main/java/com/aem/builder/service/impl/PolicyServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/PolicyServiceImpl.java
@@ -1,0 +1,114 @@
+package com.aem.builder.service.impl;
+
+import com.aem.builder.model.PolicyModel;
+import com.aem.builder.model.StyleGroupModel;
+import com.aem.builder.model.StyleModel;
+import com.aem.builder.service.PolicyService;
+import org.springframework.stereotype.Service;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+@Service
+public class PolicyServiceImpl implements PolicyService {
+
+    @Override
+    public PolicyModel getPolicy(String project, String template, String component) {
+        Path file = getPolicyFile(project, template, component);
+        if (Files.notExists(file)) {
+            return new PolicyModel();
+        }
+        try {
+            Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file.toFile());
+            Element root = doc.getDocumentElement();
+            PolicyModel policy = new PolicyModel();
+            policy.setName(root.getAttribute("name"));
+            policy.setTitle(root.getAttribute("title"));
+            policy.setDescription(root.getAttribute("description"));
+            policy.setDefaultCssClass(root.getAttribute("defaultCssClass"));
+            NodeList groupNodes = root.getElementsByTagName("styleGroup");
+            for (int i = 0; i < groupNodes.getLength(); i++) {
+                Element gEl = (Element) groupNodes.item(i);
+                StyleGroupModel group = new StyleGroupModel();
+                group.setName(gEl.getAttribute("name"));
+                group.setCombine(Boolean.parseBoolean(gEl.getAttribute("combine")));
+                NodeList styleNodes = gEl.getElementsByTagName("style");
+                ArrayList<StyleModel> styles = new ArrayList<>();
+                for (int j = 0; j < styleNodes.getLength(); j++) {
+                    Element sEl = (Element) styleNodes.item(j);
+                    styles.add(new StyleModel(sEl.getAttribute("name"), sEl.getAttribute("cssClass")));
+                }
+                group.setStyles(styles);
+                policy.getStyleGroups().add(group);
+            }
+            return policy;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read policy", e);
+        }
+    }
+
+    @Override
+    public void savePolicy(String project, String template, String component, PolicyModel policy) {
+        Path file = getPolicyFile(project, template, component);
+        try {
+            Files.createDirectories(file.getParent());
+            String xml = policyToXml(policy);
+            Files.writeString(file, xml, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to save policy", e);
+        }
+    }
+
+    private Path getPolicyFile(String project, String template, String component) {
+        return Paths.get("src/main/resources/conf", project, "settings", "wcm", "policies", template, "policies", component, ".content.xml");
+    }
+
+    private String policyToXml(PolicyModel policy) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        sb.append("<policy");
+        appendAttr(sb, "name", policy.getName());
+        appendAttr(sb, "title", policy.getTitle());
+        appendAttr(sb, "description", policy.getDescription());
+        appendAttr(sb, "defaultCssClass", policy.getDefaultCssClass());
+        sb.append(">\n");
+        if (policy.getStyleGroups() != null) {
+            for (StyleGroupModel group : policy.getStyleGroups()) {
+                sb.append("  <styleGroup");
+                appendAttr(sb, "name", group.getName());
+                appendAttr(sb, "combine", String.valueOf(group.isCombine()));
+                sb.append(">\n");
+                if (group.getStyles() != null) {
+                    for (StyleModel style : group.getStyles()) {
+                        sb.append("    <style");
+                        appendAttr(sb, "name", style.getName());
+                        appendAttr(sb, "cssClass", style.getCssClass());
+                        sb.append("/>\n");
+                    }
+                }
+                sb.append("  </styleGroup>\n");
+            }
+        }
+        sb.append("</policy>\n");
+        return sb.toString();
+    }
+
+    private void appendAttr(StringBuilder sb, String name, String value) {
+        if (value != null && !value.isEmpty()) {
+            sb.append(' ').append(name).append("=\"").append(escape(value)).append('\"');
+        }
+    }
+
+    private String escape(String value) {
+        return value.replace("&", "&amp;").replace("\"", "&quot;").replace("<", "&lt;").replace(">", "&gt;");
+    }
+}

--- a/src/main/resources/static/js/policy-editor.js
+++ b/src/main/resources/static/js/policy-editor.js
@@ -1,0 +1,137 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const project = document.getElementById('projectName').value;
+    const templateSelect = document.getElementById('templateSelect');
+    const componentSelect = document.getElementById('componentSelect');
+    const styleGroupsDiv = document.getElementById('styleGroups');
+    const addGroupBtn = document.getElementById('addGroupBtn');
+    const saveBtn = document.getElementById('savePolicy');
+
+    function loadTemplates() {
+        fetch(`/api/${project}/policy/templates`)
+            .then(r => r.json())
+            .then(templates => {
+                templateSelect.innerHTML = '<option value="" disabled selected>Select template</option>';
+                templates.forEach(t => {
+                    const opt = document.createElement('option');
+                    opt.value = t;
+                    opt.textContent = t;
+                    templateSelect.appendChild(opt);
+                });
+            });
+    }
+
+    templateSelect.addEventListener('change', () => {
+        const template = templateSelect.value;
+        fetch(`/api/${project}/policy/${template}/components`)
+            .then(r => r.json())
+            .then(components => {
+                componentSelect.innerHTML = '<option value="" disabled selected>Select component</option>';
+                components.forEach(c => {
+                    const opt = document.createElement('option');
+                    opt.value = c;
+                    opt.textContent = c;
+                    componentSelect.appendChild(opt);
+                });
+            });
+    });
+
+    componentSelect.addEventListener('change', () => {
+        const template = templateSelect.value;
+        const component = componentSelect.value;
+        fetch(`/api/${project}/policy/${template}/${component}`)
+            .then(r => r.json())
+            .then(data => {
+                document.getElementById('policyName').value = data.name || '';
+                document.getElementById('policyTitle').value = data.title || '';
+                document.getElementById('policyDescription').value = data.description || '';
+                document.getElementById('defaultCss').value = data.defaultCssClass || '';
+                styleGroupsDiv.innerHTML = '';
+                if (data.styleGroups) {
+                    data.styleGroups.forEach(g => addStyleGroup(g));
+                }
+            });
+    });
+
+    addGroupBtn.addEventListener('click', () => addStyleGroup());
+
+    function addStyleGroup(data) {
+        const groupDiv = document.createElement('div');
+        groupDiv.className = 'card p-3 mb-2 style-group';
+        groupDiv.innerHTML = `
+            <div class="d-flex justify-content-between">
+                <div class="mb-2 flex-grow-1">
+                    <label class="form-label">Group Name</label>
+                    <input type="text" class="form-control group-name" value="${data ? data.name : ''}">
+                </div>
+                <div class="ms-3 form-check align-self-end">
+                    <input class="form-check-input group-combine" type="checkbox" ${data && data.combine ? 'checked' : ''}>
+                    <label class="form-check-label">Combine</label>
+                </div>
+                <button type="button" class="btn btn-sm btn-danger remove-group ms-2">X</button>
+            </div>
+            <div class="style-entries"></div>
+            <button type="button" class="btn btn-sm btn-secondary add-style">Add Style</button>
+        `;
+        groupDiv.querySelector('.remove-group').addEventListener('click', () => groupDiv.remove());
+        groupDiv.querySelector('.add-style').addEventListener('click', () => addStyleEntry(groupDiv));
+        styleGroupsDiv.appendChild(groupDiv);
+        if (data && data.styles) {
+            data.styles.forEach(s => addStyleEntry(groupDiv, s));
+        }
+    }
+
+    function addStyleEntry(groupDiv, data) {
+        const container = groupDiv.querySelector('.style-entries');
+        const entryDiv = document.createElement('div');
+        entryDiv.className = 'd-flex mb-2 style-entry';
+        entryDiv.innerHTML = `
+            <input type="text" class="form-control me-2 style-name" placeholder="Style Name" value="${data ? data.name : ''}">
+            <input type="text" class="form-control me-2 style-class" placeholder="CSS Classes" value="${data ? data.cssClass : ''}">
+            <button type="button" class="btn btn-sm btn-danger remove-style">X</button>
+        `;
+        entryDiv.querySelector('.remove-style').addEventListener('click', () => entryDiv.remove());
+        container.appendChild(entryDiv);
+    }
+
+    function collectPolicy() {
+        const policy = {
+            name: document.getElementById('policyName').value,
+            title: document.getElementById('policyTitle').value,
+            description: document.getElementById('policyDescription').value,
+            defaultCssClass: document.getElementById('defaultCss').value,
+            styleGroups: []
+        };
+        styleGroupsDiv.querySelectorAll('.style-group').forEach(groupDiv => {
+            const group = {
+                name: groupDiv.querySelector('.group-name').value,
+                combine: groupDiv.querySelector('.group-combine').checked,
+                styles: []
+            };
+            groupDiv.querySelectorAll('.style-entry').forEach(entry => {
+                group.styles.push({
+                    name: entry.querySelector('.style-name').value,
+                    cssClass: entry.querySelector('.style-class').value
+                });
+            });
+            policy.styleGroups.push(group);
+        });
+        return policy;
+    }
+
+    saveBtn.addEventListener('click', () => {
+        const template = templateSelect.value;
+        const component = componentSelect.value;
+        if (!template || !component) {
+            alert('Select template and component');
+            return;
+        }
+        const policy = collectPolicy();
+        fetch(`/api/${project}/policy/${template}/${component}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(policy)
+        }).then(r => r.text()).then(msg => alert(msg));
+    });
+
+    loadTemplates();
+});

--- a/src/main/resources/templates/policy-editor.html
+++ b/src/main/resources/templates/policy-editor.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <script th:src="@{/js/policy-editor.js}"></script>
+    <title>Policy Editor</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="d-flex flex-column min-vh-100">
+<div th:replace="fragments/navbar :: navbar"></div>
+<main class="container py-4 flex-grow-1">
+    <h1 class="mb-4">Policy Editor</h1>
+    <input type="hidden" id="projectName" th:value="${projectName}"/>
+    <div class="row mb-3">
+        <div class="col-md-6">
+            <label class="form-label">Template</label>
+            <select id="templateSelect" class="form-select"></select>
+        </div>
+        <div class="col-md-6">
+            <label class="form-label">Component</label>
+            <select id="componentSelect" class="form-select"></select>
+        </div>
+    </div>
+    <form id="policyForm">
+        <div class="mb-3">
+            <label class="form-label">Policy Name</label>
+            <input type="text" id="policyName" class="form-control"/>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Title</label>
+            <input type="text" id="policyTitle" class="form-control"/>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Description</label>
+            <textarea id="policyDescription" class="form-control"></textarea>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Default CSS Class</label>
+            <input type="text" id="defaultCss" class="form-control"/>
+        </div>
+        <div id="styleGroups"></div>
+        <button type="button" id="addGroupBtn" class="btn btn-secondary mt-2">Add Style Group</button>
+        <button type="button" id="savePolicy" class="btn btn-primary mt-2">Save</button>
+    </form>
+</main>
+<footer class="mt-auto" th:replace="fragments/navbar :: footer"></footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add REST endpoints to manage template and component policies
- implement service to read and write policy XML definitions
- create UI and JavaScript for interactive policy editor

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.aem.builder:aembuilder:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_b_68903531eadc8330a91f04e148ee3119