### PR TITLE
Add component editing

### DIFF
--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -84,6 +84,7 @@ public class ComponentController {
 
         model.addAttribute("fieldTypes", sortedByKey);
         model.addAttribute("componentGroups", componentService.getComponentGroups(project));
+        model.addAttribute("editMode", false);
         // Components that can be extended (core components + existing ones)
         // Use a LinkedHashSet to avoid duplicates while preserving order
         Set<String> available = new LinkedHashSet<>();
@@ -104,6 +105,44 @@ public class ComponentController {
         return "create-component"; // Thymeleaf template
     }
 
+    @GetMapping("/{projectName}/editcomponent")
+    public String showEditComponentForm(@RequestParam String componentName,
+                                        @PathVariable String projectName,
+                                        Model model) {
+        ComponentRequest component = componentService.loadComponent(projectName, componentName);
+        model.addAttribute("projectName", projectName);
+
+        var typeResourceMap = FieldType.getTypeResourceMap();
+
+        var sortedByKey = typeResourceMap.entrySet()
+                .stream()
+                .sorted(Map.Entry.comparingByKey())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (v1, v2) -> v1, LinkedHashMap::new));
+
+        model.addAttribute("fieldTypes", sortedByKey);
+        model.addAttribute("componentGroups", componentService.getComponentGroups(projectName));
+        model.addAttribute("editMode", true);
+
+        // available components
+        Set<String> available = new LinkedHashSet<>();
+        try {
+            available.addAll(componentService.fetchComponentsFromGeneratedProjects(projectName).stream()
+                    .map(name -> "/apps/" + projectName + "/components/" + name)
+                    .toList());
+            available.addAll(componentService.getAllComponents());
+        } catch (IOException e) {
+            log.error("Error loading available components", e);
+        }
+        Map<String, String> compMap = new LinkedHashMap<>();
+        for (String path : available) {
+            int idx = path.lastIndexOf('/') + 1;
+            compMap.put(path, path.substring(idx));
+        }
+        model.addAttribute("availableComponents", compMap);
+        model.addAttribute("componentData", component);
+        return "create-component";
+    }
+
     @PostMapping("/component/create/{project}")
     public String createComponent(@PathVariable String project,
                                   @ModelAttribute ComponentRequest request,
@@ -116,6 +155,21 @@ public class ComponentController {
             log.error("Error creating component", e);
             redirectAttributes.addFlashAttribute("error", "Failed to create component: " + e.getMessage());
             return "redirect:/create/" + project;
+        }
+    }
+
+    @PostMapping("/component/update/{project}")
+    public String updateComponent(@PathVariable String project,
+                                  @ModelAttribute ComponentRequest request,
+                                  RedirectAttributes redirectAttributes) {
+        try {
+            componentService.updateComponent(project, request);
+            redirectAttributes.addFlashAttribute("message", "Component updated successfully!");
+            return "redirect:/" + project;
+        } catch (Exception e) {
+            log.error("Error updating component", e);
+            redirectAttributes.addFlashAttribute("error", "Failed to update component: " + e.getMessage());
+            return "redirect:/" + project + "/editcomponent?componentName=" + request.getComponentName();
         }
     }
 

--- a/src/main/java/com/aem/builder/controller/DeployController.java
+++ b/src/main/java/com/aem/builder/controller/DeployController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,10 +28,22 @@ public class DeployController {
     @GetMapping("/{projectName}")
     public String projectDetails(@PathVariable String projectName, Model model) {
         logger.info("DEPLOY: Fetching project details for project: {}", projectName);
-        List<String> components = componentService.fetchComponentsFromGeneratedProjects(projectName);
         List<String> templates = templateService.fetchTemplatesFromGeneratedProjects(projectName);
+        var compMap = componentService.fetchComponentsWithGroups(projectName);
+        List<String> components = new ArrayList<>(compMap.keySet());
+        List<String> editable = compMap.entrySet().stream()
+                .filter(e -> {
+                    String g = e.getValue();
+                    return g == null || (!g.equals(projectName + " - Content")
+                            && !g.equals(projectName + " - Structure")
+                            && !g.equals(".hidden"));
+                })
+                .map(java.util.Map.Entry::getKey)
+                .toList();
         model.addAttribute("components", components);
+        model.addAttribute("editableComponents", editable);
         model.addAttribute("templates", templates);
+        model.addAttribute("projectName", projectName);
         model.addAttribute("canDeploy", true);
         logger.debug("DEPLOY: Added attributes to model for project: {}", projectName);
         return "deploy";

--- a/src/main/java/com/aem/builder/service/ComponentService.java
+++ b/src/main/java/com/aem/builder/service/ComponentService.java
@@ -27,6 +27,12 @@ public interface ComponentService {
     List<String> getComponentGroups(String projectName);
     void generateComponent(String projectName, ComponentRequest request);
 
+    Map<String, String> fetchComponentsWithGroups(String projectName);
+
+    ComponentRequest loadComponent(String projectName, String componentName);
+
+    void updateComponent(String projectName, ComponentRequest request);
+
     //component checking
     boolean isComponentNameAvailable(String projectName, String componentName);
 

--- a/src/main/resources/static/js/create-component.js
+++ b/src/main/resources/static/js/create-component.js
@@ -266,4 +266,67 @@ document.addEventListener("DOMContentLoaded", function () {
   document.addEventListener('input', validateFormFields);
   document.addEventListener('change', validateFormFields);
   updateIndexes();
+
+  if (window.editMode) {
+    loadComponentData(window.componentData || {});
+  }
+
+  function loadComponentData(data) {
+    if (!data) return;
+    componentNameInput.value = data.componentName || '';
+    componentNameInput.readOnly = true;
+    document.getElementById('componentGroup').value = data.componentGroup || '';
+    if (data.superType) {
+      modeSelect.value = 'extend';
+      toggleSuperType();
+      document.getElementById('superType').value = data.superType;
+    } else {
+      modeSelect.value = 'new';
+      toggleSuperType();
+    }
+    const container = document.getElementById('fieldsContainer');
+    container.innerHTML = '';
+    if (data.fields) {
+      data.fields.forEach(f => {
+        const row = createBaseRow(false);
+        row.querySelector('.action-col').innerHTML = '<button type="button" class="btn btn-danger" onclick="removeFieldRow(this)">-</button>';
+        container.appendChild(row);
+        populateFieldRow(row, f);
+      });
+    }
+    updateIndexes();
+    validateFormFields();
+  }
+
+  function populateFieldRow(row, field, level = 0) {
+    row.querySelector('.fieldLabel').value = field.fieldLabel || '';
+    row.querySelector('.fieldName').value = field.fieldName || '';
+    row.querySelector('.fieldType').value = field.fieldType || '';
+    handleFieldTypeChange(row.querySelector('.fieldType'));
+
+    if (field.options && field.options.length > 0) {
+      const container = row.querySelector('.options-container');
+      const addBtn = container.querySelector('button');
+      container.innerHTML = '';
+      field.options.forEach(opt => {
+        const div = document.createElement('div');
+        div.className = 'option-row input-group mb-2';
+        div.innerHTML = `<input type="text" class="form-control optionText" placeholder="Text" value="${opt.text}" required>` +
+          `<input type="text" class="form-control optionValue" placeholder="Value" value="${opt.value}" required>` +
+          `<button type="button" class="btn btn-danger" onclick="removeOptionRow(this)">-</button>`;
+        container.appendChild(div);
+      });
+      container.appendChild(addBtn);
+    }
+
+    if (field.fieldType === 'multifield' && field.nestedFields) {
+      const container = row.querySelector('.nested-container');
+      const addBtn = container.querySelector('button');
+      field.nestedFields.forEach(nf => {
+        const nrow = createBaseRow(true, level + 1);
+        container.insertBefore(nrow, addBtn);
+        populateFieldRow(nrow, nf, level + 1);
+      });
+    }
+  }
 });

--- a/src/main/resources/templates/create-component.html
+++ b/src/main/resources/templates/create-component.html
@@ -41,9 +41,12 @@
     <!-- Component Group -->
     <div class="mb-3">
       <label class="form-label">Component Group</label>
-      <select class="form-select" name="componentGroup" id="componentGroup" th:value="${componentData?.componentGroup}" required>
+      <select class="form-select" name="componentGroup" id="componentGroup" required>
         <option value="">-- Select Component Group --</option>
-        <option th:each="group : ${componentGroups}" th:value="${group}" th:text="${group}"></option>
+        <option th:each="group : ${componentGroups}"
+                th:value="${group}"
+                th:text="${group}"
+                th:selected="${group == componentData?.componentGroup}"></option>
       </select>
     </div>
 
@@ -102,8 +105,8 @@
   <div th:replace="fragments/navbar :: footer"></div>
 </footer>
 <script th:inline="javascript">
-  const editMode = [[${editMode}]];
-  const componentData = /*[[${componentData}]]*/ null;
+  window.editMode = [[${editMode}]];
+  window.componentData = /*[[${componentData}]]*/ {};
 </script>
 </body>
 </html>

--- a/src/main/resources/templates/create-component.html
+++ b/src/main/resources/templates/create-component.html
@@ -14,7 +14,7 @@
 <div th:replace="fragments/navbar :: navbar"></div>
 
 <div class="container mt-4 mb-5">
-  <h2 class="mb-4 animate__animated animate__fadeInDown">Create AEM Component for [[${projectName}]]</h2>
+  <h2 class="mb-4 animate__animated animate__fadeInDown" th:text="${editMode} ? 'Edit AEM Component for ' + ${projectName} : 'Create AEM Component for ' + ${projectName}"></h2>
 
   <a th:href="@{'/' + ${projectName}}" class="btn btn-outline-secondary mb-3">← Back to DeployPage</a>
 
@@ -27,21 +27,21 @@
     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
   </div>
 
-  <form id="componentForm" th:action="@{'/component/create/' + ${projectName}}" method="post">
+  <form id="componentForm" th:action="${editMode} ? @{'/component/update/' + ${projectName}} : @{'/component/create/' + ${projectName}}" method="post">
     <!-- Hidden input to pass projectName into JS -->
     <input type="hidden" id="projectName" th:value="${projectName}">
 
     <!-- Component Name -->
     <div class="mb-3">
       <label class="form-label">Component Name</label>
-      <input type="text" class="form-control" name="componentName" id="componentName" required>
+      <input type="text" class="form-control" name="componentName" id="componentName" th:value="${componentData?.componentName}" th:readonly="${editMode}" required>
       <div id="nameError" class="mt-1" style="font-size: 0.9rem;"></div>
     </div>
 
     <!-- Component Group -->
     <div class="mb-3">
       <label class="form-label">Component Group</label>
-      <select class="form-select" name="componentGroup" id="componentGroup" required>
+      <select class="form-select" name="componentGroup" id="componentGroup" th:value="${componentData?.componentGroup}" required>
         <option value="">-- Select Component Group --</option>
         <option th:each="group : ${componentGroups}" th:value="${group}" th:text="${group}"></option>
       </select>
@@ -59,7 +59,7 @@
     <!-- Extends Component -->
     <div class="mb-3" id="extendsComponentDiv" style="display:none">
       <label class="form-label">Extends Component</label>
-      <select class="form-select" name="superType" id="superType">
+      <select class="form-select" name="superType" id="superType" th:value="${componentData?.superType}">
         <option value="">-- Select Component --</option>
         <option th:each="entry : ${availableComponents.entrySet()}" th:value="${entry.key}" th:text="${entry.value}"></option>
       </select>
@@ -93,7 +93,7 @@
     <button type="button" class="btn btn-primary mb-3" onclick="addFieldRow()">+ Add Field</button><br>
 
     <!-- Create Component Button -->
-    <button type="submit" class="btn btn-primary" id="createButton" disabled>Create Component</button>
+    <button type="submit" class="btn btn-primary" id="createButton" th:text="${editMode} ? 'Update Component' : 'Create Component'" disabled>Create Component</button>
   </form>
 </div>
 
@@ -101,7 +101,9 @@
 <footer>
   <div th:replace="fragments/navbar :: footer"></div>
 </footer>
-
-
+<script th:inline="javascript">
+  const editMode = [[${editMode}]];
+  const componentData = /*[[${componentData}]]*/ null;
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/deploy.html
+++ b/src/main/resources/templates/deploy.html
@@ -45,7 +45,12 @@
                 </div>
                 <div id="componentsList" class="row row-cols-1 row-cols-sm-2 g-2">
                     <div class="col" th:each="component : ${components}">
-                        <div class="border rounded p-2 bg-light text-center shadow-sm" th:text="${component}"></div>
+                        <div class="border rounded p-2 bg-light text-center shadow-sm d-flex justify-content-between align-items-center">
+                            <span th:text="${component}"></span>
+                            <a th:if="${#lists.contains(editableComponents, component)}"
+                               th:href="@{/{projectName}/editcomponent(componentName=${component}, projectName=${projectName})}"
+                               class="btn btn-sm btn-outline-secondary ms-2">Edit</a>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- support loading component groups excluding default groups and editing component files
- add edit endpoints and form to modify existing components
- show Edit buttons for non-default components in deploy page and populate fields for editing

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_689039f024148330bc1d5b3a5ea79a74