### PR TITLE
feat: add template component policy editor

### DIFF
--- a/src/main/java/com/aem/builder/controller/PolicyController.java
+++ b/src/main/java/com/aem/builder/controller/PolicyController.java
@@ -1,0 +1,53 @@
+package com.aem.builder.controller;
+
+import com.aem.builder.model.policy.PolicyModel;
+import com.aem.builder.service.PolicyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * Controller exposing endpoints to inspect allowed components for a template
+ * and to create/update component policies. The UI mimics AEM's template and
+ * policy editors but operates on the generated project structure.
+ */
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/{projectName}/templates/{templateName}")
+public class PolicyController {
+
+    private final PolicyService policyService;
+
+    @GetMapping("/components")
+    public String listAllowedComponents(@PathVariable String projectName,
+                                        @PathVariable String templateName,
+                                        Model model) {
+        List<String> components = policyService.getAllowedComponents(projectName, templateName);
+        model.addAttribute("projectName", projectName);
+        model.addAttribute("templateName", templateName);
+        model.addAttribute("components", components);
+        return "template-components";
+    }
+
+    @GetMapping("/policies/{component}")
+    @ResponseBody
+    public PolicyModel loadPolicy(@PathVariable String projectName,
+                                  @PathVariable String templateName,
+                                  @PathVariable("component") String componentName) {
+        return policyService.loadPolicy(projectName, templateName, componentName);
+    }
+
+    @PostMapping("/policies/{component}")
+    @ResponseBody
+    public ResponseEntity<String> savePolicy(@PathVariable String projectName,
+                                             @PathVariable String templateName,
+                                             @PathVariable("component") String componentName,
+                                             @RequestBody PolicyModel model) {
+        policyService.savePolicy(projectName, templateName, componentName, model);
+        return ResponseEntity.ok("saved");
+    }
+}

--- a/src/main/java/com/aem/builder/model/policy/PolicyModel.java
+++ b/src/main/java/com/aem/builder/model/policy/PolicyModel.java
@@ -1,0 +1,20 @@
+package com.aem.builder.model.policy;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a simplified AEM component policy. This model is intentionally
+ * lightweight and only captures the fields required by the UI. The structure
+ * roughly mirrors the policy editor in AEM allowing a default CSS class and
+ * multiple style groups with styles.
+ */
+@Data
+public class PolicyModel {
+    private String title;
+    private String description;
+    private String defaultCssClass;
+    private List<StyleGroup> styleGroups = new ArrayList<>();
+}

--- a/src/main/java/com/aem/builder/model/policy/StyleGroup.java
+++ b/src/main/java/com/aem/builder/model/policy/StyleGroup.java
@@ -1,0 +1,17 @@
+package com.aem.builder.model.policy;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A group of styles in a policy. Groups may optionally allow style
+ * combination similar to the behaviour in AEM's policy editor.
+ */
+@Data
+public class StyleGroup {
+    private String name;
+    private boolean allowCombination;
+    private List<StyleItem> styles = new ArrayList<>();
+}

--- a/src/main/java/com/aem/builder/model/policy/StyleItem.java
+++ b/src/main/java/com/aem/builder/model/policy/StyleItem.java
@@ -1,0 +1,13 @@
+package com.aem.builder.model.policy;
+
+import lombok.Data;
+
+/**
+ * Represents a single style with a label and the CSS class that should be
+ * applied when selected.
+ */
+@Data
+public class StyleItem {
+    private String name;
+    private String cssClass;
+}

--- a/src/main/java/com/aem/builder/service/PolicyService.java
+++ b/src/main/java/com/aem/builder/service/PolicyService.java
@@ -1,0 +1,22 @@
+package com.aem.builder.service;
+
+import com.aem.builder.model.policy.PolicyModel;
+
+import java.util.List;
+
+public interface PolicyService {
+    /**
+     * Fetch allowed components for a template's root layout container.
+     */
+    List<String> getAllowedComponents(String projectName, String templateName);
+
+    /**
+     * Load an existing policy for the given component if available.
+     */
+    PolicyModel loadPolicy(String projectName, String templateName, String componentName);
+
+    /**
+     * Persist a policy for the given component.
+     */
+    void savePolicy(String projectName, String templateName, String componentName, PolicyModel policy);
+}

--- a/src/main/java/com/aem/builder/service/impl/PolicyServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/PolicyServiceImpl.java
@@ -1,0 +1,194 @@
+package com.aem.builder.service.impl;
+
+import com.aem.builder.model.policy.PolicyModel;
+import com.aem.builder.model.policy.StyleGroup;
+import com.aem.builder.model.policy.StyleItem;
+import com.aem.builder.service.ComponentService;
+import com.aem.builder.service.PolicyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Service responsible for reading and writing simplified AEM component
+ * policies. The implementation does not aim to cover every possible AEM
+ * scenario but provides enough functionality for the UI to create and edit
+ * policies within the generated project structure.
+ */
+@Service
+@RequiredArgsConstructor
+public class PolicyServiceImpl implements PolicyService {
+
+    private final ComponentService componentService;
+
+    private Path projectConfBase(String project) {
+        return Paths.get("generated-projects", project,
+                "ui.content/src/main/content/jcr_root/conf", project);
+    }
+
+    @Override
+    public List<String> getAllowedComponents(String projectName, String templateName) {
+        // For now simply return all components present in the project. A more
+        // elaborate implementation could inspect the template's structure to
+        // determine the allowed components for the layout container.
+        return componentService.fetchComponentsFromGeneratedProjects(projectName);
+    }
+
+    @Override
+    public PolicyModel loadPolicy(String projectName, String templateName, String componentName) {
+        Path policyFile = projectConfBase(projectName).resolve(
+                Paths.get("settings/wcm/policies", componentName + ".content.xml"));
+        if (!Files.exists(policyFile)) {
+            return new PolicyModel();
+        }
+        try {
+            DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            Document doc = builder.parse(policyFile.toFile());
+            Element root = doc.getDocumentElement();
+            PolicyModel model = new PolicyModel();
+            model.setTitle(root.getAttribute("jcr:title"));
+            model.setDescription(root.getAttribute("jcr:description"));
+            model.setDefaultCssClass(root.getAttribute("cq:styleDefaultClasses"));
+
+            NodeList groupsNode = root.getElementsByTagName("cq:styleGroups");
+            if (groupsNode.getLength() > 0) {
+                Node groups = groupsNode.item(0);
+                NodeList groupList = groups.getChildNodes();
+                for (int i = 0; i < groupList.getLength(); i++) {
+                    Node n = groupList.item(i);
+                    if (n.getNodeType() != Node.ELEMENT_NODE) continue;
+                    Element ge = (Element) n;
+                    StyleGroup sg = new StyleGroup();
+                    sg.setName(ge.getNodeName());
+                    sg.setAllowCombination("true".equals(ge.getAttribute("cq:styleCombine")));
+                    NodeList styleNodes = ge.getChildNodes();
+                    for (int j = 0; j < styleNodes.getLength(); j++) {
+                        Node sn = styleNodes.item(j);
+                        if (sn.getNodeType() != Node.ELEMENT_NODE) continue;
+                        Element se = (Element) sn;
+                        StyleItem si = new StyleItem();
+                        si.setName(se.getAttribute("cq:styleLabel"));
+                        si.setCssClass(se.getAttribute("cq:styleClass"));
+                        sg.getStyles().add(si);
+                    }
+                    model.getStyleGroups().add(sg);
+                }
+            }
+            return model;
+        } catch (Exception e) {
+            // In case of parsing errors return an empty model.
+            return new PolicyModel();
+        }
+    }
+
+    @Override
+    public void savePolicy(String projectName, String templateName, String componentName, PolicyModel policy) {
+        try {
+            Path confBase = projectConfBase(projectName);
+            Path policiesDir = confBase.resolve("settings/wcm/policies");
+            Files.createDirectories(policiesDir);
+            Path policyFile = policiesDir.resolve(componentName + ".content.xml");
+
+            // Build XML for policy definition
+            DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            Document doc = builder.newDocument();
+            Element root = doc.createElement("jcr:root");
+            root.setAttribute("xmlns:sling", "http://sling.apache.org/jcr/sling/1.0");
+            root.setAttribute("xmlns:cq", "http://www.day.com/jcr/cq/1.0");
+            root.setAttribute("xmlns:jcr", "http://www.jcp.org/jcr/1.0");
+            root.setAttribute("jcr:primaryType", "nt:unstructured");
+            if (policy.getTitle() != null) root.setAttribute("jcr:title", policy.getTitle());
+            if (policy.getDescription() != null) root.setAttribute("jcr:description", policy.getDescription());
+            if (policy.getDefaultCssClass() != null) root.setAttribute("cq:styleDefaultClasses", policy.getDefaultCssClass());
+            doc.appendChild(root);
+
+            if (!policy.getStyleGroups().isEmpty()) {
+                Element groups = doc.createElement("cq:styleGroups");
+                groups.setAttribute("jcr:primaryType", "nt:unstructured");
+                for (StyleGroup sg : policy.getStyleGroups()) {
+                    Element ge = doc.createElement(sg.getName());
+                    ge.setAttribute("jcr:primaryType", "nt:unstructured");
+                    if (sg.isAllowCombination()) {
+                        ge.setAttribute("cq:styleCombine", "true");
+                    }
+                    for (StyleItem si : sg.getStyles()) {
+                        Element se = doc.createElement(si.getName());
+                        se.setAttribute("jcr:primaryType", "nt:unstructured");
+                        se.setAttribute("cq:styleLabel", si.getName());
+                        se.setAttribute("cq:styleClass", si.getCssClass());
+                        ge.appendChild(se);
+                    }
+                    groups.appendChild(ge);
+                }
+                root.appendChild(groups);
+            }
+
+            Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            transformer.transform(new DOMSource(doc), new StreamResult(policyFile.toFile()));
+
+            // Now update template mapping file
+            Path templatePoliciesFile = confBase.resolve(
+                    Paths.get("settings/wcm/templates", templateName, "policies/.content.xml"));
+            Files.createDirectories(templatePoliciesFile.getParent());
+            Document mappingDoc;
+            Element mappingRoot;
+            if (Files.exists(templatePoliciesFile)) {
+                mappingDoc = builder.parse(templatePoliciesFile.toFile());
+                mappingRoot = mappingDoc.getDocumentElement();
+            } else {
+                mappingDoc = builder.newDocument();
+                mappingRoot = mappingDoc.createElement("jcr:root");
+                mappingRoot.setAttribute("xmlns:sling", "http://sling.apache.org/jcr/sling/1.0");
+                mappingRoot.setAttribute("xmlns:cq", "http://www.day.com/jcr/cq/1.0");
+                mappingRoot.setAttribute("xmlns:jcr", "http://www.jcp.org/jcr/1.0");
+                mappingRoot.setAttribute("xmlns:nt", "http://www.jcp.org/jcr/nt/1.0");
+                mappingRoot.setAttribute("jcr:primaryType", "cq:Page");
+                Element jcrContent = mappingDoc.createElement("jcr:content");
+                jcrContent.setAttribute("jcr:primaryType", "nt:unstructured");
+                jcrContent.setAttribute("sling:resourceType", "wcm/core/components/policies/mappings");
+                Element rootMap = mappingDoc.createElement("root");
+                rootMap.setAttribute("jcr:primaryType", "nt:unstructured");
+                rootMap.setAttribute("sling:resourceType", "wcm/core/components/policies/mapping");
+                jcrContent.appendChild(rootMap);
+                mappingRoot.appendChild(jcrContent);
+                mappingDoc.appendChild(mappingRoot);
+            }
+
+            // Add/replace component mapping
+            Element jcrContent = (Element) mappingRoot.getElementsByTagName("jcr:content").item(0);
+            Element rootMap = (Element) jcrContent.getElementsByTagName("root").item(0);
+            // remove existing node if present
+            NodeList existing = rootMap.getElementsByTagName(componentName);
+            for (int i = 0; i < existing.getLength(); i++) {
+                rootMap.removeChild(existing.item(i));
+            }
+            Element comp = mappingDoc.createElement(componentName);
+            comp.setAttribute("jcr:primaryType", "nt:unstructured");
+            comp.setAttribute("sling:resourceType", "wcm/core/components/policies/mapping");
+            comp.setAttribute("cq:policy", projectName + "/settings/wcm/policies/" + componentName);
+            rootMap.appendChild(comp);
+
+            transformer.transform(new DOMSource(mappingDoc), new StreamResult(templatePoliciesFile.toFile()));
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to save policy", e);
+        }
+    }
+}

--- a/src/main/resources/static/js/policy-editor.js
+++ b/src/main/resources/static/js/policy-editor.js
@@ -1,0 +1,110 @@
+let currentComponent = null;
+
+function openPolicyModal(card) {
+    currentComponent = card.getAttribute('data-component');
+    const modal = new bootstrap.Modal(document.getElementById('policyModal'));
+    loadPolicy();
+    modal.show();
+}
+
+function loadPolicy() {
+    const project = document.body.getAttribute('data-project');
+    const template = document.body.getAttribute('data-template');
+    fetch(`/${project}/templates/${template}/policies/${currentComponent}`)
+        .then(r => r.json())
+        .then(data => {
+            const form = document.getElementById('policyForm');
+            form.title.value = data.title || '';
+            form.description.value = data.description || '';
+            form.defaultCssClass.value = data.defaultCssClass || '';
+            const groupsContainer = document.getElementById('styleGroups');
+            groupsContainer.innerHTML = '';
+            (data.styleGroups || []).forEach(g => {
+                addStyleGroup(g);
+            });
+        });
+}
+
+function addStyleGroup(existing) {
+    const container = document.getElementById('styleGroups');
+    const idx = container.children.length;
+    const div = document.createElement('div');
+    div.className = 'border rounded p-2 mb-3';
+    div.innerHTML = `
+        <div class="mb-2">
+            <label class="form-label">Group Name</label>
+            <input type="text" class="form-control" name="groups[${idx}].name" required>
+        </div>
+        <div class="form-check mb-2">
+            <input class="form-check-input" type="checkbox" name="groups[${idx}].allowCombination" id="combine${idx}">
+            <label class="form-check-label" for="combine${idx}">Styles can be combined</label>
+        </div>
+        <div class="styles"></div>
+        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="addStyle(this)">Add Style</button>
+    `;
+    container.appendChild(div);
+
+    if (existing) {
+        div.querySelector(`input[name='groups[${idx}].name']`).value = existing.name || '';
+        div.querySelector(`#combine${idx}`).checked = existing.allowCombination || false;
+        (existing.styles || []).forEach(s => addStyle(div.querySelector('.styles'), s));
+    }
+}
+
+function addStyle(btnOrContainer, existing) {
+    const container = btnOrContainer.classList ? btnOrContainer : btnOrContainer.previousElementSibling;
+    const idx = container.children.length;
+    const div = document.createElement('div');
+    div.className = 'mb-2';
+    div.innerHTML = `
+        <div class="input-group">
+          <input type="text" class="form-control" placeholder="Style Name" name="styleName">
+          <input type="text" class="form-control" placeholder="CSS Class" name="styleClass">
+          <button class="btn btn-outline-danger" type="button" onclick="this.parentNode.parentNode.remove()">×</button>
+        </div>`;
+    container.appendChild(div);
+    if (existing) {
+        div.querySelector("input[name='styleName']").value = existing.name || '';
+        div.querySelector("input[name='styleClass']").value = existing.cssClass || '';
+    }
+}
+
+function savePolicy() {
+    const project = document.body.getAttribute('data-project');
+    const template = document.body.getAttribute('data-template');
+    const form = document.getElementById('policyForm');
+    const policy = {
+        title: form.title.value,
+        description: form.description.value,
+        defaultCssClass: form.defaultCssClass.value,
+        styleGroups: []
+    };
+    document.querySelectorAll('#styleGroups > div').forEach(groupDiv => {
+        const g = {
+            name: groupDiv.querySelector('input[name^="groups"]').value,
+            allowCombination: groupDiv.querySelector('input[type=checkbox]').checked,
+            styles: []
+        };
+        groupDiv.querySelectorAll('.styles > div').forEach(styleDiv => {
+            g.styles.push({
+                name: styleDiv.querySelector("input[name='styleName']").value,
+                cssClass: styleDiv.querySelector("input[name='styleClass']").value
+            });
+        });
+        policy.styleGroups.push(g);
+    });
+    fetch(`/${project}/templates/${template}/policies/${currentComponent}`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(policy)
+    }).then(() => {
+        const modal = bootstrap.Modal.getInstance(document.getElementById('policyModal'));
+        modal.hide();
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const body = document.body;
+    body.setAttribute('data-project', body.getAttribute('data-project') || document.getElementById('projectName')?.value);
+    body.setAttribute('data-template', body.getAttribute('data-template') || document.getElementById('templateName')?.value);
+});

--- a/src/main/resources/templates/deploy.html
+++ b/src/main/resources/templates/deploy.html
@@ -63,7 +63,7 @@
                 <div id="templatesList" class="row row-cols-1 row-cols-sm-2 g-2">
                     <div class="col" th:each="template : ${templates}">
                         <div class="border rounded p-2 bg-light text-center shadow-sm d-flex justify-content-between align-items-center">
-                            <span th:text="${template}"></span>
+                            <a th:href="@{/{projectName}/templates/{template}/components(projectName=${projectName},template=${template})}" th:text="${template}" class="flex-grow-1 text-decoration-none"></a>
 
                             <!-- Show Edit button only if template is NOT page-content or xf-web-variation -->
                             <a th:if="${template != 'page-content' and template != 'xf-web-variation'}"

--- a/src/main/resources/templates/template-components.html
+++ b/src/main/resources/templates/template-components.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Template Components</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script th:src="@{/js/policy-editor.js}"></script>
+</head>
+<body class="d-flex flex-column min-vh-100" th:attr="data-project=${projectName},data-template=${templateName}">
+<div th:replace="fragments/navbar :: navbar"></div>
+<main class="container mt-4 flex-grow-1">
+    <h2 th:text="'Template: ' + ${templateName}"></h2>
+    <a th:href="@{'/' + ${projectName}}" class="btn btn-outline-secondary mb-3">← Back</a>
+
+    <div class="row row-cols-1 row-cols-sm-2 g-3">
+        <div class="col" th:each="cmp : ${components}">
+            <div class="card h-100" th:attr="data-component=${cmp}" onclick="openPolicyModal(this)">
+                <div class="card-body text-center">
+                    <span th:text="${cmp}"></span>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+<div th:replace="fragments/navbar :: footer"></div>
+
+<!-- Policy Modal -->
+<div class="modal fade" id="policyModal" tabindex="-1">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Component Policy</h5>
+        <button class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <form id="policyForm">
+          <div class="mb-3">
+            <label class="form-label">Title</label>
+            <input type="text" class="form-control" name="title" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Description</label>
+            <input type="text" class="form-control" name="description">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Default CSS Class</label>
+            <input type="text" class="form-control" name="defaultCssClass">
+          </div>
+          <div id="styleGroups"></div>
+          <button type="button" class="btn btn-sm btn-outline-primary" onclick="addStyleGroup()">Add Style Group</button>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-primary" onclick="savePolicy()">Save</button>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add controller and service for editing component policies per template
- create models and utility to write policy `.content.xml` files
- introduce UI and script for policy editing and make templates clickable

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM – network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68903d30acb88330bfdbc0fcb3f7e0d2