### PR TITLE
Add existing project listing in controller

### DIFF
--- a/src/main/java/com/aem/builder/controller/AemProjectController.java
+++ b/src/main/java/com/aem/builder/controller/AemProjectController.java
@@ -1,7 +1,7 @@
 package com.aem.builder.controller;
 
 import com.aem.builder.model.AemProjectModel;
-import com.aem.builder.service.impl.AemProjectServiceImpl;
+import com.aem.builder.service.AemProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -15,12 +15,12 @@ import java.io.IOException;
 public class AemProjectController {
 
 
-    private final AemProjectServiceImpl aemProjectService;
+    private final AemProjectService aemProjectService;
 
     @GetMapping("/create")
-    public String test(Model model) throws IOException {
-
+    public String showCreateForm(Model model) throws IOException {
         model.addAttribute("aemProjectModel", new AemProjectModel());
+        model.addAttribute("existingProjects", aemProjectService.getExistingProjects());
         return "create";
 
     }
@@ -32,3 +32,4 @@ public class AemProjectController {
         return "dashboard";
     }
 }
+

--- a/src/main/java/com/aem/builder/controller/HomeController.java
+++ b/src/main/java/com/aem/builder/controller/HomeController.java
@@ -1,13 +1,9 @@
 package com.aem.builder.controller;
 
-import com.aem.builder.model.AemProjectModel;
-import com.aem.builder.service.impl.AemProjectServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
 
 import java.io.IOException;
 

--- a/src/main/java/com/aem/builder/service/AemProjectService.java
+++ b/src/main/java/com/aem/builder/service/AemProjectService.java
@@ -3,7 +3,18 @@ package com.aem.builder.service;
 
 import com.aem.builder.model.AemProjectModel;
 
+import java.util.List;
+
 public interface AemProjectService {
 
     void generateAemProject(AemProjectModel aemProjectModel);
+
+    /**
+     * Returns the names of AEM projects that have already been generated
+     * in the workspace. This is used by the UI to warn users if they are
+     * about to create a project that already exists.
+     *
+     * @return list of project directory names, never {@code null}
+     */
+    List<String> getExistingProjects();
 }

--- a/src/main/java/com/aem/builder/service/impl/AemProjectServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/AemProjectServiceImpl.java
@@ -7,6 +7,10 @@ import org.springframework.stereotype.Service;
 import java.io.File;
 import java.io.IOException;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 @Service
 public class AemProjectServiceImpl implements AemProjectService {
     @Override
@@ -81,5 +85,25 @@ public class AemProjectServiceImpl implements AemProjectService {
         }
     }
 
+    @Override
+    public List<String> getExistingProjects() {
+        String baseDir = System.getProperty("user.dir") + "/generated-projects/";
+        File directory = new File(baseDir);
+
+        if (!directory.exists() || !directory.isDirectory()) {
+            return Collections.emptyList();
+        }
+
+        File[] dirs = directory.listFiles(File::isDirectory);
+        if (dirs == null) {
+            return Collections.emptyList();
+        }
+
+        List<String> names = new ArrayList<>();
+        for (File dir : dirs) {
+            names.add(dir.getName());
+        }
+        return names;
+    }
 
 }


### PR DESCRIPTION
## Summary
- wire `AemProjectController` to `AemProjectService` interface
- add method to list existing projects
- show existing projects on create page
- clean up unused imports in `HomeController`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6889c091d64083308735e25f6bb84c6c