### PR TITLE
Add component editing

### DIFF
--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -84,6 +84,7 @@ public class ComponentController {
 
         model.addAttribute("fieldTypes", sortedByKey);
         model.addAttribute("componentGroups", componentService.getComponentGroups(project));
+        model.addAttribute("editMode", false);
         // Components that can be extended (core components + existing ones)
         // Use a LinkedHashSet to avoid duplicates while preserving order
         Set<String> available = new LinkedHashSet<>();
@@ -101,7 +102,52 @@ public class ComponentController {
             compMap.put(path, path.substring(idx));
         }
         model.addAttribute("availableComponents", compMap);
+        model.addAttribute("componentJson", "{}");
         return "create-component"; // Thymeleaf template
+    }
+
+    @GetMapping("/{projectName}/editcomponent")
+    public String showEditComponentForm(@RequestParam String componentName,
+                                        @PathVariable String projectName,
+                                        Model model) {
+        ComponentRequest component = componentService.loadComponent(projectName, componentName);
+        model.addAttribute("projectName", projectName);
+
+        var typeResourceMap = FieldType.getTypeResourceMap();
+
+        var sortedByKey = typeResourceMap.entrySet()
+                .stream()
+                .sorted(Map.Entry.comparingByKey())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (v1, v2) -> v1, LinkedHashMap::new));
+
+        model.addAttribute("fieldTypes", sortedByKey);
+        model.addAttribute("componentGroups", componentService.getComponentGroups(projectName));
+        model.addAttribute("editMode", true);
+
+        // available components
+        Set<String> available = new LinkedHashSet<>();
+        try {
+            available.addAll(componentService.fetchComponentsFromGeneratedProjects(projectName).stream()
+                    .map(name -> "/apps/" + projectName + "/components/" + name)
+                    .toList());
+            available.addAll(componentService.getAllComponents());
+        } catch (IOException e) {
+            log.error("Error loading available components", e);
+        }
+        Map<String, String> compMap = new LinkedHashMap<>();
+        for (String path : available) {
+            int idx = path.lastIndexOf('/') + 1;
+            compMap.put(path, path.substring(idx));
+        }
+        model.addAttribute("availableComponents", compMap);
+        model.addAttribute("componentData", component);
+        try {
+            String json = new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(component);
+            model.addAttribute("componentJson", json);
+        } catch (Exception e) {
+            model.addAttribute("componentJson", "{}");
+        }
+        return "create-component";
     }
 
     @PostMapping("/component/create/{project}")
@@ -116,6 +162,21 @@ public class ComponentController {
             log.error("Error creating component", e);
             redirectAttributes.addFlashAttribute("error", "Failed to create component: " + e.getMessage());
             return "redirect:/create/" + project;
+        }
+    }
+
+    @PostMapping("/component/update/{project}")
+    public String updateComponent(@PathVariable String project,
+                                  @ModelAttribute ComponentRequest request,
+                                  RedirectAttributes redirectAttributes) {
+        try {
+            componentService.updateComponent(project, request);
+            redirectAttributes.addFlashAttribute("message", "Component updated successfully!");
+            return "redirect:/" + project;
+        } catch (Exception e) {
+            log.error("Error updating component", e);
+            redirectAttributes.addFlashAttribute("error", "Failed to update component: " + e.getMessage());
+            return "redirect:/" + project + "/editcomponent?componentName=" + request.getComponentName();
         }
     }
 

--- a/src/main/java/com/aem/builder/controller/DeployController.java
+++ b/src/main/java/com/aem/builder/controller/DeployController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,10 +28,22 @@ public class DeployController {
     @GetMapping("/{projectName}")
     public String projectDetails(@PathVariable String projectName, Model model) {
         logger.info("DEPLOY: Fetching project details for project: {}", projectName);
-        List<String> components = componentService.fetchComponentsFromGeneratedProjects(projectName);
         List<String> templates = templateService.fetchTemplatesFromGeneratedProjects(projectName);
+        var compMap = componentService.fetchComponentsWithGroups(projectName);
+        List<String> components = new ArrayList<>(compMap.keySet());
+        List<String> editable = compMap.entrySet().stream()
+                .filter(e -> {
+                    String g = e.getValue();
+                    return g == null || (!g.equals(projectName + " - Content")
+                            && !g.equals(projectName + " - Structure")
+                            && !g.equals(".hidden"));
+                })
+                .map(java.util.Map.Entry::getKey)
+                .toList();
         model.addAttribute("components", components);
+        model.addAttribute("editableComponents", editable);
         model.addAttribute("templates", templates);
+        model.addAttribute("projectName", projectName);
         model.addAttribute("canDeploy", true);
         logger.debug("DEPLOY: Added attributes to model for project: {}", projectName);
         return "deploy";

--- a/src/main/java/com/aem/builder/service/ComponentService.java
+++ b/src/main/java/com/aem/builder/service/ComponentService.java
@@ -27,6 +27,12 @@ public interface ComponentService {
     List<String> getComponentGroups(String projectName);
     void generateComponent(String projectName, ComponentRequest request);
 
+    Map<String, String> fetchComponentsWithGroups(String projectName);
+
+    ComponentRequest loadComponent(String projectName, String componentName);
+
+    void updateComponent(String projectName, ComponentRequest request);
+
     //component checking
     boolean isComponentNameAvailable(String projectName, String componentName);
 

--- a/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
@@ -1,6 +1,9 @@
 package com.aem.builder.service.impl;
 
+import com.aem.builder.model.DTO.ComponentField;
 import com.aem.builder.model.DTO.ComponentRequest;
+import com.aem.builder.model.DTO.OptionItem;
+import com.aem.builder.model.Enum.FieldType;
 import com.aem.builder.service.ComponentService;
 
 import com.aem.builder.util.FileGenerationUtil;
@@ -8,17 +11,24 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.io.FileUtils;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
-import java.io.IOException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -41,6 +51,33 @@ public class ComponentServiceImpl implements ComponentService {
                     .collect(Collectors.toList());
         }
         return List.of();
+    }
+
+    @Override
+    public Map<String, String> fetchComponentsWithGroups(String projectName) {
+        Map<String, String> result = new LinkedHashMap<>();
+        File componentsDir = new File(PROJECTS_DIR,
+                projectName + "/ui.apps/src/main/content/jcr_root/apps/" + projectName + "/components");
+        if (componentsDir.exists()) {
+            File[] dirs = componentsDir.listFiles(File::isDirectory);
+            if (dirs != null) {
+                for (File comp : dirs) {
+                    File contentXml = new File(comp, ".content.xml");
+                    String group = "";
+                    if (contentXml.exists()) {
+                        String content = FileGenerationUtil.readFile(contentXml);
+                        if (content.contains("componentGroup")) {
+                            int idx = content.indexOf("componentGroup");
+                            int start = content.indexOf("\"", idx) + 1;
+                            int end = content.indexOf("\"", start);
+                            group = content.substring(start, end);
+                        }
+                    }
+                    result.put(comp.getName(), group);
+                }
+            }
+        }
+        return result;
     }
 
     @Override
@@ -84,6 +121,163 @@ public class ComponentServiceImpl implements ComponentService {
             }
         }
         return existingProjects;
+    }
+
+    @Override
+    public ComponentRequest loadComponent(String projectName, String componentName) {
+        String basePath = PROJECTS_DIR + "/" + projectName + "/ui.apps/src/main/content/jcr_root/apps/" + projectName
+                + "/components/" + componentName;
+        String group = "";
+        String superType = null;
+        List<ComponentField> fields = new ArrayList<>();
+
+        try {
+            File contentXml = new File(basePath, ".content.xml");
+            if (contentXml.exists()) {
+                String content = FileGenerationUtil.readFile(contentXml);
+                if (content.contains("componentGroup")) {
+                    int idx = content.indexOf("componentGroup");
+                    int start = content.indexOf("\"", idx) + 1;
+                    int end = content.indexOf("\"", start);
+                    group = content.substring(start, end);
+                }
+                if (content.contains("sling:resourceSuperType")) {
+                    int idx = content.indexOf("sling:resourceSuperType");
+                    int start = content.indexOf("\"", idx) + 1;
+                    int end = content.indexOf("\"", start);
+                    superType = content.substring(start, end);
+                }
+            }
+
+            // load fields from this component
+            fields = readDialogFields(new File(basePath + "/_cq_dialog/.content.xml"));
+
+            // If no fields and component extends another, try loading from super type
+            if (fields.isEmpty() && superType != null && !superType.isEmpty()) {
+                String superPath;
+                if (superType.startsWith("/apps/")) {
+                    superPath = PROJECTS_DIR + "/" + projectName + "/ui.apps/src/main/content/jcr_root" + superType;
+                } else {
+                    superPath = "src/main/resources/aem-components/" + superType;
+                }
+                fields = readDialogFields(new File(superPath + "/_cq_dialog/.content.xml"));
+            }
+        } catch (Exception e) {
+            log.error("Failed to load component {}", componentName, e);
+        }
+
+        ComponentRequest req = new ComponentRequest();
+        req.setProjectName(projectName);
+        req.setComponentName(componentName);
+        req.setComponentGroup(group);
+        req.setSuperType(superType);
+        req.setFields(fields);
+        return req;
+    }
+
+    @Override
+    public void updateComponent(String projectName, ComponentRequest request) {
+        String compPath = PROJECTS_DIR + "/" + projectName + "/ui.apps/src/main/content/jcr_root/apps/" + projectName
+                + "/components/" + request.getComponentName();
+        try {
+            FileUtils.deleteDirectory(new File(compPath));
+        } catch (IOException e) {
+            log.warn("Could not clean component folder before update", e);
+        }
+        FileGenerationUtil.generateAllFiles(projectName, request);
+    }
+
+    private List<ComponentField> readDialogFields(File dialogXml) {
+        List<ComponentField> fields = new ArrayList<>();
+        if (!dialogXml.exists()) {
+            return fields;
+        }
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(false);
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document doc = builder.parse(dialogXml);
+            Element root = doc.getDocumentElement();
+            Element content = (Element) root.getElementsByTagName("content").item(0);
+            if (content != null) {
+                Element items = (Element) content.getElementsByTagName("items").item(0);
+                if (items != null) {
+                    Element tabs = (Element) items.getElementsByTagName("tabs").item(0);
+                    if (tabs != null) {
+                        Element tabsItems = (Element) tabs.getElementsByTagName("items").item(0);
+                        if (tabsItems != null) {
+                            Element tab1 = (Element) tabsItems.getElementsByTagName("tab1").item(0);
+                            if (tab1 != null) {
+                                Element tabItems = (Element) tab1.getElementsByTagName("items").item(0);
+                                if (tabItems != null) {
+                                    NodeList fieldNodes = tabItems.getChildNodes();
+                                    for (int i = 0; i < fieldNodes.getLength(); i++) {
+                                        Node node = fieldNodes.item(i);
+                                        if (node instanceof Element elem) {
+                                            fields.add(parseField(elem));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to parse dialog {}", dialogXml.getPath(), e);
+        }
+        return fields;
+    }
+
+    private String getFieldTypeFromResource(String resourceType) {
+        return FieldType.getTypeResourceMap().entrySet().stream()
+                .filter(e -> e.getValue().equals(resourceType))
+                .map(Map.Entry::getKey)
+                .findFirst()
+                .orElse("");
+    }
+
+    private ComponentField parseField(Element elem) {
+        String fieldLabel = elem.getAttribute("fieldLabel");
+        String nameAttr = elem.getAttribute("name");
+        String fieldName = nameAttr.startsWith("./") ? nameAttr.substring(2) : nameAttr;
+        String resourceType = elem.getAttribute("sling:resourceType");
+        String fieldType = getFieldTypeFromResource(resourceType);
+
+        List<OptionItem> options = null;
+        List<ComponentField> nested = null;
+
+        if ("multifield".equals(fieldType)) {
+            Element fieldElem = (Element) elem.getElementsByTagName("field").item(0);
+            if (fieldElem != null) {
+                Element items = (Element) fieldElem.getElementsByTagName("items").item(0);
+                if (items != null) {
+                    nested = new ArrayList<>();
+                    NodeList nodes = items.getChildNodes();
+                    for (int i = 0; i < nodes.getLength(); i++) {
+                        Node n = nodes.item(i);
+                        if (n instanceof Element child) {
+                            nested.add(parseField(child));
+                        }
+                    }
+                }
+            }
+        } else if (fieldType.equals("select") || fieldType.equals("multiselect")
+                || fieldType.equals("checkboxgroup") || fieldType.equals("radiogroup")) {
+            Element items = (Element) elem.getElementsByTagName("items").item(0);
+            if (items != null) {
+                options = new ArrayList<>();
+                NodeList nodes = items.getChildNodes();
+                for (int i = 0; i < nodes.getLength(); i++) {
+                    Node n = nodes.item(i);
+                    if (n instanceof Element opt) {
+                        options.add(new OptionItem(opt.getAttribute("value"), opt.getAttribute("text")));
+                    }
+                }
+            }
+        }
+
+        return new ComponentField(fieldName, fieldLabel, fieldType, nested, options);
     }
 
     @Override

--- a/src/main/resources/static/js/create-component.js
+++ b/src/main/resources/static/js/create-component.js
@@ -266,4 +266,67 @@ document.addEventListener("DOMContentLoaded", function () {
   document.addEventListener('input', validateFormFields);
   document.addEventListener('change', validateFormFields);
   updateIndexes();
+
+  if (window.editMode) {
+    loadComponentData(window.componentData || {});
+  }
+
+  function loadComponentData(data) {
+    if (!data) return;
+    componentNameInput.value = data.componentName || '';
+    componentNameInput.readOnly = true;
+    document.getElementById('componentGroup').value = data.componentGroup || '';
+    if (data.superType) {
+      modeSelect.value = 'extend';
+      toggleSuperType();
+      document.getElementById('superType').value = data.superType;
+    } else {
+      modeSelect.value = 'new';
+      toggleSuperType();
+    }
+    const container = document.getElementById('fieldsContainer');
+    container.innerHTML = '';
+    if (data.fields) {
+      data.fields.forEach(f => {
+        const row = createBaseRow(false);
+        row.querySelector('.action-col').innerHTML = '<button type="button" class="btn btn-danger" onclick="removeFieldRow(this)">-</button>';
+        container.appendChild(row);
+        populateFieldRow(row, f);
+      });
+    }
+    updateIndexes();
+    validateFormFields();
+  }
+
+  function populateFieldRow(row, field, level = 0) {
+    row.querySelector('.fieldLabel').value = field.fieldLabel || '';
+    row.querySelector('.fieldName').value = field.fieldName || '';
+    row.querySelector('.fieldType').value = field.fieldType || '';
+    handleFieldTypeChange(row.querySelector('.fieldType'));
+
+    if (field.options && field.options.length > 0) {
+      const container = row.querySelector('.options-container');
+      const addBtn = container.querySelector('button');
+      container.innerHTML = '';
+      field.options.forEach(opt => {
+        const div = document.createElement('div');
+        div.className = 'option-row input-group mb-2';
+        div.innerHTML = `<input type="text" class="form-control optionText" placeholder="Text" value="${opt.text}" required>` +
+          `<input type="text" class="form-control optionValue" placeholder="Value" value="${opt.value}" required>` +
+          `<button type="button" class="btn btn-danger" onclick="removeOptionRow(this)">-</button>`;
+        container.appendChild(div);
+      });
+      container.appendChild(addBtn);
+    }
+
+    if (field.fieldType === 'multifield' && field.nestedFields) {
+      const container = row.querySelector('.nested-container');
+      const addBtn = container.querySelector('button');
+      field.nestedFields.forEach(nf => {
+        const nrow = createBaseRow(true, level + 1);
+        container.insertBefore(nrow, addBtn);
+        populateFieldRow(nrow, nf, level + 1);
+      });
+    }
+  }
 });

--- a/src/main/resources/templates/create-component.html
+++ b/src/main/resources/templates/create-component.html
@@ -14,7 +14,7 @@
 <div th:replace="fragments/navbar :: navbar"></div>
 
 <div class="container mt-4 mb-5">
-  <h2 class="mb-4 animate__animated animate__fadeInDown">Create AEM Component for [[${projectName}]]</h2>
+  <h2 class="mb-4 animate__animated animate__fadeInDown" th:text="${editMode} ? 'Edit AEM Component for ' + ${projectName} : 'Create AEM Component for ' + ${projectName}"></h2>
 
   <a th:href="@{'/' + ${projectName}}" class="btn btn-outline-secondary mb-3">← Back to DeployPage</a>
 
@@ -27,14 +27,14 @@
     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
   </div>
 
-  <form id="componentForm" th:action="@{'/component/create/' + ${projectName}}" method="post">
+  <form id="componentForm" th:action="${editMode} ? @{'/component/update/' + ${projectName}} : @{'/component/create/' + ${projectName}}" method="post">
     <!-- Hidden input to pass projectName into JS -->
     <input type="hidden" id="projectName" th:value="${projectName}">
 
     <!-- Component Name -->
     <div class="mb-3">
       <label class="form-label">Component Name</label>
-      <input type="text" class="form-control" name="componentName" id="componentName" required>
+      <input type="text" class="form-control" name="componentName" id="componentName" th:value="${componentData?.componentName}" th:readonly="${editMode}" required>
       <div id="nameError" class="mt-1" style="font-size: 0.9rem;"></div>
     </div>
 
@@ -43,7 +43,10 @@
       <label class="form-label">Component Group</label>
       <select class="form-select" name="componentGroup" id="componentGroup" required>
         <option value="">-- Select Component Group --</option>
-        <option th:each="group : ${componentGroups}" th:value="${group}" th:text="${group}"></option>
+        <option th:each="group : ${componentGroups}"
+                th:value="${group}"
+                th:text="${group}"
+                th:selected="${group == componentData?.componentGroup}"></option>
       </select>
     </div>
 
@@ -59,7 +62,7 @@
     <!-- Extends Component -->
     <div class="mb-3" id="extendsComponentDiv" style="display:none">
       <label class="form-label">Extends Component</label>
-      <select class="form-select" name="superType" id="superType">
+      <select class="form-select" name="superType" id="superType" th:value="${componentData?.superType}">
         <option value="">-- Select Component --</option>
         <option th:each="entry : ${availableComponents.entrySet()}" th:value="${entry.key}" th:text="${entry.value}"></option>
       </select>
@@ -93,7 +96,7 @@
     <button type="button" class="btn btn-primary mb-3" onclick="addFieldRow()">+ Add Field</button><br>
 
     <!-- Create Component Button -->
-    <button type="submit" class="btn btn-primary" id="createButton" disabled>Create Component</button>
+    <button type="submit" class="btn btn-primary" id="createButton" th:text="${editMode} ? 'Update Component' : 'Create Component'" disabled>Create Component</button>
   </form>
 </div>
 
@@ -101,7 +104,9 @@
 <footer>
   <div th:replace="fragments/navbar :: footer"></div>
 </footer>
-
-
+<script th:inline="javascript">
+  window.editMode = [[${editMode}]];
+  window.componentData = JSON.parse(/*[[${componentJson}]]*/ '{}');
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/deploy.html
+++ b/src/main/resources/templates/deploy.html
@@ -45,7 +45,12 @@
                 </div>
                 <div id="componentsList" class="row row-cols-1 row-cols-sm-2 g-2">
                     <div class="col" th:each="component : ${components}">
-                        <div class="border rounded p-2 bg-light text-center shadow-sm" th:text="${component}"></div>
+                        <div class="border rounded p-2 bg-light text-center shadow-sm d-flex justify-content-between align-items-center">
+                            <span th:text="${component}"></span>
+                            <a th:if="${#lists.contains(editableComponents, component)}"
+                               th:href="@{/{projectName}/editcomponent(componentName=${component}, projectName=${projectName})}"
+                               class="btn btn-sm btn-outline-secondary ms-2">Edit</a>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- load component dialog fields including fallback to super type when editing
- send component definition as JSON so edit form pre-populates properly
- fix option text/value parsing when reading existing dialog definitions

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_689039f024148330bc1d5b3a5ea79a74