### PR TITLE
feat: add standalone policy editor

### DIFF
--- a/src/main/java/com/aem/builder/controller/PolicyController.java
+++ b/src/main/java/com/aem/builder/controller/PolicyController.java
@@ -33,6 +33,24 @@ public class PolicyController {
         return "template-components";
     }
 
+    @GetMapping("/policies")
+    @ResponseBody
+    public List<String> listPolicies(@PathVariable String projectName,
+                                     @PathVariable String templateName) {
+        return policyService.listPolicies(projectName);
+    }
+
+    @GetMapping("/policies/{component}/edit")
+    public String editPolicyPage(@PathVariable String projectName,
+                                 @PathVariable String templateName,
+                                 @PathVariable("component") String componentName,
+                                 Model model) {
+        model.addAttribute("projectName", projectName);
+        model.addAttribute("templateName", templateName);
+        model.addAttribute("componentName", componentName);
+        return "policy-editor";
+    }
+
     @GetMapping("/policies/{component}")
     @ResponseBody
     public PolicyModel loadPolicy(@PathVariable String projectName,

--- a/src/main/java/com/aem/builder/service/PolicyService.java
+++ b/src/main/java/com/aem/builder/service/PolicyService.java
@@ -16,6 +16,11 @@ public interface PolicyService {
     PolicyModel loadPolicy(String projectName, String templateName, String componentName);
 
     /**
+     * List names of all available policies for the project.
+     */
+    List<String> listPolicies(String projectName);
+
+    /**
      * Persist a policy for the given component.
      */
     void savePolicy(String projectName, String templateName, String componentName, PolicyModel policy);

--- a/src/main/resources/templates/policy-editor.html
+++ b/src/main/resources/templates/policy-editor.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Policy Editor</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script th:src="@{/js/policy-editor.js}"></script>
+</head>
+<body class="d-flex flex-column min-vh-100" th:attr="data-project=${projectName},data-template=${templateName},data-component=${componentName}">
+<div th:replace="fragments/navbar :: navbar"></div>
+<main class="container mt-4 flex-grow-1">
+    <h2 th:text="'Policy: ' + ${componentName}"></h2>
+    <a th:href="@{'/' + ${projectName} + '/templates/' + ${templateName}}" class="btn btn-outline-secondary mb-3">&larr; Back</a>
+
+    <div class="mb-3">
+        <label class="form-label">Existing Policy</label>
+        <select id="existingPolicies" class="form-select"></select>
+    </div>
+
+    <form id="policyForm">
+        <div class="mb-3">
+            <label class="form-label">Title</label>
+            <input type="text" class="form-control" name="title" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Description</label>
+            <input type="text" class="form-control" name="description">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Default CSS Class</label>
+            <input type="text" class="form-control" name="defaultCssClass">
+        </div>
+        <div id="styleGroups"></div>
+        <button type="button" class="btn btn-sm btn-outline-primary" onclick="addStyleGroup()">Add Style Group</button>
+    </form>
+    <button class="btn btn-primary mt-3" onclick="savePolicy()">Save</button>
+</main>
+<div th:replace="fragments/navbar :: footer"></div>
+</body>
+</html>
+

--- a/src/main/resources/templates/template-components.html
+++ b/src/main/resources/templates/template-components.html
@@ -4,7 +4,6 @@
     <title>Template Components</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script th:src="@{/js/policy-editor.js}"></script>
 </head>
 <body class="d-flex flex-column min-vh-100" th:attr="data-project=${projectName},data-template=${templateName}">
 <div th:replace="fragments/navbar :: navbar"></div>
@@ -14,47 +13,16 @@
 
     <div class="row row-cols-1 row-cols-sm-2 g-3">
         <div class="col" th:each="cmp : ${components}">
-            <div class="card h-100" th:attr="data-component=${cmp}" onclick="openPolicyModal(this)">
-                <div class="card-body text-center">
-                    <span th:text="${cmp}"></span>
+            <a th:href="@{'/' + ${projectName} + '/templates/' + ${templateName} + '/policies/' + ${cmp} + '/edit'}" class="text-decoration-none">
+                <div class="card h-100">
+                    <div class="card-body text-center">
+                        <span th:text="${cmp}"></span>
+                    </div>
                 </div>
-            </div>
+            </a>
         </div>
     </div>
 </main>
 <div th:replace="fragments/navbar :: footer"></div>
-
-<!-- Policy Modal -->
-<div class="modal fade" id="policyModal" tabindex="-1">
-  <div class="modal-dialog modal-lg modal-dialog-scrollable">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Component Policy</h5>
-        <button class="btn-close" data-bs-dismiss="modal"></button>
-      </div>
-      <div class="modal-body">
-        <form id="policyForm">
-          <div class="mb-3">
-            <label class="form-label">Title</label>
-            <input type="text" class="form-control" name="title" required>
-          </div>
-          <div class="mb-3">
-            <label class="form-label">Description</label>
-            <input type="text" class="form-control" name="description">
-          </div>
-          <div class="mb-3">
-            <label class="form-label">Default CSS Class</label>
-            <input type="text" class="form-control" name="defaultCssClass">
-          </div>
-          <div id="styleGroups"></div>
-          <button type="button" class="btn btn-sm btn-outline-primary" onclick="addStyleGroup()">Add Style Group</button>
-        </form>
-      </div>
-      <div class="modal-footer">
-        <button class="btn btn-primary" onclick="savePolicy()">Save</button>
-      </div>
-    </div>
-  </div>
-</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add controller endpoints and service hooks to list and edit component policies
- expose policy editor as its own page with existing policy selection
- update policy persistence to keep global and template mappings in sync

## Testing
- `./mvnw -q test` *(failed: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_b_6891acf77b24833080175d259fb446de