### PR TITLE
Add template component policy editing

### DIFF
--- a/src/main/java/com/aem/builder/controller/PolicyController.java
+++ b/src/main/java/com/aem/builder/controller/PolicyController.java
@@ -1,0 +1,69 @@
+package com.aem.builder.controller;
+
+import com.aem.builder.model.policy.PolicyModel;
+import com.aem.builder.service.PolicyService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class PolicyController {
+
+    private final PolicyService policyService;
+
+    /**
+     * Shows allowed components for a template.
+     */
+    @GetMapping("/{project}/templates/{template}/components")
+    public String showComponents(@PathVariable String project,
+                                 @PathVariable String template,
+                                 Model model) {
+        List<String> components = policyService.getAllowedComponents(project, template);
+        model.addAttribute("projectName", project);
+        model.addAttribute("templateName", template);
+        model.addAttribute("components", components);
+        return "template-components";
+    }
+
+    /**
+     * Shows policy editor for component.
+     */
+    @GetMapping("/{project}/templates/{template}/component")
+    public String showPolicyEditor(@PathVariable String project,
+                                   @PathVariable String template,
+                                   @RequestParam("resource") String component,
+                                   Model model) {
+        Map<String, PolicyModel> policies = policyService.getPolicies(project, component);
+        model.addAttribute("projectName", project);
+        model.addAttribute("templateName", template);
+        model.addAttribute("component", component);
+        model.addAttribute("policies", policies);
+        return "policy-editor";
+    }
+
+    @GetMapping("/api/{project}/component/policy")
+    @ResponseBody
+    public PolicyModel loadPolicy(@PathVariable String project,
+                                  @RequestParam String resource,
+                                  @RequestParam String policyId) {
+        return policyService.loadPolicy(project, resource, policyId);
+    }
+
+    @PostMapping("/api/{project}/templates/{template}/component/policy")
+    @ResponseBody
+    public ResponseEntity<String> savePolicy(@PathVariable String project,
+                                             @PathVariable String template,
+                                             @RequestParam String resource,
+                                             @RequestBody PolicyModel policy) {
+        String id = policyService.savePolicy(project, template, resource, policy);
+        return ResponseEntity.ok(id);
+    }
+}

--- a/src/main/java/com/aem/builder/model/policy/PolicyModel.java
+++ b/src/main/java/com/aem/builder/model/policy/PolicyModel.java
@@ -1,0 +1,17 @@
+package com.aem.builder.model.policy;
+
+import lombok.Data;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents an AEM component policy with style groups.
+ */
+@Data
+public class PolicyModel {
+    private String id; // folder name of policy
+    private String title;
+    private String description;
+    private String defaultCssClass;
+    private List<StyleGroupModel> styleGroups = new ArrayList<>();
+}

--- a/src/main/java/com/aem/builder/model/policy/StyleGroupModel.java
+++ b/src/main/java/com/aem/builder/model/policy/StyleGroupModel.java
@@ -1,0 +1,15 @@
+package com.aem.builder.model.policy;
+
+import lombok.Data;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a group of styles in a policy.
+ */
+@Data
+public class StyleGroupModel {
+    private String name;
+    private boolean allowCombination;
+    private List<StyleModel> styles = new ArrayList<>();
+}

--- a/src/main/java/com/aem/builder/model/policy/StyleModel.java
+++ b/src/main/java/com/aem/builder/model/policy/StyleModel.java
@@ -1,0 +1,12 @@
+package com.aem.builder.model.policy;
+
+import lombok.Data;
+
+/**
+ * Represents a single style in a style group.
+ */
+@Data
+public class StyleModel {
+    private String name;
+    private String cssClass;
+}

--- a/src/main/java/com/aem/builder/service/PolicyService.java
+++ b/src/main/java/com/aem/builder/service/PolicyService.java
@@ -1,0 +1,29 @@
+package com.aem.builder.service;
+
+import com.aem.builder.model.policy.PolicyModel;
+import java.util.List;
+import java.util.Map;
+
+public interface PolicyService {
+    /**
+     * Fetch allowed component resource types for the template's layout container.
+     */
+    List<String> getAllowedComponents(String project, String template);
+
+    /**
+     * Fetch existing policies for a given component resource type.
+     * Key of map is policy id (folder name).
+     */
+    Map<String, PolicyModel> getPolicies(String project, String componentResourceType);
+
+    /**
+     * Save or update a policy and update template mappings.
+     * Returns the policy id used for storage.
+     */
+    String savePolicy(String project, String template, String componentResourceType, PolicyModel policy);
+
+    /**
+     * Load a policy by id.
+     */
+    PolicyModel loadPolicy(String project, String componentResourceType, String policyId);
+}

--- a/src/main/java/com/aem/builder/service/impl/PolicyServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/PolicyServiceImpl.java
@@ -1,0 +1,304 @@
+package com.aem.builder.service.impl;
+
+import com.aem.builder.model.policy.PolicyModel;
+import com.aem.builder.model.policy.StyleGroupModel;
+import com.aem.builder.model.policy.StyleModel;
+import com.aem.builder.service.PolicyService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+public class PolicyServiceImpl implements PolicyService {
+
+    private static final String BASE_PATH = "generated-projects";
+
+    private DocumentBuilder newBuilder() {
+        try {
+            return DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String buildConfPath(String project) {
+        return BASE_PATH + "/" + project + "/ui.content/src/main/content/jcr_root/conf/" + project;
+    }
+
+    @Override
+    public List<String> getAllowedComponents(String project, String template) {
+        try {
+            String mappingPath = buildConfPath(project) + "/settings/wcm/templates/" + template + "/policies/.content.xml";
+            File mappingFile = new File(mappingPath);
+            if (!mappingFile.exists()) {
+                return List.of();
+            }
+            Document doc = newBuilder().parse(mappingFile);
+            Element root = doc.getDocumentElement();
+            String policyPath = null;
+            NodeList all = root.getElementsByTagName("*");
+            for (int i = 0; i < all.getLength(); i++) {
+                Element el = (Element) all.item(i);
+                if (el.hasAttribute("cq:policy")) {
+                    policyPath = el.getAttribute("cq:policy");
+                    break;
+                }
+            }
+            if (policyPath == null) {
+                return List.of();
+            }
+            String policyFilePath = buildConfPath(project) + "/settings/wcm/policies/" + policyPath + "/.content.xml";
+            File policyFile = new File(policyFilePath);
+            if (!policyFile.exists()) {
+                return List.of();
+            }
+            Document policyDoc = newBuilder().parse(policyFile);
+            Element polRoot = policyDoc.getDocumentElement();
+            String allowed = polRoot.getAttribute("cq:allowedComponents");
+            if (allowed == null || allowed.isBlank()) {
+                return List.of();
+            }
+            allowed = allowed.replace("[", "").replace("]", "");
+            return Arrays.stream(allowed.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            log.error("Failed to read allowed components", e);
+            return List.of();
+        }
+    }
+
+    @Override
+    public Map<String, PolicyModel> getPolicies(String project, String componentResourceType) {
+        Map<String, PolicyModel> result = new LinkedHashMap<>();
+        String policyDirPath = buildConfPath(project) + "/settings/wcm/policies/" + componentResourceType;
+        File dir = new File(policyDirPath);
+        if (!dir.exists()) {
+            return result;
+        }
+        File[] policies = dir.listFiles(File::isDirectory);
+        if (policies == null) return result;
+        for (File p : policies) {
+            File content = new File(p, ".content.xml");
+            if (content.exists()) {
+                PolicyModel model = readPolicy(content);
+                if (model != null) {
+                    model.setId(p.getName());
+                    result.put(p.getName(), model);
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public PolicyModel loadPolicy(String project, String componentResourceType, String policyId) {
+        String path = buildConfPath(project) + "/settings/wcm/policies/" + componentResourceType + "/" + policyId + "/.content.xml";
+        File file = new File(path);
+        if (!file.exists()) return null;
+        return readPolicy(file);
+    }
+
+    private PolicyModel readPolicy(File file) {
+        try {
+            Document doc = newBuilder().parse(file);
+            Element root = doc.getDocumentElement();
+            PolicyModel model = new PolicyModel();
+            model.setTitle(root.getAttribute("jcr:title"));
+            model.setDescription(root.getAttribute("jcr:description"));
+            model.setDefaultCssClass(root.getAttribute("cq:styleDefaultClasses"));
+            String groupsAttr = root.getAttribute("cq:styleGroups");
+            if (groupsAttr != null && !groupsAttr.isBlank()) {
+                groupsAttr = groupsAttr.replace("[", "").replace("]", "");
+                List<String> groupNames = Arrays.stream(groupsAttr.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.toList());
+                Element groupsElement = getChild(root, "cq:styleGroups");
+                for (String gName : groupNames) {
+                    Element gEl = getChild(groupsElement, gName);
+                    if (gEl == null) continue;
+                    StyleGroupModel group = new StyleGroupModel();
+                    group.setName(gName);
+                    group.setAllowCombination(Boolean.parseBoolean(gEl.getAttribute("cq:styleAllowedCombination")));
+                    String names = gEl.getAttribute("cq:styleNames").replace("[", "").replace("]", "");
+                    String classes = gEl.getAttribute("cq:styleClasses").replace("[", "").replace("]", "");
+                    String[] nArr = names.split(",");
+                    String[] cArr = classes.split(",");
+                    List<StyleModel> styles = new ArrayList<>();
+                    for (int i = 0; i < nArr.length; i++) {
+                        String n = nArr[i].trim();
+                        if (n.isEmpty()) continue;
+                        String c = i < cArr.length ? cArr[i].trim() : "";
+                        StyleModel sm = new StyleModel();
+                        sm.setName(n);
+                        sm.setCssClass(c);
+                        styles.add(sm);
+                    }
+                    group.setStyles(styles);
+                    model.getStyleGroups().add(group);
+                }
+            }
+            return model;
+        } catch (Exception e) {
+            log.error("Error reading policy", e);
+            return null;
+        }
+    }
+
+    @Override
+    public String savePolicy(String project, String template, String componentResourceType, PolicyModel policy) {
+        String policyId = policy.getId();
+        if (policyId == null || policyId.isBlank()) {
+            policyId = "policy_" + System.currentTimeMillis();
+        }
+        String base = buildConfPath(project);
+        File policyDir = new File(base + "/settings/wcm/policies/" + componentResourceType + "/" + policyId);
+        policyDir.mkdirs();
+        // ensure root policies .content.xml
+        ensureFolderContent(new File(base + "/settings/wcm/policies"));
+        // write policy file
+        File policyFile = new File(policyDir, ".content.xml");
+        writePolicyFile(policyFile, policy);
+        // update template policy mapping
+        String mappingPath = base + "/settings/wcm/templates/" + template + "/policies/.content.xml";
+        updateTemplateMapping(mappingPath, componentResourceType + "/" + policyId);
+        // touch template root .content.xml (ensure exists)
+        ensureFolderContent(new File(base + "/settings/wcm/templates/" + template));
+        return policyId;
+    }
+
+    private void ensureFolderContent(File folder) {
+        folder.mkdirs();
+        File content = new File(folder, ".content.xml");
+        if (!content.exists()) {
+            try {
+                Document doc = newBuilder().newDocument();
+                Element root = doc.createElement("jcr:root");
+                root.setAttribute("xmlns:jcr", "http://www.jcp.org/jcr/1.0");
+                root.setAttribute("xmlns:sling", "http://sling.apache.org/jcr/sling/1.0");
+                root.setAttribute("jcr:primaryType", "sling:Folder");
+                doc.appendChild(root);
+                writeDoc(doc, content);
+            } catch (Exception e) {
+                log.error("Failed to write folder .content.xml", e);
+            }
+        }
+    }
+
+    private void writePolicyFile(File file, PolicyModel policy) {
+        try {
+            Document doc = newBuilder().newDocument();
+            Element root = doc.createElement("jcr:root");
+            root.setAttribute("xmlns:jcr", "http://www.jcp.org/jcr/1.0");
+            root.setAttribute("xmlns:cq", "http://www.day.com/jcr/cq/1.0");
+            root.setAttribute("xmlns:nt", "http://www.jcp.org/jcr/nt/1.0");
+            root.setAttribute("jcr:primaryType", "cq:Policy");
+            if (policy.getTitle() != null) root.setAttribute("jcr:title", policy.getTitle());
+            if (policy.getDescription() != null) root.setAttribute("jcr:description", policy.getDescription());
+            if (policy.getDefaultCssClass() != null && !policy.getDefaultCssClass().isBlank()) {
+                root.setAttribute("cq:styleDefaultClasses", policy.getDefaultCssClass());
+            }
+            if (!policy.getStyleGroups().isEmpty()) {
+                String groupNames = policy.getStyleGroups().stream()
+                        .map(StyleGroupModel::getName)
+                        .collect(Collectors.joining(","));
+                root.setAttribute("cq:styleGroups", "[" + groupNames + "]");
+                Element groupsEl = doc.createElement("cq:styleGroups");
+                for (StyleGroupModel sg : policy.getStyleGroups()) {
+                    Element gEl = doc.createElement(sg.getName());
+                    gEl.setAttribute("jcr:primaryType", "nt:unstructured");
+                    gEl.setAttribute("cq:styleAllowedCombination", "{Boolean}" + sg.isAllowCombination());
+                    String names = sg.getStyles().stream().map(StyleModel::getName).collect(Collectors.joining(","));
+                    String classes = sg.getStyles().stream().map(StyleModel::getCssClass).collect(Collectors.joining(","));
+                    gEl.setAttribute("cq:styleNames", "[" + names + "]");
+                    gEl.setAttribute("cq:styleClasses", "[" + classes + "]");
+                    groupsEl.appendChild(gEl);
+                }
+                root.appendChild(groupsEl);
+            }
+            doc.appendChild(root);
+            writeDoc(doc, file);
+        } catch (Exception e) {
+            log.error("Failed to write policy file", e);
+        }
+    }
+
+    private void updateTemplateMapping(String mappingPath, String policyRelPath) {
+        try {
+            File file = new File(mappingPath);
+            if (!file.exists()) {
+                file.getParentFile().mkdirs();
+                Document doc = newBuilder().newDocument();
+                Element root = doc.createElement("jcr:root");
+                root.setAttribute("xmlns:sling", "http://sling.apache.org/jcr/sling/1.0");
+                root.setAttribute("xmlns:cq", "http://www.day.com/jcr/cq/1.0");
+                root.setAttribute("xmlns:jcr", "http://www.jcp.org/jcr/1.0");
+                root.setAttribute("xmlns:nt", "http://www.jcp.org/jcr/nt/1.0");
+                root.setAttribute("jcr:primaryType", "cq:Page");
+                Element content = doc.createElement("jcr:content");
+                content.setAttribute("jcr:primaryType", "nt:unstructured");
+                content.setAttribute("sling:resourceType", "wcm/core/components/policies/mappings");
+                Element rootNode = doc.createElement("root");
+                rootNode.setAttribute("jcr:primaryType", "nt:unstructured");
+                rootNode.setAttribute("sling:resourceType", "wcm/core/components/policies/mapping");
+                rootNode.setAttribute("cq:policy", policyRelPath);
+                content.appendChild(rootNode);
+                root.appendChild(content);
+                doc.appendChild(root);
+                writeDoc(doc, file);
+                return;
+            }
+            Document doc = newBuilder().parse(file);
+            Element root = doc.getDocumentElement();
+            Element content = getChild(root, "jcr:content");
+            Element rootNode = getChild(content, "root");
+            if (rootNode == null) {
+                rootNode = doc.createElement("root");
+                rootNode.setAttribute("jcr:primaryType", "nt:unstructured");
+                rootNode.setAttribute("sling:resourceType", "wcm/core/components/policies/mapping");
+                content.appendChild(rootNode);
+            }
+            rootNode.setAttribute("cq:policy", policyRelPath);
+            writeDoc(doc, file);
+        } catch (Exception e) {
+            log.error("Failed to update template policy mapping", e);
+        }
+    }
+
+    private Element getChild(Element parent, String name) {
+        if (parent == null) return null;
+        NodeList nodes = parent.getElementsByTagName(name);
+        for (int i = 0; i < nodes.getLength(); i++) {
+            if (nodes.item(i).getParentNode() == parent) {
+                return (Element) nodes.item(i);
+            }
+        }
+        return null;
+    }
+
+    private void writeDoc(Document doc, File file) throws Exception {
+        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            transformer.transform(new DOMSource(doc), new StreamResult(fos));
+        }
+    }
+}

--- a/src/main/resources/static/js/policy-editor.js
+++ b/src/main/resources/static/js/policy-editor.js
@@ -1,0 +1,98 @@
+let groupCounter = 0;
+
+function addGroup(data) {
+    const container = document.getElementById('styleGroups');
+    const index = groupCounter++;
+    const group = document.createElement('div');
+    group.className = 'border p-3 mb-3';
+    group.dataset.index = index;
+    group.innerHTML = `
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <input type="text" class="form-control me-2" placeholder="Group Name" value="${data?data.name:''}" required>
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" ${data&&data.allowCombination?'checked':''}>
+                <label class="form-check-label">Styles can be combined</label>
+            </div>
+            <button type="button" class="btn btn-sm btn-danger ms-2" onclick="this.closest('.border').remove()">Remove</button>
+        </div>
+        <div class="styles"></div>
+        <button type="button" class="btn btn-sm btn-outline-secondary mt-2" onclick="addStyle(this.parentElement)">+ Style</button>
+    `;
+    container.appendChild(group);
+    if (data && data.styles) {
+        data.styles.forEach(s => addStyle(group, s));
+    }
+}
+
+function addStyle(groupEl, data) {
+    const stylesContainer = groupEl.querySelector('.styles');
+    const row = document.createElement('div');
+    row.className = 'd-flex mb-2';
+    row.innerHTML = `
+        <input type="text" class="form-control me-2" placeholder="Style Name" value="${data?data.name:''}" required>
+        <input type="text" class="form-control me-2" placeholder="CSS Class" value="${data?data.cssClass:''}" required>
+        <button type="button" class="btn btn-sm btn-outline-danger" onclick="this.parentElement.remove()">X</button>`;
+    stylesContainer.appendChild(row);
+}
+
+function gatherPolicy() {
+    const policy = {
+        id: document.getElementById('policyId').value,
+        title: document.getElementById('policyTitle').value,
+        description: document.getElementById('policyDesc').value,
+        defaultCssClass: document.getElementById('defaultCss').value,
+        styleGroups: []
+    };
+    document.querySelectorAll('#styleGroups > div').forEach(groupEl => {
+        const name = groupEl.querySelector('input[type="text"]').value;
+        const allow = groupEl.querySelector('input[type="checkbox"]').checked;
+        const styles = [];
+        groupEl.querySelectorAll('.styles > div').forEach(row => {
+            const inputs = row.querySelectorAll('input');
+            styles.push({name: inputs[0].value, cssClass: inputs[1].value});
+        });
+        policy.styleGroups.push({name: name, allowCombination: allow, styles: styles});
+    });
+    return policy;
+}
+
+document.getElementById('policyForm').addEventListener('submit', function(e){
+    e.preventDefault();
+    const policy = gatherPolicy();
+    const body = JSON.stringify(policy);
+    const project = document.body.dataset.project;
+    const template = document.body.dataset.template;
+    const component = document.body.dataset.component;
+    fetch(`/api/${project}/templates/${template}/component/policy?resource=${encodeURIComponent(component)}`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: body
+    }).then(r => {
+        if(r.ok){alert('Policy saved');} else {alert('Error saving policy');}
+    });
+});
+
+document.getElementById('existingPolicy').addEventListener('change', function(){
+    const id = this.value;
+    if(!id){
+        document.getElementById('policyId').value='';
+        document.getElementById('policyTitle').value='';
+        document.getElementById('policyDesc').value='';
+        document.getElementById('defaultCss').value='';
+        document.getElementById('styleGroups').innerHTML='';
+        return;
+    }
+    const project = document.body.dataset.project;
+    const component = document.body.dataset.component;
+    fetch(`/api/${project}/component/policy?resource=${encodeURIComponent(component)}&policyId=${id}`)
+        .then(r => r.json()).then(data => {
+            document.getElementById('policyId').value=id;
+            document.getElementById('policyTitle').value=data.title || '';
+            document.getElementById('policyDesc').value=data.description || '';
+            document.getElementById('defaultCss').value=data.defaultCssClass || '';
+            document.getElementById('styleGroups').innerHTML='';
+            if(data.styleGroups){
+                data.styleGroups.forEach(g => addGroup(g));
+            }
+        });
+});

--- a/src/main/resources/templates/deploy.html
+++ b/src/main/resources/templates/deploy.html
@@ -63,7 +63,7 @@
                 <div id="templatesList" class="row row-cols-1 row-cols-sm-2 g-2">
                     <div class="col" th:each="template : ${templates}">
                         <div class="border rounded p-2 bg-light text-center shadow-sm d-flex justify-content-between align-items-center">
-                            <span th:text="${template}"></span>
+                            <a th:href="@{/{projectName}/templates/{template}/components(projectName=${projectName},template=${template})}" class="text-decoration-none" th:text="${template}"></a>
 
                             <!-- Show Edit button only if template is NOT page-content or xf-web-variation -->
                             <a th:if="${template != 'page-content' and template != 'xf-web-variation'}"

--- a/src/main/resources/templates/policy-editor.html
+++ b/src/main/resources/templates/policy-editor.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Component Policy Editor</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script th:src="@{/js/policy-editor.js}"></script>
+</head>
+<body class="d-flex flex-column min-vh-100" th:data-project="${projectName}" th:data-template="${templateName}" th:data-component="${component}">
+<div th:replace="fragments/navbar :: navbar"></div>
+<main class="flex-grow-1 container mt-4">
+    <h3 th:text="${component}"></h3>
+    <div class="mb-3">
+        <label for="existingPolicy" class="form-label">Existing Policies</label>
+        <select id="existingPolicy" class="form-select">
+            <option value="">-- New Policy --</option>
+            <option th:each="entry : ${policies}" th:value="${entry.key}" th:text="${entry.value.title}"></option>
+        </select>
+    </div>
+    <form id="policyForm">
+        <input type="hidden" id="policyId">
+        <div class="mb-3">
+            <label class="form-label">Policy Title*</label>
+            <input type="text" id="policyTitle" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Description</label>
+            <textarea id="policyDesc" class="form-control" rows="2"></textarea>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Default CSS Class</label>
+            <input type="text" id="defaultCss" class="form-control">
+        </div>
+        <div id="styleGroups"></div>
+        <button type="button" class="btn btn-outline-primary mb-3" onclick="addGroup()">+ Add Style Group</button>
+        <div class="mt-3">
+            <button type="submit" class="btn btn-success">Save Policy</button>
+        </div>
+    </form>
+</main>
+<div th:replace="fragments/navbar :: footer"></div>
+</body>
+</html>

--- a/src/main/resources/templates/template-components.html
+++ b/src/main/resources/templates/template-components.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Template Components</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</head>
+<body class="d-flex flex-column min-vh-100">
+<div th:replace="fragments/navbar :: navbar"></div>
+<main class="flex-grow-1 container mt-4">
+    <h3 th:text="'Template: ' + ${templateName}"></h3>
+    <div class="row mt-3">
+        <div class="col-md-4 mb-3" th:each="comp : ${components}">
+            <a th:href="@{'/' + ${projectName} + '/templates/' + ${templateName} + '/component?resource=' + ${comp}}" class="text-decoration-none">
+                <div class="card h-100 text-center shadow-sm">
+                    <div class="card-body">
+                        <span th:text="${comp}"></span>
+                    </div>
+                </div>
+            </a>
+        </div>
+    </div>
+</main>
+<div th:replace="fragments/navbar :: footer"></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add policy controller and service to read allowed components, list policies, and persist component policies
- Introduce policy, style group, and style models for structured policy data
- Provide new Thymeleaf pages and JS for component list and policy editor with dynamic style groups
- Link templates in deploy view to component list

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_b_6891dab5bc708330a7920c50988ea966