### PR TITLE
Ensure edit component loads existing fields

### DIFF
--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -3,6 +3,8 @@ package com.aem.builder.controller;
 import com.aem.builder.model.DTO.ComponentRequest;
 import com.aem.builder.model.Enum.FieldType;
 import com.aem.builder.service.ComponentService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -85,6 +87,7 @@ public class ComponentController {
         model.addAttribute("fieldTypes", sortedByKey);
         model.addAttribute("componentGroups", componentService.getComponentGroups(project));
         model.addAttribute("editMode", false);
+        model.addAttribute("componentDataJson", "{}");
         // Components that can be extended (core components + existing ones)
         // Use a LinkedHashSet to avoid duplicates while preserving order
         Set<String> available = new LinkedHashSet<>();
@@ -140,6 +143,13 @@ public class ComponentController {
         }
         model.addAttribute("availableComponents", compMap);
         model.addAttribute("componentData", component);
+        String componentJson = "{}";
+        try {
+            componentJson = new ObjectMapper().writeValueAsString(component);
+        } catch (JsonProcessingException e) {
+            log.error("Error serializing component data", e);
+        }
+        model.addAttribute("componentDataJson", componentJson);
         return "create-component";
     }
 

--- a/src/main/java/com/aem/builder/model/Enum/FieldType.java
+++ b/src/main/java/com/aem/builder/model/Enum/FieldType.java
@@ -11,7 +11,7 @@ public enum FieldType {
     CHECKBOXGROUP("checkboxgroup", "granite/ui/components/coral/foundation/form/checkboxgroup"),
     RADIOGROUP("radiogroup", "granite/ui/components/coral/foundation/form/radiogroup"),
     SELECT("select", "granite/ui/components/coral/foundation/form/select"),
-    MULTISELECT("multiselect", "granite/ui/components/coral/foundation/form/multifield"),
+    MULTISELECT("multiselect", "granite/ui/components/coral/foundation/form/select"),
     PATHFIELD("pathfield", "granite/ui/components/coral/foundation/form/pathfield"),
     AUTOCOMPLETE("autocomplete", "granite/ui/components/coral/foundation/form/autocomplete"),
     DATEPICKER("datepicker", "granite/ui/components/coral/foundation/form/datepicker"),

--- a/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
@@ -222,6 +222,10 @@ public class ComponentServiceImpl implements ComponentService {
         String fieldName = nameAttr.startsWith("./") ? nameAttr.substring(2) : nameAttr;
         String resourceType = elem.getAttribute("sling:resourceType");
         String fieldType = getFieldTypeFromResource(resourceType);
+        String multipleAttr = Optional.ofNullable(elem.getAttribute("multiple")).orElse("");
+        if ("select".equals(fieldType) && "true".equalsIgnoreCase(multipleAttr.replace("{Boolean}", ""))) {
+            fieldType = "multiselect";
+        }
 
         List<OptionItem> options = null;
         List<ComponentField> nested = null;

--- a/src/main/resources/templates/create-component.html
+++ b/src/main/resources/templates/create-component.html
@@ -106,7 +106,7 @@
 </footer>
 <script th:inline="javascript">
   window.editMode = [[${editMode}]];
-  window.componentData = /*[[${componentData}]]*/ {};
+  window.componentData = JSON.parse(/*[[${componentDataJson}]]*/ '{}');
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Provide component data as JSON for edit component form and parse it client-side
- Initialize default JSON data for create form

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6892e383f2648330a9c71eaa03987a0f