### PR TITLE
feat: rewrite policy backend

### DIFF
--- a/src/main/java/com/aem/builder/service/impl/PolicyServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/PolicyServiceImpl.java
@@ -19,89 +19,91 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * Back end service that handles AEM style component policies. The implementation
+ * reads and writes the same .content.xml structure that AEM uses so the
+ * generated project can be imported into an actual AEM instance.
+ */
 @Slf4j
 @Service
 public class PolicyServiceImpl implements PolicyService {
 
-    private static final String BASE_PATH = "generated-projects";
+    private static final String PROJECTS_DIR = "generated-projects";
 
     private DocumentBuilder newBuilder() {
         try {
-            return DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            return factory.newDocumentBuilder();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    private String buildConfPath(String project) {
-        return BASE_PATH + "/" + project + "/ui.content/src/main/content/jcr_root/conf/" + project;
+    private String confRoot(String project) {
+        return PROJECTS_DIR + "/" + project + "/ui.content/src/main/content/jcr_root/conf/" + project;
     }
+
+    // ---------------------------------------------------------------------
+    // Read operations
+    // ---------------------------------------------------------------------
 
     @Override
     public List<String> getAllowedComponents(String project, String template) {
+        File mappingFile = new File(confRoot(project)
+                + "/settings/wcm/templates/" + template + "/policies/.content.xml");
+        if (!mappingFile.exists()) {
+            return List.of();
+        }
         try {
-            String mappingPath = buildConfPath(project) + "/settings/wcm/templates/" + template + "/policies/.content.xml";
-            File mappingFile = new File(mappingPath);
-            if (!mappingFile.exists()) {
-                return List.of();
-            }
             Document doc = newBuilder().parse(mappingFile);
-            Element root = doc.getDocumentElement();
-            String policyPath = null;
-            NodeList all = root.getElementsByTagName("*");
-            for (int i = 0; i < all.getLength(); i++) {
-                Element el = (Element) all.item(i);
-                if (el.hasAttribute("cq:policy")) {
-                    policyPath = el.getAttribute("cq:policy");
-                    break;
-                }
-            }
-            if (policyPath == null) {
-                return List.of();
-            }
-            String policyFilePath = buildConfPath(project) + "/settings/wcm/policies/" + policyPath + "/.content.xml";
-            File policyFile = new File(policyFilePath);
-            if (!policyFile.exists()) {
-                return List.of();
-            }
-            Document policyDoc = newBuilder().parse(policyFile);
-            Element polRoot = policyDoc.getDocumentElement();
-            String allowed = polRoot.getAttribute("cq:allowedComponents");
-            if (allowed == null || allowed.isBlank()) {
-                return List.of();
-            }
-            allowed = allowed.replace("[", "").replace("]", "");
-            return Arrays.stream(allowed.split(","))
+            Element policyEl = getPolicyElement(doc);
+            if (policyEl == null) return List.of();
+            String rel = policyEl.getAttribute("cq:policy");
+            if (rel == null || rel.isBlank()) return List.of();
+            File policyFile = new File(confRoot(project)
+                    + "/settings/wcm/policies/" + rel + "/.content.xml");
+            if (!policyFile.exists()) return List.of();
+            Document polDoc = newBuilder().parse(policyFile);
+            String allowed = polDoc.getDocumentElement().getAttribute("cq:allowedComponents");
+            if (allowed == null || allowed.isBlank()) return List.of();
+            return Arrays.stream(allowed.replaceAll("[\\[\\]]", "").split(","))
                     .map(String::trim)
                     .filter(s -> !s.isEmpty())
                     .collect(Collectors.toList());
         } catch (Exception e) {
-            log.error("Failed to read allowed components", e);
+            log.error("Unable to read allowed components", e);
             return List.of();
         }
+    }
+
+    private Element getPolicyElement(Document mappingDoc) {
+        Element root = mappingDoc.getDocumentElement();
+        Element content = getChild(root, "jcr:content");
+        return getChild(content, "root");
     }
 
     @Override
     public Map<String, PolicyModel> getPolicies(String project, String componentResourceType) {
         Map<String, PolicyModel> result = new LinkedHashMap<>();
-        String policyDirPath = buildConfPath(project) + "/settings/wcm/policies/" + componentResourceType;
-        File dir = new File(policyDirPath);
-        if (!dir.exists()) {
-            return result;
-        }
-        File[] policies = dir.listFiles(File::isDirectory);
-        if (policies == null) return result;
-        for (File p : policies) {
-            File content = new File(p, ".content.xml");
-            if (content.exists()) {
-                PolicyModel model = readPolicy(content);
-                if (model != null) {
-                    model.setId(p.getName());
-                    result.put(p.getName(), model);
-                }
+        File dir = new File(confRoot(project) + "/settings/wcm/policies/" + componentResourceType);
+        if (!dir.exists()) return result;
+        File[] folders = dir.listFiles(File::isDirectory);
+        if (folders == null) return result;
+        for (File folder : folders) {
+            File content = new File(folder, ".content.xml");
+            if (!content.exists()) continue;
+            PolicyModel model = readPolicy(content);
+            if (model != null) {
+                model.setId(folder.getName());
+                result.put(folder.getName(), model);
             }
         }
         return result;
@@ -109,8 +111,8 @@ public class PolicyServiceImpl implements PolicyService {
 
     @Override
     public PolicyModel loadPolicy(String project, String componentResourceType, String policyId) {
-        String path = buildConfPath(project) + "/settings/wcm/policies/" + componentResourceType + "/" + policyId + "/.content.xml";
-        File file = new File(path);
+        File file = new File(confRoot(project) + "/settings/wcm/policies/" + componentResourceType
+                + "/" + policyId + "/.content.xml");
         if (!file.exists()) return null;
         return readPolicy(file);
     }
@@ -123,29 +125,27 @@ public class PolicyServiceImpl implements PolicyService {
             model.setTitle(root.getAttribute("jcr:title"));
             model.setDescription(root.getAttribute("jcr:description"));
             model.setDefaultCssClass(root.getAttribute("cq:styleDefaultClasses"));
+
             String groupsAttr = root.getAttribute("cq:styleGroups");
             if (groupsAttr != null && !groupsAttr.isBlank()) {
-                groupsAttr = groupsAttr.replace("[", "").replace("]", "");
-                List<String> groupNames = Arrays.stream(groupsAttr.split(","))
+                List<String> groupNames = Arrays.stream(groupsAttr.replaceAll("[\\[\\]]", "").split(","))
                         .map(String::trim)
                         .filter(s -> !s.isEmpty())
                         .collect(Collectors.toList());
-                Element groupsElement = getChild(root, "cq:styleGroups");
-                for (String gName : groupNames) {
-                    Element gEl = getChild(groupsElement, gName);
+                Element groupsNode = getChild(root, "cq:styleGroups");
+                for (String name : groupNames) {
+                    Element gEl = getChild(groupsNode, name);
                     if (gEl == null) continue;
                     StyleGroupModel group = new StyleGroupModel();
-                    group.setName(gName);
+                    group.setName(name);
                     group.setAllowCombination(Boolean.parseBoolean(gEl.getAttribute("cq:styleAllowedCombination")));
-                    String names = gEl.getAttribute("cq:styleNames").replace("[", "").replace("]", "");
-                    String classes = gEl.getAttribute("cq:styleClasses").replace("[", "").replace("]", "");
-                    String[] nArr = names.split(",");
-                    String[] cArr = classes.split(",");
+                    String[] names = gEl.getAttribute("cq:styleNames").replaceAll("[\\[\\]]", "").split(",");
+                    String[] classes = gEl.getAttribute("cq:styleClasses").replaceAll("[\\[\\]]", "").split(",");
                     List<StyleModel> styles = new ArrayList<>();
-                    for (int i = 0; i < nArr.length; i++) {
-                        String n = nArr[i].trim();
+                    for (int i = 0; i < names.length; i++) {
+                        String n = names[i].trim();
                         if (n.isEmpty()) continue;
-                        String c = i < cArr.length ? cArr[i].trim() : "";
+                        String c = i < classes.length ? classes[i].trim() : "";
                         StyleModel sm = new StyleModel();
                         sm.setName(n);
                         sm.setCssClass(c);
@@ -155,50 +155,54 @@ public class PolicyServiceImpl implements PolicyService {
                     model.getStyleGroups().add(group);
                 }
             }
+
             return model;
         } catch (Exception e) {
-            log.error("Error reading policy", e);
+            log.error("Failed to parse policy file {}", file, e);
             return null;
         }
     }
 
+    // ---------------------------------------------------------------------
+    // Write operations
+    // ---------------------------------------------------------------------
+
     @Override
     public String savePolicy(String project, String template, String componentResourceType, PolicyModel policy) {
-        String policyId = policy.getId();
-        if (policyId == null || policyId.isBlank()) {
-            policyId = "policy_" + System.currentTimeMillis();
-        }
-        String base = buildConfPath(project);
-        File policyDir = new File(base + "/settings/wcm/policies/" + componentResourceType + "/" + policyId);
-        policyDir.mkdirs();
-        // ensure root policies .content.xml
+        String id = (policy.getId() != null && !policy.getId().isBlank())
+                ? policy.getId()
+                : "policy_" + System.currentTimeMillis();
+
+        String base = confRoot(project);
+
         ensureFolderContent(new File(base + "/settings/wcm/policies"));
-        // write policy file
-        File policyFile = new File(policyDir, ".content.xml");
-        writePolicyFile(policyFile, policy);
-        // update template policy mapping
-        String mappingPath = base + "/settings/wcm/templates/" + template + "/policies/.content.xml";
-        updateTemplateMapping(mappingPath, componentResourceType + "/" + policyId);
-        // touch template root .content.xml (ensure exists)
+
+        File policyDir = new File(base + "/settings/wcm/policies/" + componentResourceType + "/" + id);
+        policyDir.mkdirs();
+        writePolicyFile(new File(policyDir, ".content.xml"), policy);
+
+        File mapping = new File(base + "/settings/wcm/templates/" + template + "/policies/.content.xml");
+        updateTemplateMapping(mapping, componentResourceType + "/" + id);
+
         ensureFolderContent(new File(base + "/settings/wcm/templates/" + template));
-        return policyId;
+
+        return id;
     }
 
     private void ensureFolderContent(File folder) {
         folder.mkdirs();
         File content = new File(folder, ".content.xml");
-        if (!content.exists()) {
-            try {
-                Document doc = newBuilder().newDocument();
-                Element root = doc.createElement("jcr:root");
-                root.setAttribute("xmlns:jcr", "http://www.jcp.org/jcr/1.0");
-                root.setAttribute("xmlns:sling", "http://sling.apache.org/jcr/sling/1.0");
-                root.setAttribute("jcr:primaryType", "sling:Folder");
-                doc.appendChild(root);
-                writeDoc(doc, content);
-            } catch (Exception e) {
-                log.error("Failed to write folder .content.xml", e);
-            }
+        if (content.exists()) return;
+        try {
+            Document doc = newBuilder().newDocument();
+            Element root = doc.createElement("jcr:root");
+            root.setAttribute("xmlns:jcr", "http://www.jcp.org/jcr/1.0");
+            root.setAttribute("xmlns:sling", "http://sling.apache.org/jcr/sling/1.0");
+            root.setAttribute("jcr:primaryType", "sling:Folder");
+            doc.appendChild(root);
+            writeDoc(doc, content);
+        } catch (Exception e) {
+            log.error("Unable to create folder .content.xml {}", content, e);
         }
     }
 
@@ -216,35 +220,38 @@ public class PolicyServiceImpl implements PolicyService {
                 root.setAttribute("cq:styleDefaultClasses", policy.getDefaultCssClass());
             }
             if (!policy.getStyleGroups().isEmpty()) {
-                String groupNames = policy.getStyleGroups().stream()
+                String groups = policy.getStyleGroups().stream()
                         .map(StyleGroupModel::getName)
                         .collect(Collectors.joining(","));
-                root.setAttribute("cq:styleGroups", "[" + groupNames + "]");
-                Element groupsEl = doc.createElement("cq:styleGroups");
-                for (StyleGroupModel sg : policy.getStyleGroups()) {
-                    Element gEl = doc.createElement(sg.getName());
+                root.setAttribute("cq:styleGroups", "[" + groups + "]");
+                Element groupsNode = doc.createElement("cq:styleGroups");
+                for (StyleGroupModel g : policy.getStyleGroups()) {
+                    Element gEl = doc.createElement(g.getName());
                     gEl.setAttribute("jcr:primaryType", "nt:unstructured");
-                    gEl.setAttribute("cq:styleAllowedCombination", "{Boolean}" + sg.isAllowCombination());
-                    String names = sg.getStyles().stream().map(StyleModel::getName).collect(Collectors.joining(","));
-                    String classes = sg.getStyles().stream().map(StyleModel::getCssClass).collect(Collectors.joining(","));
+                    gEl.setAttribute("cq:styleAllowedCombination", "{Boolean}" + g.isAllowCombination());
+                    String names = g.getStyles().stream()
+                            .map(StyleModel::getName)
+                            .collect(Collectors.joining(","));
+                    String classes = g.getStyles().stream()
+                            .map(StyleModel::getCssClass)
+                            .collect(Collectors.joining(","));
                     gEl.setAttribute("cq:styleNames", "[" + names + "]");
                     gEl.setAttribute("cq:styleClasses", "[" + classes + "]");
-                    groupsEl.appendChild(gEl);
+                    groupsNode.appendChild(gEl);
                 }
-                root.appendChild(groupsEl);
+                root.appendChild(groupsNode);
             }
             doc.appendChild(root);
             writeDoc(doc, file);
         } catch (Exception e) {
-            log.error("Failed to write policy file", e);
+            log.error("Unable to write policy file {}", file, e);
         }
     }
 
-    private void updateTemplateMapping(String mappingPath, String policyRelPath) {
+    private void updateTemplateMapping(File mappingFile, String relPolicyPath) {
         try {
-            File file = new File(mappingPath);
-            if (!file.exists()) {
-                file.getParentFile().mkdirs();
+            if (!mappingFile.exists()) {
+                mappingFile.getParentFile().mkdirs();
                 Document doc = newBuilder().newDocument();
                 Element root = doc.createElement("jcr:root");
                 root.setAttribute("xmlns:sling", "http://sling.apache.org/jcr/sling/1.0");
@@ -258,16 +265,22 @@ public class PolicyServiceImpl implements PolicyService {
                 Element rootNode = doc.createElement("root");
                 rootNode.setAttribute("jcr:primaryType", "nt:unstructured");
                 rootNode.setAttribute("sling:resourceType", "wcm/core/components/policies/mapping");
-                rootNode.setAttribute("cq:policy", policyRelPath);
+                rootNode.setAttribute("cq:policy", relPolicyPath);
                 content.appendChild(rootNode);
                 root.appendChild(content);
                 doc.appendChild(root);
-                writeDoc(doc, file);
+                writeDoc(doc, mappingFile);
                 return;
             }
-            Document doc = newBuilder().parse(file);
+            Document doc = newBuilder().parse(mappingFile);
             Element root = doc.getDocumentElement();
             Element content = getChild(root, "jcr:content");
+            if (content == null) {
+                content = doc.createElement("jcr:content");
+                content.setAttribute("jcr:primaryType", "nt:unstructured");
+                content.setAttribute("sling:resourceType", "wcm/core/components/policies/mappings");
+                root.appendChild(content);
+            }
             Element rootNode = getChild(content, "root");
             if (rootNode == null) {
                 rootNode = doc.createElement("root");
@@ -275,10 +288,10 @@ public class PolicyServiceImpl implements PolicyService {
                 rootNode.setAttribute("sling:resourceType", "wcm/core/components/policies/mapping");
                 content.appendChild(rootNode);
             }
-            rootNode.setAttribute("cq:policy", policyRelPath);
-            writeDoc(doc, file);
+            rootNode.setAttribute("cq:policy", relPolicyPath);
+            writeDoc(doc, mappingFile);
         } catch (Exception e) {
-            log.error("Failed to update template policy mapping", e);
+            log.error("Unable to update template policy mapping {}", mappingFile, e);
         }
     }
 


### PR DESCRIPTION
## Summary
- replace old policy service with new implementation that reads/writes AEM style `.content.xml`
- support listing allowed components, existing policies and saving policy updates with style groups
- ensure template policy mappings and folder `.content.xml` files are created

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_b_6892e997acf08330b21009d65e10394a