### PR TITLE
feat: fetch allowed components from template layout

### DIFF
--- a/src/main/java/com/aem/builder/controller/PolicyController.java
+++ b/src/main/java/com/aem/builder/controller/PolicyController.java
@@ -1,6 +1,7 @@
 package com.aem.builder.controller;
 
-import com.aem.builder.model.policy.PolicyModel;
+import com.aem.builder.model.ComponentInfo;
+import com.aem.builder.model.PolicyModel;
 import com.aem.builder.service.PolicyService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,9 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @Controller
@@ -27,9 +26,11 @@ public class PolicyController {
                                  @PathVariable String template,
                                  Model model) {
         List<String> components = policyService.getAllowedComponents(project, template);
+        List<ComponentInfo> componentInfos = policyService.checkDesignDialogs(project, components);
         model.addAttribute("projectName", project);
         model.addAttribute("templateName", template);
         model.addAttribute("components", components);
+        model.addAttribute("components", componentInfos); // updated
         return "template-components";
     }
 
@@ -41,10 +42,7 @@ public class PolicyController {
                                    @PathVariable String template,
                                    @RequestParam("resource") String component,
                                    Model model) {
-        Map<String, PolicyModel>    policies = policyService.getPolicies(project, component);
-
-
-        log.info("Policies>>....>>{}");
+        List<PolicyModel>    policies = policyService.getPolicies(project, component);
         model.addAttribute("projectName", project);
         model.addAttribute("templateName", template);
         model.addAttribute("component", component);
@@ -57,6 +55,7 @@ public class PolicyController {
     public PolicyModel loadPolicy(@PathVariable String project,
                                   @RequestParam String resource,
                                   @RequestParam String policyId) {
+        log.info("......{}",policyService.loadPolicy(project, resource, policyId));
         return policyService.loadPolicy(project, resource, policyId);
     }
 
@@ -66,6 +65,7 @@ public class PolicyController {
                                              @PathVariable String template,
                                              @RequestParam String resource,
                                              @RequestBody PolicyModel policy) {
+
         String id = policyService.savePolicy(project, template, resource, policy);
         return ResponseEntity.ok(id);
     }

--- a/src/main/java/com/aem/builder/controller/PolicyController.java
+++ b/src/main/java/com/aem/builder/controller/PolicyController.java
@@ -41,7 +41,10 @@ public class PolicyController {
                                    @PathVariable String template,
                                    @RequestParam("resource") String component,
                                    Model model) {
-        Map<String, PolicyModel> policies = policyService.getPolicies(project, component);
+        Map<String, PolicyModel>    policies = policyService.getPolicies(project, component);
+
+
+        log.info("Policies>>....>>{}");
         model.addAttribute("projectName", project);
         model.addAttribute("templateName", template);
         model.addAttribute("component", component);

--- a/src/main/java/com/aem/builder/model/ComponentInfo.java
+++ b/src/main/java/com/aem/builder/model/ComponentInfo.java
@@ -1,0 +1,11 @@
+package com.aem.builder.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor
+@Data
+public class ComponentInfo {
+    private String name;
+    private boolean hasDesignDialog;
+}

--- a/src/main/java/com/aem/builder/model/PolicyModel.java
+++ b/src/main/java/com/aem/builder/model/PolicyModel.java
@@ -1,14 +1,9 @@
-package com.aem.builder.model.policy;
+package com.aem.builder.model;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
-import org.w3c.dom.Node;
-
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Represents an AEM component policy with style groups.
@@ -16,7 +11,7 @@ import java.util.Map;
 @Data
 @RequiredArgsConstructor
 public class PolicyModel {
-    private String id; // folder name of policy
+    private String id;
     private String title;
     private String description;
     private String defaultCssClass;

--- a/src/main/java/com/aem/builder/model/StyleGroupModel.java
+++ b/src/main/java/com/aem/builder/model/StyleGroupModel.java
@@ -1,4 +1,4 @@
-package com.aem.builder.model.policy;
+package com.aem.builder.model;
 
 import lombok.Data;
 import java.util.ArrayList;

--- a/src/main/java/com/aem/builder/model/StyleModel.java
+++ b/src/main/java/com/aem/builder/model/StyleModel.java
@@ -1,4 +1,4 @@
-package com.aem.builder.model.policy;
+package com.aem.builder.model;
 
 import lombok.Data;
 

--- a/src/main/java/com/aem/builder/model/policy/PolicyModel.java
+++ b/src/main/java/com/aem/builder/model/policy/PolicyModel.java
@@ -1,13 +1,20 @@
 package com.aem.builder.model.policy;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.w3c.dom.Node;
+
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents an AEM component policy with style groups.
  */
 @Data
+@RequiredArgsConstructor
 public class PolicyModel {
     private String id; // folder name of policy
     private String title;

--- a/src/main/java/com/aem/builder/service/PolicyService.java
+++ b/src/main/java/com/aem/builder/service/PolicyService.java
@@ -1,20 +1,36 @@
 package com.aem.builder.service;
 
-import com.aem.builder.model.policy.PolicyModel;
+import com.aem.builder.model.ComponentInfo;
+import com.aem.builder.model.PolicyModel;
+
 import java.util.List;
-import java.util.Map;
 
 public interface PolicyService {
+
     /**
      * Fetch allowed component resource types for the template's layout container.
      */
     List<String> getAllowedComponents(String project, String template);
 
     /**
-     * Fetch existing policies for a given component resource type.
-     * Key of map is policy id (folder name).
+     * Fetch allowed components from a policy path.
      */
-    Map<String, PolicyModel>  getPolicies(String project, String component);
+    List<String> getAllowedComponentsFromPolicy(String project, String policyRelPath);
+
+    /**
+     * Resolve all components in a given componentGroup.
+     */
+    List<String> resolveComponentsByGroup(String project, String groupName);
+
+    /**
+     * Extract the component name from its full path.
+     */
+    String getComponentNameOnly(String path);
+
+    /**
+     * Check if components contain design dialogs.
+     */
+    List<ComponentInfo> checkDesignDialogs(String project, List<String> components);
 
     /**
      * Save or update a policy and update template mappings.
@@ -23,7 +39,12 @@ public interface PolicyService {
     String savePolicy(String project, String template, String componentResourceType, PolicyModel policy);
 
     /**
-     * Load a policy by id.
+     * Fetch existing policies for a given component resource type.
+     */
+    List<PolicyModel> getPolicies(String project, String component);
+
+    /**
+     * Load a policy by ID.
      */
     PolicyModel loadPolicy(String project, String componentResourceType, String policyId);
 }

--- a/src/main/java/com/aem/builder/service/PolicyService.java
+++ b/src/main/java/com/aem/builder/service/PolicyService.java
@@ -14,7 +14,7 @@ public interface PolicyService {
      * Fetch existing policies for a given component resource type.
      * Key of map is policy id (folder name).
      */
-    Map<String, PolicyModel> getPolicies(String project, String componentResourceType);
+    Map<String, PolicyModel>  getPolicies(String project, String component);
 
     /**
      * Save or update a policy and update template mappings.

--- a/src/main/java/com/aem/builder/service/impl/PolicyServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/PolicyServiceImpl.java
@@ -5,10 +5,9 @@ import com.aem.builder.model.policy.StyleGroupModel;
 import com.aem.builder.model.policy.StyleModel;
 import com.aem.builder.service.PolicyService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
+import org.w3c.dom.*;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -19,6 +18,12 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -37,317 +42,507 @@ public class PolicyServiceImpl implements PolicyService {
     }
 
     private String buildConfPath(String project) {
-        return BASE_PATH + "/" + project + "/ui.content/src/main/content/jcr_root/conf/" + project;
+        String path = BASE_PATH + "/" + project + "/ui.content/src/main/content/jcr_root/conf/" + project;
+        log.info("🔧 buildConfPath() => {}", path);
+        return path;
     }
+
+
+
 
     @Override
     public List<String> getAllowedComponents(String project, String template) {
         try {
+            // Step 1: Get structure container path
             String base = buildConfPath(project) + "/settings/wcm/templates/" + template;
-            String structurePath = base + "/structure/.content.xml";
+            File structureFile = new File(base + "/structure/.content.xml");
+
             String containerPath = "root";
-            File structureFile = new File(structurePath);
             if (structureFile.exists()) {
-                try {
-                    Document structDoc = newBuilder().parse(structureFile);
-                    Element structRoot = structDoc.getDocumentElement();
-                    Element content = getChild(structRoot, "jcr:content");
-                    if (content != null) {
-                        NodeList children = content.getChildNodes();
-                        for (int i = 0; i < children.getLength(); i++) {
-                            if (children.item(i) instanceof Element el) {
-                                String found = findLayoutContainerPath(el, el.getTagName());
-                                if (found != null) {
-                                    containerPath = found;
-                                    break;
-                                }
+                Document doc = newBuilder().parse(structureFile);
+                Element root = doc.getDocumentElement();
+                Element content = getChild(root, "jcr:content");
+
+                if (content != null) {
+                    NodeList children = content.getChildNodes();
+                    for (int i = 0; i < children.getLength(); i++) {
+                        if (children.item(i) instanceof Element el) {
+                            String found = findLayoutContainerPath(el, el.getTagName());
+                            if (found != null) {
+                                containerPath = found;
+                                break;
                             }
                         }
                     }
-                } catch (Exception e) {
-                    log.error("Failed to parse template structure", e);
                 }
             }
 
-            String mappingPath = base + "/policies/.content.xml";
-            File mappingFile = new File(mappingPath);
-            if (!mappingFile.exists()) {
-                return List.of();
-            }
-            Document doc = newBuilder().parse(mappingFile);
-            Element root = doc.getDocumentElement();
-            Element content = getChild(root, "jcr:content");
-            if (content == null) {
-                return List.of();
-            }
-            Element current = content;
+            // Step 2: Get cq:policy path from template's policy mapping
+            File mappingFile = new File(base + "/policies/.content.xml");
+            if (!mappingFile.exists()) return List.of();
+
+            Document mapDoc = newBuilder().parse(mappingFile);
+            Element mappingRoot = getChild(mapDoc.getDocumentElement(), "jcr:content");
+            if (mappingRoot == null) return List.of();
+
+            Element current = mappingRoot;
             for (String seg : containerPath.split("/")) {
                 current = getChild(current, seg);
-                if (current == null) break;
+                if (current == null) return List.of();
             }
-            if (current == null || !current.hasAttribute("cq:policy")) {
-                return List.of();
-            }
-            String policyPath = current.getAttribute("cq:policy");
-            String policyFilePath = buildConfPath(project) + "/settings/wcm/policies/" + policyPath + "/.content.xml";
-            File policyFile = new File(policyFilePath);
-            if (!policyFile.exists()) {
-                return List.of();
-            }
-            Document policyDoc = newBuilder().parse(policyFile);
-            Element polRoot = policyDoc.getDocumentElement();
-            String allowed = polRoot.getAttribute("cq:allowedComponents");
-            if (allowed == null || allowed.isBlank()) {
-                return List.of();
-            }
-            allowed = allowed.replace("[", "").replace("]", "");
-            return Arrays.stream(allowed.split(","))
-                    .map(String::trim)
-                    .filter(s -> !s.isEmpty())
-                    .collect(Collectors.toList());
+
+            String policyRelPath = current.getAttribute("cq:policy");
+            if (policyRelPath == null || policyRelPath.isBlank()) return List.of();
+
+            // Step 3: Return allowed components (including resolving group entries)
+            return getAllowedComponentsFromPolicy(project, policyRelPath);
+
         } catch (Exception e) {
-            log.error("Failed to read allowed components", e);
             return List.of();
         }
     }
+
+
+
+    private List<String> getAllowedComponentsFromPolicy(String project, String policyRelPath) {
+        try {
+            File policyFile = new File(buildConfPath(project) + "/settings/wcm/policies/.content.xml");
+            if (!policyFile.exists()) return List.of();
+
+            Document doc = newBuilder().parse(policyFile);
+            Element current = doc.getDocumentElement();
+
+            for (String seg : policyRelPath.split("/")) {
+                current = getChild(current, seg);
+                if (current == null) return List.of();
+            }
+
+            String raw = current.getAttribute("components");
+            if (raw == null || raw.isBlank()) raw = current.getAttribute("cq:allowedComponents");
+            if (raw == null || raw.isBlank()) return List.of();
+
+            List<String> result = new ArrayList<>();
+            String[] entries = raw.replace("[", "").replace("]", "").split(",");
+
+            for (String entry : entries) {
+                entry = entry.trim();
+                if (entry.startsWith("group:")) {
+                    String groupName = entry.substring("group:".length()).trim();
+                    // Extract only component names from group resolution
+                    List<String> groupComponents = resolveComponentsByGroup(project, groupName);
+                    for (String comp : groupComponents) {
+                        result.add(getComponentNameOnly(comp));
+                    }
+                } else if (!entry.isEmpty()) {
+                    result.add(getComponentNameOnly(entry));
+                }
+            }
+
+            return result;
+
+        } catch (Exception e) {
+            return List.of();
+        }
+    }
+
+    private String getComponentNameOnly(String path) {
+        if (path == null || path.isBlank()) return path;
+        String[] parts = path.split("/");
+        return parts[parts.length - 1];  // Last segment is component name
+    }
+
+
+    private List<String> resolveComponentsByGroup(String project, String groupName) {
+        List<String> components = new ArrayList<>();
+        File baseDir = new File("generated-projects/" + project + "/ui.apps/src/main/content/jcr_root/apps/" + project + "/components");
+
+        if (!baseDir.exists()) return components;
+
+        try {
+            Files.walk(baseDir.toPath())
+                    .filter(path -> path.getFileName().toString().equals(".content.xml"))
+                    .forEach(path -> {
+                        try {
+                            Document doc = newBuilder().parse(path.toFile());
+                            Element root = doc.getDocumentElement();
+                            String groupAttr = root.getAttribute("componentGroup");
+
+                            if (groupAttr != null && groupAttr.equalsIgnoreCase(groupName)) {
+                                Path componentDir = path.getParent(); // directory of component
+                                String componentName = componentDir.getFileName().toString(); // just the name
+                                components.add(componentName);
+                            }
+                        } catch (Exception ignore) {}
+                    });
+        } catch (IOException e) {
+            // Optionally log the error
+        }
+
+        return components;
+    }
+
+
+
 
     private String findLayoutContainerPath(Element element, String path) {
         String resourceType = element.getAttribute("sling:resourceType");
         boolean isContainer = resourceType != null && resourceType.contains("container");
         boolean editable = element.hasAttribute("editable") && element.getAttribute("editable").contains("true");
-        if (isContainer && editable) {
-            return path;
-        }
+
+        if (isContainer && editable) return path;
+
         NodeList children = element.getChildNodes();
         for (int i = 0; i < children.getLength(); i++) {
             if (children.item(i) instanceof Element child) {
                 String found = findLayoutContainerPath(child, path + "/" + child.getTagName());
-                if (found != null) {
-                    return found;
-                }
+                if (found != null) return found;
             }
         }
-        if (isContainer) {
-            return path;
+
+        return isContainer ? path : null;
+    }
+
+    private Element getChild(Element parent, String name) {
+        NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            if (children.item(i) instanceof Element el && el.getTagName().equals(name)) {
+                return el;
+            }
         }
         return null;
     }
 
-    @Override
-    public Map<String, PolicyModel> getPolicies(String project, String componentResourceType) {
-        Map<String, PolicyModel> result = new LinkedHashMap<>();
-        String policyDirPath = buildConfPath(project) + "/settings/wcm/policies/" + componentResourceType;
-        File dir = new File(policyDirPath);
-        if (!dir.exists()) {
-            return result;
-        }
-        File[] policies = dir.listFiles(File::isDirectory);
-        if (policies == null) return result;
-        for (File p : policies) {
-            File content = new File(p, ".content.xml");
-            if (content.exists()) {
-                PolicyModel model = readPolicy(content);
-                if (model != null) {
-                    model.setId(p.getName());
-                    result.put(p.getName(), model);
-                }
-            }
-        }
-        return result;
-    }
 
-    @Override
-    public PolicyModel loadPolicy(String project, String componentResourceType, String policyId) {
-        String path = buildConfPath(project) + "/settings/wcm/policies/" + componentResourceType + "/" + policyId + "/.content.xml";
-        File file = new File(path);
-        if (!file.exists()) return null;
-        return readPolicy(file);
-    }
-
-    private PolicyModel readPolicy(File file) {
-        try {
-            Document doc = newBuilder().parse(file);
-            Element root = doc.getDocumentElement();
-            PolicyModel model = new PolicyModel();
-            model.setTitle(root.getAttribute("jcr:title"));
-            model.setDescription(root.getAttribute("jcr:description"));
-            model.setDefaultCssClass(root.getAttribute("cq:styleDefaultClasses"));
-            String groupsAttr = root.getAttribute("cq:styleGroups");
-            if (groupsAttr != null && !groupsAttr.isBlank()) {
-                groupsAttr = groupsAttr.replace("[", "").replace("]", "");
-                List<String> groupNames = Arrays.stream(groupsAttr.split(","))
-                        .map(String::trim)
-                        .filter(s -> !s.isEmpty())
-                        .collect(Collectors.toList());
-                Element groupsElement = getChild(root, "cq:styleGroups");
-                for (String gName : groupNames) {
-                    Element gEl = getChild(groupsElement, gName);
-                    if (gEl == null) continue;
-                    StyleGroupModel group = new StyleGroupModel();
-                    group.setName(gName);
-                    group.setAllowCombination(Boolean.parseBoolean(gEl.getAttribute("cq:styleAllowedCombination")));
-                    String names = gEl.getAttribute("cq:styleNames").replace("[", "").replace("]", "");
-                    String classes = gEl.getAttribute("cq:styleClasses").replace("[", "").replace("]", "");
-                    String[] nArr = names.split(",");
-                    String[] cArr = classes.split(",");
-                    List<StyleModel> styles = new ArrayList<>();
-                    for (int i = 0; i < nArr.length; i++) {
-                        String n = nArr[i].trim();
-                        if (n.isEmpty()) continue;
-                        String c = i < cArr.length ? cArr[i].trim() : "";
-                        StyleModel sm = new StyleModel();
-                        sm.setName(n);
-                        sm.setCssClass(c);
-                        styles.add(sm);
-                    }
-                    group.setStyles(styles);
-                    model.getStyleGroups().add(group);
-                }
-            }
-            return model;
-        } catch (Exception e) {
-            log.error("Error reading policy", e);
-            return null;
-        }
-    }
 
     @Override
     public String savePolicy(String project, String template, String componentResourceType, PolicyModel policy) {
         String policyId = policy.getId();
         if (policyId == null || policyId.isBlank()) {
             policyId = "policy_" + System.currentTimeMillis();
+            policy.setId(policyId);
         }
+
         String base = buildConfPath(project);
-        File policyDir = new File(base + "/settings/wcm/policies/" + componentResourceType + "/" + policyId);
-        policyDir.mkdirs();
-        // ensure root policies .content.xml
         ensureFolderContent(new File(base + "/settings/wcm/policies"));
-        // write policy file
-        File policyFile = new File(policyDir, ".content.xml");
-        writePolicyFile(policyFile, policy);
-        // update template policy mapping
+        File centralPolicyFile = new File(base + "/settings/wcm/policies/.content.xml");
+        writePolicyFile(centralPolicyFile, componentResourceType, policy);
+
         String mappingPath = base + "/settings/wcm/templates/" + template + "/policies/.content.xml";
         updateTemplateMapping(mappingPath, componentResourceType + "/" + policyId);
-        // touch template root .content.xml (ensure exists)
-        ensureFolderContent(new File(base + "/settings/wcm/templates/" + template));
+
         return policyId;
     }
 
+
+    private void writePolicyFile(File centralPolicyFile, String componentResourceType, PolicyModel policy) {
+        try {
+            Document doc;
+            Element root;
+
+            if (centralPolicyFile.exists()) {
+                doc = newBuilder().parse(centralPolicyFile);
+                root = doc.getDocumentElement();
+            } else {
+                doc = newBuilder().newDocument();
+                root = doc.createElement("jcr:root");
+                root.setAttribute("xmlns:jcr", "http://www.jcp.org/jcr/1.0");
+                root.setAttribute("xmlns:cq", "http://www.day.com/jcr/cq/1.0");
+                root.setAttribute("xmlns:sling", "http://sling.apache.org/jcr/sling/1.0");
+                root.setAttribute("xmlns:nt", "http://www.jcp.org/jcr/nt/1.0");
+                root.setAttribute("jcr:primaryType", "cq:Page");
+                doc.appendChild(root);
+            }
+
+            Element componentEl = getOrCreateChild(doc, root, componentResourceType);
+
+            // Dynamically generate policy node name
+            String policyNodeName = "policy_" + System.currentTimeMillis();
+
+            Element policyEl = doc.createElement(policyNodeName);
+            policyEl.setAttribute("jcr:primaryType", "nt:unstructured");
+            policyEl.setAttribute("jcr:title", policy.getTitle());
+            policyEl.setAttribute("jcr:description", policy.getDescription());
+            policyEl.setAttribute("cq:styleDefaultClasses", policy.getDefaultCssClass());
+            policyEl.setAttribute("sling:resourceType", "wcm/core/components/policy/policy");
+            policyEl.setAttribute("jcr:lastModifiedBy", "admin");
+            policyEl.setAttribute("jcr:lastModified", "{Date}" + getCurrentDate());
+
+            // Add <jcr:content>
+            Element contentEl = doc.createElement("jcr:content");
+            contentEl.setAttribute("jcr:primaryType", "nt:unstructured");
+            policyEl.appendChild(contentEl);
+
+            // Add <cq:styleGroups> if any style groups exist
+            if (!policy.getStyleGroups().isEmpty()) {
+                Element styleGroupsEl = doc.createElement("cq:styleGroups");
+                styleGroupsEl.setAttribute("jcr:primaryType", "nt:unstructured");
+
+                for (int i = 0; i < policy.getStyleGroups().size(); i++) {
+                    StyleGroupModel group = policy.getStyleGroups().get(i);
+                    Element groupEl = doc.createElement("item" + i);
+                    groupEl.setAttribute("jcr:primaryType", "nt:unstructured");
+                    groupEl.setAttribute("cq:styleGroupLabel", group.getName());
+                    groupEl.setAttribute("cq:styleGroupMultiple", String.valueOf(group.isAllowCombination()));
+
+                    // <cq:styles>
+                    Element stylesEl = doc.createElement("cq:styles");
+                    stylesEl.setAttribute("jcr:primaryType", "nt:unstructured");
+
+                    for (int j = 0; j < group.getStyles().size(); j++) {
+                        StyleModel sm = group.getStyles().get(j);
+                        Element styleEl = doc.createElement("item" + j);
+                        styleEl.setAttribute("jcr:primaryType", "nt:unstructured");
+                        styleEl.setAttribute("cq:styleLabel", sm.getName());
+                        styleEl.setAttribute("cq:styleClasses", sm.getCssClass());
+                        styleEl.setAttribute("cq:styleId", "style_" + System.currentTimeMillis());
+                        stylesEl.appendChild(styleEl);
+                    }
+
+                    groupEl.appendChild(stylesEl);
+                    styleGroupsEl.appendChild(groupEl);
+                }
+
+                policyEl.appendChild(styleGroupsEl);
+            }
+
+            componentEl.appendChild(policyEl);
+            writeDoc(doc, centralPolicyFile);
+        } catch (Exception e) {
+            log.error("❌ Failed to merge policy into central file", e);
+        }
+    }
+
+    private String getCurrentDate() {
+        return ZonedDateTime.now(ZoneId.of("Asia/Kolkata"))
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"));
+    }
+    @Override
+    public Map<String, PolicyModel> getPolicies(String project, String componentName) {
+        Map<String, PolicyModel> policies = new LinkedHashMap<>();
+
+        try {
+            // Resolve resourceType using component's content.xml
+            String componentPath = "generated-projects/" + project + "/ui.apps/src/main/content/jcr_root/apps/" + project + "/components/" + componentName + "/.content.xml";
+            File componentFile = new File(componentPath);
+            if (!componentFile.exists()) {
+                log.warn("⚠️ Component not found: {}", componentPath);
+                return policies;
+            }
+
+            Document componentDoc = newBuilder().parse(componentFile);
+            Element componentRoot = componentDoc.getDocumentElement();
+            String resourceType = componentRoot.getAttribute("sling:resourceType");
+
+            if (resourceType == null || resourceType.isEmpty()) {
+                // Fallback: assume standard resourceType
+                resourceType = "apps/" + project + "/components/" + componentName;
+            }
+
+            // Now read the policies file
+            File policyFile = new File(buildConfPath(project) + "/settings/wcm/policies/.content.xml");
+            if (!policyFile.exists()) return policies;
+
+            Document policyDoc = newBuilder().parse(policyFile);
+            Element root = policyDoc.getDocumentElement();
+
+            // Traverse through resourceType segments (e.g., apps → project → components → component)
+            String[] segments = resourceType.split("/");
+            Element current = root;
+
+            for (String segment : segments) {
+                if (segment.isEmpty()) continue;
+                current = getChild(current, segment);
+                if (current == null) {
+                    log.warn("⚠️ Segment '{}' not found in path: {}", segment, resourceType);
+                    return policies;
+                }
+            }
+
+            // Extract all policy nodes under this component resourceType
+            NodeList children = current.getChildNodes();
+            for (int i = 0; i < children.getLength(); i++) {
+                Node child = children.item(i);
+                if (child.getNodeType() == Node.ELEMENT_NODE) {
+                    Element el = (Element) child;
+                    String name = el.getNodeName();
+
+                    if (name.startsWith("policy_")) {
+                        PolicyModel policy = new PolicyModel();
+                        policy.setId(name);
+                        policy.(el.getAttribute("jcr:title"));
+                        policy.setDescription(el.getAttribute("jcr:description"));
+                        policy.setAttributes(getAttributes(el));
+                        policies.put(name, policy);
+                    }
+                }
+            }
+
+        } catch (Exception e) {
+            log.error("❌ Error while loading policies for component '{}': {}", componentName, e.getMessage());
+        }
+
+        return policies;
+    }
+
+    @Override
+    public PolicyModel loadPolicy(String project, String componentResourceType, String policyId) {
+        try {
+            File policyFile = new File(buildConfPath(project) + "/settings/wcm/policies/.content.xml");
+            if (!policyFile.exists()) return null;
+
+            Document doc = newBuilder().parse(policyFile);
+            Element root = doc.getDocumentElement();
+            Element componentEl = getChild(root, componentResourceType);
+            if (componentEl == null) return null;
+
+            Element policyEl = getChild(componentEl, policyId);
+            if (policyEl == null) return null;
+
+            PolicyModel model = new PolicyModel();
+            model.setId(policyId);
+            model.setTitle(policyEl.getAttribute("jcr:title"));
+            model.setDescription(policyEl.getAttribute("jcr:description"));
+            model.setDefaultCssClass(policyEl.getAttribute("cq:styleDefaultClasses"));
+
+            Element styleGroupsEl = getChild(policyEl, "cq:styleGroups");
+            if (styleGroupsEl != null) {
+                List<StyleGroupModel> groups = new ArrayList<>();
+                NodeList groupNodes = styleGroupsEl.getChildNodes();
+                for (int i = 0; i < groupNodes.getLength(); i++) {
+                    Node groupNode = groupNodes.item(i);
+                    if (groupNode.getNodeType() != Node.ELEMENT_NODE) continue;
+                    Element groupEl = (Element) groupNode;
+
+                    StyleGroupModel group = new StyleGroupModel();
+                    group.setName(groupEl.getAttribute("cq:styleGroupLabel"));
+
+                    Element stylesEl = getChild(groupEl, "cq:styles");
+                    if (stylesEl != null) {
+                        List<StyleModel> styles = new ArrayList<>();
+                        NodeList styleNodes = stylesEl.getChildNodes();
+                        for (int j = 0; j < styleNodes.getLength(); j++) {
+                            Node styleNode = styleNodes.item(j);
+                            if (styleNode.getNodeType() != Node.ELEMENT_NODE) continue;
+                            Element styleEl = (Element) styleNode;
+
+                            StyleModel sm = new StyleModel();
+                            sm.setName(styleEl.getAttribute("cq:styleLabel"));
+                            sm.setCssClass(styleEl.getAttribute("cq:styleClasses"));
+                            styles.add(sm);
+                        }
+                        group.setStyles(styles);
+                    }
+
+                    groups.add(group);
+                }
+
+                model.setStyleGroups(groups);
+            }
+
+            return model;
+        } catch (Exception e) {
+            log.error("❌ Failed to load policy", e);
+            return null;
+        }
+    }
+
+
+
+
+
+
+    private void updateTemplateMapping(String mappingFilePath, String policyPath) {
+        try {
+            File mappingFile = new File(mappingFilePath);
+            Document doc;
+            Element root;
+
+            if (mappingFile.exists()) {
+                doc = newBuilder().parse(mappingFile);
+                root = doc.getDocumentElement();
+            } else {
+                doc = newBuilder().newDocument();
+                root = doc.createElement("jcr:root");
+                root.setAttribute("xmlns:jcr", "http://www.jcp.org/jcr/1.0");
+                root.setAttribute("xmlns:sling", "http://sling.apache.org/jcr/sling/1.0");
+                root.setAttribute("xmlns:nt", "http://www.jcp.org/jcr/nt/1.0");
+                root.setAttribute("jcr:primaryType", "nt:unstructured");
+                doc.appendChild(root);
+            }
+
+            String[] segments = policyPath.split("/");
+            String compType = segments[0];
+            String policyId = segments[1];
+
+            Element componentEl = getOrCreateChild(doc, root, compType);
+            componentEl.setAttribute("cq:policy", policyPath);
+
+            writeDoc(doc, mappingFile);
+        } catch (Exception e) {
+            log.error("❌ Failed to update template mapping file: " + mappingFilePath, e);
+        }
+    }
+
     private void ensureFolderContent(File folder) {
-        folder.mkdirs();
-        File content = new File(folder, ".content.xml");
-        if (!content.exists()) {
+        if (!folder.exists()) folder.mkdirs();
+
+        File contentXml = new File(folder, ".content.xml");
+        if (!contentXml.exists()) {
             try {
                 Document doc = newBuilder().newDocument();
                 Element root = doc.createElement("jcr:root");
                 root.setAttribute("xmlns:jcr", "http://www.jcp.org/jcr/1.0");
-                root.setAttribute("xmlns:sling", "http://sling.apache.org/jcr/sling/1.0");
-                root.setAttribute("jcr:primaryType", "sling:Folder");
-                doc.appendChild(root);
-                writeDoc(doc, content);
-            } catch (Exception e) {
-                log.error("Failed to write folder .content.xml", e);
-            }
-        }
-    }
-
-    private void writePolicyFile(File file, PolicyModel policy) {
-        try {
-            Document doc = newBuilder().newDocument();
-            Element root = doc.createElement("jcr:root");
-            root.setAttribute("xmlns:jcr", "http://www.jcp.org/jcr/1.0");
-            root.setAttribute("xmlns:cq", "http://www.day.com/jcr/cq/1.0");
-            root.setAttribute("xmlns:nt", "http://www.jcp.org/jcr/nt/1.0");
-            root.setAttribute("jcr:primaryType", "cq:Policy");
-            if (policy.getTitle() != null) root.setAttribute("jcr:title", policy.getTitle());
-            if (policy.getDescription() != null) root.setAttribute("jcr:description", policy.getDescription());
-            if (policy.getDefaultCssClass() != null && !policy.getDefaultCssClass().isBlank()) {
-                root.setAttribute("cq:styleDefaultClasses", policy.getDefaultCssClass());
-            }
-            if (!policy.getStyleGroups().isEmpty()) {
-                String groupNames = policy.getStyleGroups().stream()
-                        .map(StyleGroupModel::getName)
-                        .collect(Collectors.joining(","));
-                root.setAttribute("cq:styleGroups", "[" + groupNames + "]");
-                Element groupsEl = doc.createElement("cq:styleGroups");
-                for (StyleGroupModel sg : policy.getStyleGroups()) {
-                    Element gEl = doc.createElement(sg.getName());
-                    gEl.setAttribute("jcr:primaryType", "nt:unstructured");
-                    gEl.setAttribute("cq:styleAllowedCombination", "{Boolean}" + sg.isAllowCombination());
-                    String names = sg.getStyles().stream().map(StyleModel::getName).collect(Collectors.joining(","));
-                    String classes = sg.getStyles().stream().map(StyleModel::getCssClass).collect(Collectors.joining(","));
-                    gEl.setAttribute("cq:styleNames", "[" + names + "]");
-                    gEl.setAttribute("cq:styleClasses", "[" + classes + "]");
-                    groupsEl.appendChild(gEl);
-                }
-                root.appendChild(groupsEl);
-            }
-            doc.appendChild(root);
-            writeDoc(doc, file);
-        } catch (Exception e) {
-            log.error("Failed to write policy file", e);
-        }
-    }
-
-    private void updateTemplateMapping(String mappingPath, String policyRelPath) {
-        try {
-            File file = new File(mappingPath);
-            if (!file.exists()) {
-                file.getParentFile().mkdirs();
-                Document doc = newBuilder().newDocument();
-                Element root = doc.createElement("jcr:root");
-                root.setAttribute("xmlns:sling", "http://sling.apache.org/jcr/sling/1.0");
-                root.setAttribute("xmlns:cq", "http://www.day.com/jcr/cq/1.0");
-                root.setAttribute("xmlns:jcr", "http://www.jcp.org/jcr/1.0");
                 root.setAttribute("xmlns:nt", "http://www.jcp.org/jcr/nt/1.0");
-                root.setAttribute("jcr:primaryType", "cq:Page");
-                Element content = doc.createElement("jcr:content");
-                content.setAttribute("jcr:primaryType", "nt:unstructured");
-                content.setAttribute("sling:resourceType", "wcm/core/components/policies/mappings");
-                Element rootNode = doc.createElement("root");
-                rootNode.setAttribute("jcr:primaryType", "nt:unstructured");
-                rootNode.setAttribute("sling:resourceType", "wcm/core/components/policies/mapping");
-                rootNode.setAttribute("cq:policy", policyRelPath);
-                content.appendChild(rootNode);
-                root.appendChild(content);
+                root.setAttribute("jcr:primaryType", "nt:unstructured");
                 doc.appendChild(root);
-                writeDoc(doc, file);
+                writeDoc(doc, contentXml);
+            } catch (Exception e) {
+                log.error("⚠️ Failed to create .content.xml at: " + contentXml.getPath(), e);
+            }
+        }
+    }
+
+    private Element getOrCreateChild(Document doc, Element parent, String childName) {
+        NodeList children = parent.getElementsByTagName(childName);
+        for (int i = 0; i < children.getLength(); i++) {
+            Node child = children.item(i);
+            if (child.getNodeType() == Node.ELEMENT_NODE && child.getNodeName().equals(childName)) {
+                return (Element) child;
+            }
+        }
+        Element newChild = doc.createElement(childName);
+        newChild.setAttribute("jcr:primaryType", "nt:unstructured");
+        parent.appendChild(newChild);
+        return newChild;
+    }
+
+
+
+    private void removeIfExists(Element parent, String nodeName) {
+        NodeList children = parent.getElementsByTagName(nodeName);
+        for (int i = 0; i < children.getLength(); i++) {
+            Node child = children.item(i);
+            if (child.getNodeType() == Node.ELEMENT_NODE && child.getNodeName().equals(nodeName)) {
+                parent.removeChild(child);
                 return;
             }
-            Document doc = newBuilder().parse(file);
-            Element root = doc.getDocumentElement();
-            Element content = getChild(root, "jcr:content");
-            Element rootNode = getChild(content, "root");
-            if (rootNode == null) {
-                rootNode = doc.createElement("root");
-                rootNode.setAttribute("jcr:primaryType", "nt:unstructured");
-                rootNode.setAttribute("sling:resourceType", "wcm/core/components/policies/mapping");
-                content.appendChild(rootNode);
-            }
-            rootNode.setAttribute("cq:policy", policyRelPath);
-            writeDoc(doc, file);
-        } catch (Exception e) {
-            log.error("Failed to update template policy mapping", e);
         }
-    }
-
-    private Element getChild(Element parent, String name) {
-        if (parent == null) return null;
-        NodeList nodes = parent.getElementsByTagName(name);
-        for (int i = 0; i < nodes.getLength(); i++) {
-            if (nodes.item(i).getParentNode() == parent) {
-                return (Element) nodes.item(i);
-            }
-        }
-        return null;
     }
 
     private void writeDoc(Document doc, File file) throws Exception {
         Transformer transformer = TransformerFactory.newInstance().newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
-        try (FileOutputStream fos = new FileOutputStream(file)) {
-            transformer.transform(new DOMSource(doc), new StreamResult(fos));
-        }
+        DOMSource source = new DOMSource(doc);
+        StreamResult result = new StreamResult(file);
+        transformer.transform(source, result);
     }
+
+
+
+
+
+
+
+
 }

--- a/src/main/resources/static/css/template-components.css
+++ b/src/main/resources/static/css/template-components.css
@@ -1,0 +1,20 @@
+.settings-icon {
+    position: absolute;
+    top: 10px;
+    right: 12px;
+    font-size: 1.2rem;
+    color: #0d6efd;
+}
+
+.card-wrapper {
+    position: relative;
+}
+
+.card:hover {
+    transform: scale(1.02);
+    transition: transform 0.2s ease-in-out;
+}
+
+.card-body {
+    position: relative;
+}

--- a/src/main/resources/static/js/policy-editor.js
+++ b/src/main/resources/static/js/policy-editor.js
@@ -8,9 +8,9 @@ function addGroup(data) {
     group.dataset.index = index;
     group.innerHTML = `
         <div class="d-flex justify-content-between align-items-center mb-2">
-            <input type="text" class="form-control me-2" placeholder="Group Name" value="${data?data.name:''}" required>
+            <input type="text" class="form-control me-2" placeholder="Group Name" value="${data ? data.name : ''}" required>
             <div class="form-check">
-                <input class="form-check-input" type="checkbox" ${data&&data.allowCombination?'checked':''}>
+                <input class="form-check-input" type="checkbox" ${data && data.allowCombination ? 'checked' : ''}>
                 <label class="form-check-label">Styles can be combined</label>
             </div>
             <button type="button" class="btn btn-sm btn-danger ms-2" onclick="this.closest('.border').remove()">Remove</button>
@@ -29,8 +29,8 @@ function addStyle(groupEl, data) {
     const row = document.createElement('div');
     row.className = 'd-flex mb-2';
     row.innerHTML = `
-        <input type="text" class="form-control me-2" placeholder="Style Name" value="${data?data.name:''}" required>
-        <input type="text" class="form-control me-2" placeholder="CSS Class" value="${data?data.cssClass:''}" required>
+        <input type="text" class="form-control me-2" placeholder="Style Name" value="${data ? data.name : ''}" required>
+        <input type="text" class="form-control me-2" placeholder="CSS Class" value="${data ? data.cssClass : ''}" required>
         <button type="button" class="btn btn-sm btn-outline-danger" onclick="this.parentElement.remove()">X</button>`;
     stylesContainer.appendChild(row);
 }
@@ -49,50 +49,89 @@ function gatherPolicy() {
         const styles = [];
         groupEl.querySelectorAll('.styles > div').forEach(row => {
             const inputs = row.querySelectorAll('input');
-            styles.push({name: inputs[0].value, cssClass: inputs[1].value});
+            styles.push({ name: inputs[0].value, cssClass: inputs[1].value });
         });
-        policy.styleGroups.push({name: name, allowCombination: allow, styles: styles});
+        policy.styleGroups.push({ name: name, allowCombination: allow, styles: styles });
     });
     return policy;
 }
 
-document.getElementById('policyForm').addEventListener('submit', function(e){
+document.getElementById('policyForm').addEventListener('submit', function (e) {
     e.preventDefault();
     const policy = gatherPolicy();
     const body = JSON.stringify(policy);
     const project = document.body.dataset.project;
     const template = document.body.dataset.template;
     const component = document.body.dataset.component;
+
     fetch(`/api/${project}/templates/${template}/component/policy?resource=${encodeURIComponent(component)}`, {
         method: 'POST',
-        headers: {'Content-Type': 'application/json'},
+        headers: { 'Content-Type': 'application/json' },
         body: body
     }).then(r => {
-        if(r.ok){alert('Policy saved');} else {alert('Error saving policy');}
+        if (r.ok) {
+            const isNew = !policy.id;
+            showMessage(isNew ? 'Policy created successfully' : 'Policy updated successfully', 'success');
+
+            setTimeout(() => {
+                window.location.href = `/${project}/templates/${template}/components`;
+            }, 2000);
+        } else {
+            showMessage('Error saving policy', 'danger');
+        }
+    }).catch(err => {
+        showMessage('Network error', 'danger');
     });
 });
 
-document.getElementById('existingPolicy').addEventListener('change', function(){
+document.getElementById('existingPolicy').addEventListener('change', function () {
     const id = this.value;
-    if(!id){
-        document.getElementById('policyId').value='';
-        document.getElementById('policyTitle').value='';
-        document.getElementById('policyDesc').value='';
-        document.getElementById('defaultCss').value='';
-        document.getElementById('styleGroups').innerHTML='';
+    if (!id) {
+        document.getElementById('policyId').value = '';
+        document.getElementById('policyTitle').value = '';
+        document.getElementById('policyDesc').value = '';
+        document.getElementById('defaultCss').value = '';
+        document.getElementById('styleGroups').innerHTML = '';
         return;
     }
+
     const project = document.body.dataset.project;
     const component = document.body.dataset.component;
     fetch(`/api/${project}/component/policy?resource=${encodeURIComponent(component)}&policyId=${id}`)
         .then(r => r.json()).then(data => {
-            document.getElementById('policyId').value=id;
-            document.getElementById('policyTitle').value=data.title || '';
-            document.getElementById('policyDesc').value=data.description || '';
-            document.getElementById('defaultCss').value=data.defaultCssClass || '';
-            document.getElementById('styleGroups').innerHTML='';
-            if(data.styleGroups){
+            document.getElementById('policyId').value = id;
+            document.getElementById('policyTitle').value = data.title || '';
+            document.getElementById('policyDesc').value = data.description || '';
+            document.getElementById('defaultCss').value = data.defaultCssClass || '';
+            document.getElementById('styleGroups').innerHTML = '';
+            if (data.styleGroups) {
                 data.styleGroups.forEach(g => addGroup(g));
             }
         });
 });
+
+function createNewPolicy() {
+    document.getElementById('existingPolicy').value = '';
+    document.getElementById('policyId').value = '';
+    document.getElementById('policyTitle').value = '';
+    document.getElementById('policyDesc').value = '';
+    document.getElementById('defaultCss').value = '';
+    document.getElementById('styleGroups').innerHTML = '';
+}
+
+// Update option label on title input
+document.getElementById('policyTitle').addEventListener('input', function () {
+    const select = document.getElementById('existingPolicy');
+    const selectedOption = select.options[select.selectedIndex];
+    if (selectedOption && selectedOption.value) {
+        selectedOption.textContent = this.value || '(Untitled)';
+    }
+});
+
+// Show success/error message
+function showMessage(text, type) {
+    const box = document.getElementById('messageBox');
+    box.textContent = text;
+    box.className = `alert alert-${type}`;
+    box.classList.remove('d-none');
+}

--- a/src/main/resources/static/js/template-components.js
+++ b/src/main/resources/static/js/template-components.js
@@ -1,0 +1,6 @@
+ function handleComponentClick(hasDesignDialog, event) {
+            if (!hasDesignDialog) {
+                event.preventDefault();
+                alert("This component does not have a design dialog.");
+            }
+        }

--- a/src/main/resources/templates/policy-editor.html
+++ b/src/main/resources/templates/policy-editor.html
@@ -4,42 +4,78 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Component Policy Editor</title>
+
+    <!-- Bootstrap -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" defer></script>
+
+    <!-- Custom Script -->
     <script th:src="@{/js/policy-editor.js}" defer></script>
+
+
 </head>
-<body class="d-flex flex-column min-vh-100" th:data-project="${projectName}" th:data-template="${templateName}" th:data-component="${component}">
+<body class="d-flex flex-column min-vh-100"
+      th:data-project="${projectName}"
+      th:data-template="${templateName}"
+      th:data-component="${component}">
+
 <div th:replace="fragments/navbar :: navbar"></div>
+
 <main class="flex-grow-1 container mt-4">
+
+    <!-- Back Button -->
+    <a th:href="@{'/' + ${projectName} + '/templates/' + ${templateName} + '/components'}"
+       class="btn btn-outline-secondary mb-3">
+        ← Back
+    </a>
+
+
     <h3 th:text="${component}"></h3>
+    <div id="messageBox" class="alert d-none" role="alert"></div>
+    <!-- Existing Policies -->
     <div class="mb-3">
         <label for="existingPolicy" class="form-label">Existing Policies</label>
-        <select id="existingPolicy" class="form-select">
-            <option value="">-- New Policy --</option>
-            <option th:each="entry : ${policies}" th:value="${entry.key}" th:text="${entry.value.title}"></option>
-        </select>
+        <div class="input-group">
+            <select id="existingPolicy" class="form-select">
+                <option value="">New Policy</option>
+                <option th:each="policy : ${policies}" th:value="${policy.id}" th:text="${policy.title}"></option>
+            </select>
+            <button type="button" class="btn btn-outline-secondary" onclick="createNewPolicy()">➕</button>
+        </div>
     </div>
+
+    <!-- Policy Form -->
     <form id="policyForm">
         <input type="hidden" id="policyId">
+
         <div class="mb-3">
             <label class="form-label">Policy Title*</label>
             <input type="text" id="policyTitle" class="form-control" required>
         </div>
+
         <div class="mb-3">
             <label class="form-label">Description</label>
             <textarea id="policyDesc" class="form-control" rows="2"></textarea>
         </div>
+
         <div class="mb-3">
             <label class="form-label">Default CSS Class</label>
             <input type="text" id="defaultCss" class="form-control">
         </div>
+
         <div id="styleGroups"></div>
+
         <button type="button" class="btn btn-outline-primary mb-3" onclick="addGroup()">+ Add Style Group</button>
+
         <div class="mt-3">
             <button type="submit" class="btn btn-success">Save Policy</button>
         </div>
     </form>
 </main>
+
 <div th:replace="fragments/navbar :: footer"></div>
+
+<!-- Bootstrap Icons (optional) -->
+<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
 </body>
 </html>

--- a/src/main/resources/templates/template-components.html
+++ b/src/main/resources/templates/template-components.html
@@ -4,25 +4,45 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Template Components</title>
+
+    <!-- Bootstrap -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" defer></script>
+    <script th:src="@{/js/template-components.js}" defer></script>
+
 </head>
 <body class="d-flex flex-column min-vh-100">
 <div th:replace="fragments/navbar :: navbar"></div>
+
 <main class="flex-grow-1 container mt-4">
+    <!-- Back Button -->
+    <a th:href="@{'/'+${projectName}}" class="btn btn-outline-secondary mb-3">
+        ← Back
+    </a>
+
+    <!-- Template Name Heading -->
     <h3 th:text="'Template: ' + ${templateName}"></h3>
+
+    <!-- Components Grid -->
     <div class="row mt-3">
         <div class="col-md-4 mb-3" th:each="comp : ${components}">
-            <a th:href="@{'/' + ${projectName} + '/templates/' + ${templateName} + '/component?resource=' + ${comp}}" class="text-decoration-none">
-                <div class="card h-100 text-center shadow-sm">
-                    <div class="card-body">
-                        <span th:text="${comp}"></span>
+            <div class="card-wrapper">
+                <a th:href="@{'/' + ${projectName} + '/templates/' + ${templateName} + '/component?resource=' + ${comp.name}}"
+                   th:onclick="'handleComponentClick(' + ${comp.hasDesignDialog} + ', event)'"
+                   class="text-decoration-none">
+                    <div class="card h-100 text-center shadow-sm">
+                        <div class="card-body pt-4">
+                            <i class="bi bi-gear-fill settings-icon" th:if="${comp.hasDesignDialog}" title="Has Design Dialog"></i>
+                            <span th:text="${comp.name}"></span>
+                        </div>
                     </div>
-                </div>
-            </a>
+                </a>
+            </div>
         </div>
     </div>
 </main>
+
 <div th:replace="fragments/navbar :: footer"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- parse template structure to locate layout container
- fetch allowed components from the corresponding policy

## Testing
- `./mvnw -q test` *(fails: Failed to fetch maven distribution)*
- `mvn -q test` *(fails: Could not transfer parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6892f21e089483308c3f16d045611297