### PR TITLE
Show component and template source on deploy page

### DIFF
--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -186,4 +186,11 @@ public class ComponentController {
         return ResponseEntity.ok(isAvailable); // true means name is available
     }
 
+    @GetMapping("/{projectName}/component/source")
+    @ResponseBody
+    public Map<String, String> getComponentSource(@PathVariable String projectName,
+                                                  @RequestParam String componentName) {
+        return componentService.getComponentSource(projectName, componentName);
+    }
+
 }

--- a/src/main/java/com/aem/builder/controller/TemplateController.java
+++ b/src/main/java/com/aem/builder/controller/TemplateController.java
@@ -136,11 +136,10 @@ public class TemplateController {
 
 
 
+    @GetMapping("/{projectName}/template/source")
+    @ResponseBody
+    public Map<String, String> getTemplateSource(@PathVariable String projectName,
+                                                 @RequestParam String templateName) {
+        return templateService.getTemplateSource(projectName, templateName);
+    }
 }
-
-
-
-
-
-
-

--- a/src/main/java/com/aem/builder/service/ComponentService.java
+++ b/src/main/java/com/aem/builder/service/ComponentService.java
@@ -36,4 +36,7 @@ public interface ComponentService {
     //component checking
     boolean isComponentNameAvailable(String projectName, String componentName);
 
+    //view source
+    Map<String, String> getComponentSource(String projectName, String componentName);
+
 }

--- a/src/main/java/com/aem/builder/service/TemplateService.java
+++ b/src/main/java/com/aem/builder/service/TemplateService.java
@@ -8,6 +8,7 @@ import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 
 
@@ -35,4 +36,6 @@ public interface TemplateService {
 
 
     public void updateTemplate(TemplateModel updatedModel, String projectName, String oldTemplateName) throws ParserConfigurationException, IOException, SAXException, TransformerException;
+
+    Map<String, String> getTemplateSource(String projectName, String templateName);
 }

--- a/src/main/java/com/aem/builder/service/impl/TemplateServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/TemplateServiceImpl.java
@@ -29,10 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.*;
 
 
 @Service
@@ -425,6 +422,21 @@ public class TemplateServiceImpl implements TemplateService {
 
     }
 
+    @Override
+    public Map<String, String> getTemplateSource(String projectName, String templateName) {
+        Map<String, String> result = new HashMap<>();
+        String path = PROJECTS_DIR + "/" + projectName
+                + "/ui.content/src/main/content/jcr_root/conf/" + projectName
+                + "/settings/wcm/templates/" + templateName + "/.content.xml";
+        File file = new File(path);
+        try {
+            result.put("html", file.exists() ? Files.readString(file.toPath()) : "");
+        } catch (IOException e) {
+            result.put("html", "");
+        }
+        result.put("java", "");
+        return result;
+    }
 
 
 }

--- a/src/main/resources/static/js/deploy.js
+++ b/src/main/resources/static/js/deploy.js
@@ -42,21 +42,33 @@
     function openComponentModal() {
         const projectName = getProjectName();
         fetch(`/fetch-components/${projectName}`)
-            .then(res => res.json())
+            .then(res => {
+                if (!res.ok) {
+                    throw new Error('Failed to load components');
+                }
+                return res.json();
+            })
             .then(data => {
                 renderList('componentList', data, selectedComponents, 'component');
                 new bootstrap.Modal(document.getElementById('componentModal')).show();
-            });
+            })
+            .catch(err => console.error('Error fetching components:', err));
     }
 
     function openTemplateModal() {
         const projectName = getProjectName();
         fetch(`/fetch-templates/${projectName}`)
-            .then(res => res.json())
+            .then(res => {
+                if (!res.ok) {
+                    throw new Error('Failed to load templates');
+                }
+                return res.json();
+            })
             .then(data => {
                 renderList('templateList', data, selectedTemplates, 'template');
                 new bootstrap.Modal(document.getElementById('templateModal')).show();
-            });
+            })
+            .catch(err => console.error('Error fetching templates:', err));
     }
 
     function addSelected(type) {
@@ -160,20 +172,42 @@
 
     function viewComponent(project, component) {
         fetch(`/${project}/component/source?componentName=${component}`)
-            .then(res => res.json())
+            .then(res => {
+                if (!res.ok) {
+                    throw new Error('Failed to load component source');
+                }
+                return res.json();
+            })
             .then(data => {
                 document.getElementById('htmlCode').textContent = data.html || '';
                 document.getElementById('javaCode').textContent = data.java || 'No Java class';
                 new bootstrap.Modal(document.getElementById('codeModal')).show();
+            })
+            .catch(err => {
+                document.getElementById('htmlCode').textContent = 'Error loading component source';
+                document.getElementById('javaCode').textContent = '';
+                new bootstrap.Modal(document.getElementById('codeModal')).show();
+                console.error('Error fetching component source:', err);
             });
     }
 
     function viewTemplate(project, template) {
         fetch(`/${project}/template/source?templateName=${template}`)
-            .then(res => res.json())
+            .then(res => {
+                if (!res.ok) {
+                    throw new Error('Failed to load template source');
+                }
+                return res.json();
+            })
             .then(data => {
                 document.getElementById('htmlCode').textContent = data.html || '';
                 document.getElementById('javaCode').textContent = data.java || 'No Java class';
                 new bootstrap.Modal(document.getElementById('codeModal')).show();
+            })
+            .catch(err => {
+                document.getElementById('htmlCode').textContent = 'Error loading template source';
+                document.getElementById('javaCode').textContent = '';
+                new bootstrap.Modal(document.getElementById('codeModal')).show();
+                console.error('Error fetching template source:', err);
             });
     }

--- a/src/main/resources/static/js/deploy.js
+++ b/src/main/resources/static/js/deploy.js
@@ -157,3 +157,23 @@
         document.getElementById('deployBtn').disabled = true;
         return true;
     }
+
+    function viewComponent(project, component) {
+        fetch(`/${project}/component/source?componentName=${component}`)
+            .then(res => res.json())
+            .then(data => {
+                document.getElementById('htmlCode').textContent = data.html || '';
+                document.getElementById('javaCode').textContent = data.java || 'No Java class';
+                new bootstrap.Modal(document.getElementById('codeModal')).show();
+            });
+    }
+
+    function viewTemplate(project, template) {
+        fetch(`/${project}/template/source?templateName=${template}`)
+            .then(res => res.json())
+            .then(data => {
+                document.getElementById('htmlCode').textContent = data.html || '';
+                document.getElementById('javaCode').textContent = data.java || 'No Java class';
+                new bootstrap.Modal(document.getElementById('codeModal')).show();
+            });
+    }

--- a/src/main/resources/templates/deploy.html
+++ b/src/main/resources/templates/deploy.html
@@ -48,7 +48,8 @@
                         <div class="border rounded p-2 bg-light text-center shadow-sm d-flex justify-content-between align-items-center">
                             <span th:text="${component}"></span>
                             <a th:if="${#lists.contains(editableComponents, component)}"
-                               th:href="@{/{projectName}/editcomponent(componentName=${component}, projectName=${projectName})}"
+                               href="#"
+                               th:attr="onclick='viewComponent(\'' + ${projectName} + '\',\'' + ${component} + '\')'"
                                class="btn btn-sm btn-outline-secondary ms-2">Edit</a>
                         </div>
                     </div>
@@ -72,7 +73,8 @@
 
                             <!-- Show Edit button only if template is NOT page-content or xf-web-variation -->
                             <a th:if="${template != 'page-content' and template != 'xf-web-variation'}"
-                               th:href="@{/{projectName}/edittemplate(templateName=${template}, projectName=${projectName})}"
+                               href="#"
+                               th:attr="onclick='viewTemplate(\'' + ${projectName} + '\',\'' + ${template} + '\')'"
                                class="btn btn-sm btn-outline-secondary ms-2">Edit</a>
                         </div>
                     </div>
@@ -114,6 +116,36 @@
             </div>
             <div class="modal-footer">
                 <button class="btn btn-primary" onclick="addSelectedTemplates()">Add Selected</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Code Modal -->
+<div class="modal fade" id="codeModal" tabindex="-1">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Source Viewer</h5>
+                <button class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <ul class="nav nav-tabs" role="tablist">
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link active" id="html-tab" data-bs-toggle="tab" data-bs-target="#htmlContent" type="button" role="tab">HTML</button>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link" id="java-tab" data-bs-toggle="tab" data-bs-target="#javaContent" type="button" role="tab">Java</button>
+                    </li>
+                </ul>
+                <div class="tab-content pt-3">
+                    <div class="tab-pane fade show active" id="htmlContent" role="tabpanel">
+                        <pre><code id="htmlCode"></code></pre>
+                    </div>
+                    <div class="tab-pane fade" id="javaContent" role="tabpanel">
+                        <pre><code id="javaCode"></code></pre>
+                    </div>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Show component and template HTML/Java source in a modal on the deploy page
- Add backend endpoints to retrieve component and template source code

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6892f65a15888330ae95d85efdf706cf