### PR TITLE
feat: display component sources in edit mode

### DIFF
--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -110,6 +110,7 @@ public class ComponentController {
                                         @PathVariable String projectName,
                                         Model model) {
         ComponentRequest component = componentService.loadComponent(projectName, componentName);
+        Map<String, String> sources = componentService.loadComponentSources(projectName, componentName);
         model.addAttribute("projectName", projectName);
 
         var typeResourceMap = FieldType.getTypeResourceMap();
@@ -140,6 +141,8 @@ public class ComponentController {
         }
         model.addAttribute("availableComponents", compMap);
         model.addAttribute("componentData", component);
+        model.addAttribute("componentHtml", sources.getOrDefault("html", ""));
+        model.addAttribute("componentJava", sources.getOrDefault("java", ""));
         return "create-component";
     }
 

--- a/src/main/java/com/aem/builder/service/ComponentService.java
+++ b/src/main/java/com/aem/builder/service/ComponentService.java
@@ -31,6 +31,8 @@ public interface ComponentService {
 
     ComponentRequest loadComponent(String projectName, String componentName);
 
+    Map<String, String> loadComponentSources(String projectName, String componentName);
+
     void updateComponent(String projectName, ComponentRequest request);
 
     //component checking

--- a/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -194,6 +195,44 @@ public class ComponentServiceImpl implements ComponentService {
         req.setSuperType(superType);
         req.setFields(fields);
         return req;
+    }
+
+    @Override
+    public Map<String, String> loadComponentSources(String projectName, String componentName) {
+        Map<String, String> sources = new HashMap<>();
+        Path htmlPath = Paths.get(PROJECTS_DIR, projectName,
+                "ui.apps/src/main/content/jcr_root/apps", projectName,
+                "components", componentName, componentName + ".html");
+        if (Files.exists(htmlPath)) {
+            try {
+                sources.put("html", FileUtils.readFileToString(htmlPath.toFile(), StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                log.error("Failed to read component html for {}", componentName, e);
+            }
+        }
+
+        Path javaRoot = Paths.get(PROJECTS_DIR, projectName, "core/src/main/java");
+        String modelFile = capitalize(componentName) + "Model.java";
+        try (Stream<Path> paths = Files.walk(javaRoot)) {
+            paths.filter(Files::isRegularFile)
+                    .filter(p -> p.getFileName().toString().equals(modelFile))
+                    .findFirst()
+                    .ifPresent(p -> {
+                        try {
+                            sources.put("java", FileUtils.readFileToString(p.toFile(), StandardCharsets.UTF_8));
+                        } catch (IOException e) {
+                            log.error("Failed to read component model for {}", componentName, e);
+                        }
+                    });
+        } catch (IOException e) {
+            log.error("Failed to locate model file for {}", componentName, e);
+        }
+        return sources;
+    }
+
+    private String capitalize(String input) {
+        return (input == null || input.isEmpty()) ? input
+                : input.substring(0, 1).toUpperCase() + input.substring(1);
     }
 
     @Override

--- a/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
@@ -166,15 +166,18 @@ public class ComponentServiceImpl implements ComponentService {
                         if (tabs != null) {
                             Element tabsItems = (Element) tabs.getElementsByTagName("items").item(0);
                             if (tabsItems != null) {
-                                Element tab1 = (Element) tabsItems.getElementsByTagName("tab1").item(0);
-                                if (tab1 != null) {
-                                    Element tabItems = (Element) tab1.getElementsByTagName("items").item(0);
-                                    if (tabItems != null) {
-                                        NodeList fieldNodes = tabItems.getChildNodes();
-                                        for (int i = 0; i < fieldNodes.getLength(); i++) {
-                                            Node node = fieldNodes.item(i);
-                                            if (node instanceof Element elem) {
-                                                fields.add(parseField(elem));
+                                NodeList tabNodes = tabsItems.getChildNodes();
+                                for (int t = 0; t < tabNodes.getLength(); t++) {
+                                    Node tabNode = tabNodes.item(t);
+                                    if (tabNode instanceof Element tabElement) {
+                                        Element tabItems = (Element) tabElement.getElementsByTagName("items").item(0);
+                                        if (tabItems != null) {
+                                            NodeList fieldNodes = tabItems.getChildNodes();
+                                            for (int i = 0; i < fieldNodes.getLength(); i++) {
+                                                Node node = fieldNodes.item(i);
+                                                if (node instanceof Element elem) {
+                                                    fields.add(parseField(elem));
+                                                }
                                             }
                                         }
                                     }

--- a/src/main/resources/static/js/create-component.js
+++ b/src/main/resources/static/js/create-component.js
@@ -224,7 +224,9 @@ document.addEventListener("DOMContentLoaded", function () {
       });
   }, 400);
 
-  componentNameInput.addEventListener('input', checkComponentNameAvailability);
+  if (!window.editMode) {
+    componentNameInput.addEventListener('input', checkComponentNameAvailability);
+  }
 
   window.validateFormFields = function () {
     const name = componentNameInput.value.trim();
@@ -240,7 +242,7 @@ document.addEventListener("DOMContentLoaded", function () {
       return;
     }
     const rows = document.querySelectorAll('#fieldsContainer .field-row, #fieldsContainer .nested-row');
-    if (mode === 'new' && rows.length === 0) {
+    if (!window.editMode && mode === 'new' && rows.length === 0) {
       createButton.disabled = true;
       return;
     }

--- a/src/main/resources/templates/create-component.html
+++ b/src/main/resources/templates/create-component.html
@@ -98,6 +98,14 @@
     <!-- Create Component Button -->
     <button type="submit" class="btn btn-primary" id="createButton" th:text="${editMode} ? 'Update Component' : 'Create Component'" disabled>Create Component</button>
   </form>
+
+  <div th:if="${editMode}" class="mt-4">
+    <h5>Component HTL</h5>
+    <pre class="bg-light p-3 overflow-auto" th:text="${componentHtml}"></pre>
+
+    <h5 class="mt-3">Component Java</h5>
+    <pre class="bg-light p-3 overflow-auto" th:text="${componentJava}"></pre>
+  </div>
 </div>
 
 <!-- Footer -->


### PR DESCRIPTION
## Summary
- load existing component HTML and Java sources in service
- expose source content on edit component page
- show read-only component code snippets when editing

## Testing
- `mvn test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6892fdac2c4083309c7109974a3edcd7