### PR TITLE
feat: allow project download as zip

### DIFF
--- a/src/main/java/com/aem/builder/controller/HomeController.java
+++ b/src/main/java/com/aem/builder/controller/HomeController.java
@@ -6,6 +6,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 
 import java.io.IOException;
 import java.util.List;
@@ -28,6 +33,17 @@ public class HomeController {
         model.addAttribute("projects", projects);
         return "dashboard";
     }
-    
+
+    @GetMapping("/download/{projectName}")
+    public ResponseEntity<ByteArrayResource> downloadProject(@PathVariable String projectName) throws IOException {
+        byte[] data = aemProjectService.getProjectZip(projectName);
+        ByteArrayResource resource = new ByteArrayResource(data);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + projectName + ".zip")
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .contentLength(data.length)
+                .body(resource);
+    }
+
 
 }

--- a/src/main/java/com/aem/builder/service/AemProjectService.java
+++ b/src/main/java/com/aem/builder/service/AemProjectService.java
@@ -9,5 +9,6 @@ import java.util.List;
 public interface AemProjectService {
     void generateAemProject(AemProjectModel aemProjectModel);
     List<ProjectDetails> getAllProjects();
+    byte[] getProjectZip(String projectName) throws java.io.IOException;
 
 }

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -78,6 +78,7 @@
           <div class="d-grid gap-2">
             <a th:href="@{'/' + ${project.name}}" class="btn btn-outline-primary btn-sm">🔍 View Details</a>
             <a th:href="@{'/show-folder?path=' + ${project.path}}" class="btn btn-outline-secondary btn-sm">📂 Show in Folder</a>
+            <a th:href="@{'/download/' + ${project.name}}" class="btn btn-outline-success btn-sm">⬇️ Download Zip</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add zip export endpoint for generated projects
- expose download zip button on dashboard

## Testing
- `./mvnw -q -e test` *(failed: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_b_6894936a30588330950df56f2c9de243