### PR TITLE
Fix component edit filtering and add project import validation

### DIFF
--- a/src/main/java/com/aem/builder/controller/DeployController.java
+++ b/src/main/java/com/aem/builder/controller/DeployController.java
@@ -34,8 +34,11 @@ public class DeployController {
         List<String> editable = compMap.entrySet().stream()
                 .filter(e -> {
                     String g = e.getValue();
-                    return g == null || (!g.equals(projectName + " - Content")
-                            && !g.equals(projectName + " - Structure")
+                    if (g != null) {
+                        g = g.trim();
+                    }
+                    return g == null || (!g.equalsIgnoreCase(projectName + " - Content")
+                            && !g.equalsIgnoreCase(projectName + " - Structure")
                             && !g.equals(".hidden"));
                 })
                 .map(java.util.Map.Entry::getKey)

--- a/src/main/java/com/aem/builder/controller/DeployController.java
+++ b/src/main/java/com/aem/builder/controller/DeployController.java
@@ -31,14 +31,15 @@ public class DeployController {
         List<String> templates = templateService.fetchTemplatesFromGeneratedProjects(projectName);
         var compMap = componentService.fetchComponentsWithGroups(projectName);
         List<String> components = new ArrayList<>(compMap.keySet());
+        String appName = componentService.getAppName(projectName);
         List<String> editable = compMap.entrySet().stream()
                 .filter(e -> {
                     String g = e.getValue();
                     if (g != null) {
                         g = g.trim();
                     }
-                    return g == null || (!g.equalsIgnoreCase(projectName + " - Content")
-                            && !g.equalsIgnoreCase(projectName + " - Structure")
+                    return g == null || (!g.equalsIgnoreCase(appName + " - Content")
+                            && !g.equalsIgnoreCase(appName + " - Structure")
                             && !g.equals(".hidden"));
                 })
                 .map(java.util.Map.Entry::getKey)

--- a/src/main/java/com/aem/builder/controller/HomeController.java
+++ b/src/main/java/com/aem/builder/controller/HomeController.java
@@ -7,6 +7,10 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -43,6 +47,18 @@ public class HomeController {
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .contentLength(data.length)
                 .body(resource);
+    }
+
+    @PostMapping("/import")
+    public String importProject(@RequestParam("file") MultipartFile file,
+                                RedirectAttributes redirectAttributes) {
+        try {
+            aemProjectService.importProject(file);
+            redirectAttributes.addFlashAttribute("message", "Project imported successfully!");
+        } catch (IOException e) {
+            redirectAttributes.addFlashAttribute("error", e.getMessage());
+        }
+        return "redirect:/dashboard";
     }
 
 

--- a/src/main/java/com/aem/builder/service/AemProjectService.java
+++ b/src/main/java/com/aem/builder/service/AemProjectService.java
@@ -10,5 +10,6 @@ public interface AemProjectService {
     void generateAemProject(AemProjectModel aemProjectModel);
     List<ProjectDetails> getAllProjects();
     byte[] getProjectZip(String projectName) throws java.io.IOException;
+    void importProject(org.springframework.web.multipart.MultipartFile file) throws java.io.IOException;
 
 }

--- a/src/main/java/com/aem/builder/service/ComponentService.java
+++ b/src/main/java/com/aem/builder/service/ComponentService.java
@@ -9,6 +9,11 @@ public interface ComponentService {
 
     List<String> fetchComponentsFromGeneratedProjects(String projectName);
 
+    /**
+     * Returns the actual application folder name under ui.apps for the given project.
+     */
+    String getAppName(String projectName);
+
     List<String> getAllComponents() throws IOException;
 
     void copySelectedComponents(List<String> selectedComponents, String targetPath, String projectName);

--- a/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
@@ -77,7 +77,7 @@ public class ComponentServiceImpl implements ComponentService {
                     String group = "";
                     if (contentXml.exists()) {
                         String content = FileGenerationUtil.readFile(contentXml);
-                        group = extractProperty(content, "componentGroup");
+                        group = extractProperty(content, "componentGroup").trim();
                     }
                     result.put(comp.getName(), group);
                 }
@@ -141,8 +141,8 @@ public class ComponentServiceImpl implements ComponentService {
             File contentXml = new File(basePath, ".content.xml");
             if (contentXml.exists()) {
                 String content = FileGenerationUtil.readFile(contentXml);
-                group = extractProperty(content, "componentGroup");
-                superType = extractProperty(content, "sling:resourceSuperType");
+                group = extractProperty(content, "componentGroup").trim();
+                superType = extractProperty(content, "sling:resourceSuperType").trim();
             }
 
             File dialogXml = new File(basePath + "/_cq_dialog/.content.xml");
@@ -694,7 +694,7 @@ public class ComponentServiceImpl implements ComponentService {
                     File contentXml = new File(comp, ".content.xml");
                     if (contentXml.exists()) {
                         String content = FileGenerationUtil.readFile(contentXml);
-                        String g = extractProperty(content, "componentGroup");
+                        String g = extractProperty(content, "componentGroup").trim();
                         if (!g.isEmpty()) {
                             groups.add(g);
                         }
@@ -702,9 +702,12 @@ public class ComponentServiceImpl implements ComponentService {
                 }
             }
         }
-        groups.removeIf(g -> g.equals(projectName + " - Content")
-                || g.equals(projectName + " - Structure")
-                || g.equals(".hidden"));
+        groups.removeIf(g -> {
+            String t = g.trim();
+            return t.equalsIgnoreCase(projectName + " - Content")
+                    || t.equalsIgnoreCase(projectName + " - Structure")
+                    || t.equals(".hidden");
+        });
         return groups.isEmpty() ? List.of(projectName) : new ArrayList<>(groups);
     }
 

--- a/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
@@ -67,6 +67,11 @@ public class ComponentServiceImpl implements ComponentService {
     }
 
     @Override
+    public String getAppName(String projectName) {
+        return resolveAppName(projectName);
+    }
+
+    @Override
     public List<String> fetchComponentsFromGeneratedProjects(String projectName) {
         String appName = resolveAppName(projectName);
         File componentsDir = new File(PROJECTS_DIR,

--- a/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
@@ -41,6 +41,17 @@ public class ComponentServiceImpl implements ComponentService {
 
     private static final String PROJECTS_DIR = "generated-projects";
 
+    /**
+     * Extracts a property value from an xml string, handling AEM typed values like
+     * <code>componentGroup="{String}my-group"</code>.
+     */
+    private String extractProperty(String content, String property) {
+        if (content == null) return "";
+        Pattern p = Pattern.compile(property + "=\"(?:\\{String\\})?([^\"]+)\"");
+        Matcher m = p.matcher(content);
+        return m.find() ? m.group(1) : "";
+    }
+
     @Override
     public List<String> fetchComponentsFromGeneratedProjects(String projectName) {
         File componentsDir = new File(PROJECTS_DIR,
@@ -66,12 +77,7 @@ public class ComponentServiceImpl implements ComponentService {
                     String group = "";
                     if (contentXml.exists()) {
                         String content = FileGenerationUtil.readFile(contentXml);
-                        if (content.contains("componentGroup")) {
-                            int idx = content.indexOf("componentGroup");
-                            int start = content.indexOf("\"", idx) + 1;
-                            int end = content.indexOf("\"", start);
-                            group = content.substring(start, end);
-                        }
+                        group = extractProperty(content, "componentGroup");
                     }
                     result.put(comp.getName(), group);
                 }
@@ -135,18 +141,8 @@ public class ComponentServiceImpl implements ComponentService {
             File contentXml = new File(basePath, ".content.xml");
             if (contentXml.exists()) {
                 String content = FileGenerationUtil.readFile(contentXml);
-                if (content.contains("componentGroup")) {
-                    int idx = content.indexOf("componentGroup");
-                    int start = content.indexOf("\"", idx) + 1;
-                    int end = content.indexOf("\"", start);
-                    group = content.substring(start, end);
-                }
-                if (content.contains("sling:resourceSuperType")) {
-                    int idx = content.indexOf("sling:resourceSuperType");
-                    int start = content.indexOf("\"", idx) + 1;
-                    int end = content.indexOf("\"", start);
-                    superType = content.substring(start, end);
-                }
+                group = extractProperty(content, "componentGroup");
+                superType = extractProperty(content, "sling:resourceSuperType");
             }
 
             File dialogXml = new File(basePath + "/_cq_dialog/.content.xml");
@@ -698,11 +694,9 @@ public class ComponentServiceImpl implements ComponentService {
                     File contentXml = new File(comp, ".content.xml");
                     if (contentXml.exists()) {
                         String content = FileGenerationUtil.readFile(contentXml);
-                        if (content.contains("componentGroup")) {
-                            int idx = content.indexOf("componentGroup");
-                            int start = content.indexOf("\"", idx) + 1;
-                            int end = content.indexOf("\"", start);
-                            groups.add(content.substring(start, end));
+                        String g = extractProperty(content, "componentGroup");
+                        if (!g.isEmpty()) {
+                            groups.add(g);
                         }
                     }
                 }

--- a/src/main/java/com/aem/builder/util/FileGenerationUtil.java
+++ b/src/main/java/com/aem/builder/util/FileGenerationUtil.java
@@ -33,8 +33,13 @@ public class FileGenerationUtil {
     public static void generateAllFiles(String projectName, ComponentRequest request) {
         logger.info("FILEGEN: Starting file generation for project: {}", projectName);
         try {
-            String basePath = "generated-projects/" + projectName + "/ui.apps/src/main/content/jcr_root/apps/"
-                    + projectName + "/components/";
+            String appsRoot = "generated-projects/" + projectName + "/ui.apps/src/main/content/jcr_root/apps";
+            String appName = projectName;
+            File[] dirs = new File(appsRoot).listFiles(File::isDirectory);
+            if (dirs != null && dirs.length > 0) {
+                appName = dirs[0].getName();
+            }
+            String basePath = appsRoot + "/" + appName + "/components/";
 
 
             Path javaSourceRoot = Paths.get("generated-projects/" + projectName + "/core/src/main/java/");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 spring:
   application:
     name: aembuilder
+  servlet:
+    multipart:
+      max-file-size: 200MB
+      max-request-size: 200MB
 
 server:
   port: 8081


### PR DESCRIPTION
## Summary
- ensure component groups are parsed correctly so structure/content/.hidden components don't show edit links
- add import endpoint and service to validate AEM project zips before adding to dashboard
