### PR TITLE
feat: add API to assign policy to template

### DIFF
--- a/src/main/java/com/aem/builder/controller/PolicyController.java
+++ b/src/main/java/com/aem/builder/controller/PolicyController.java
@@ -55,8 +55,22 @@ public class PolicyController {
         return "policies"; // Thymeleaf page for creating policy
     }
 
-    public String addPolicyToParticularTemplate() {
-        return "";
+    @PostMapping("/api/{project}/templates/{template}/policy")
+    @ResponseBody
+    public ResponseEntity<String> addPolicyToTemplate(@PathVariable String project,
+            @PathVariable String template,
+            @RequestBody PolicyRequest request) {
+        try {
+            String node = policyXmlUpdater.addPolicyToTemplate(project, template,
+                    request.getName(), request.getComponentPath(),
+                    request.getStyleDefaultClasses(),
+                    request.getStyleDefaultElement(), request.getStyles());
+            return ResponseEntity.ok(node);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("Error saving policy");
+        }
     }
 
 

--- a/src/main/java/com/aem/builder/service/TemplatePolicy.java
+++ b/src/main/java/com/aem/builder/service/TemplatePolicy.java
@@ -12,6 +12,11 @@ public interface TemplatePolicy {
     public void assignPolicyToTemplate(String projectName, String templateName,
                                        String policyNodeName) throws Exception;
 
+    String addPolicyToTemplate(String projectName, String templateName,
+                               String policyName, String componentPath,
+                               String styleDefaultClasses, String styleDefaultElement,
+                               Map<String, Map<String, String>> styles) throws Exception;
+
     public void saveOrUpdatePolicy(String projectName, String templateName, PolicyRequest request) throws Exception;
     List<String> getExistingPolicies(String projectName) throws Exception;
 

--- a/src/main/java/com/aem/builder/service/TemplatePolicy.java
+++ b/src/main/java/com/aem/builder/service/TemplatePolicy.java
@@ -10,7 +10,7 @@ public interface TemplatePolicy {
     public String addPolicy(String projectname,String policyName, String componentGroups,String styleDefaultClasses,
                             String styleDefaultElement, Map<String, Map<String, String>> styles) throws Exception ;
     public void assignPolicyToTemplate(String projectName, String templateName,
-                                       String policyNodeName) throws Exception;
+                                       String componentPath, String policyNodeName) throws Exception;
 
     String addPolicyToTemplate(String projectName, String templateName,
                                String policyName, String componentPath,

--- a/src/main/java/com/aem/builder/service/impl/TemplatePolicyImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/TemplatePolicyImpl.java
@@ -164,6 +164,17 @@ public class TemplatePolicyImpl implements TemplatePolicy {
         writeFile(templatePath, TemplateUtil.policyForParticularTemplate(policyNodeName, projectName));
     }
 
+    @Override
+    public String addPolicyToTemplate(String projectName, String templateName,
+                                      String policyName, String componentPath,
+                                      String styleDefaultClasses, String styleDefaultElement,
+                                      Map<String, Map<String, String>> styles) throws Exception {
+        String nodeName = addPolicy(projectName, policyName, componentPath,
+                styleDefaultClasses, styleDefaultElement, styles);
+        assignPolicyToTemplate(projectName, templateName, nodeName);
+        return nodeName;
+    }
+
     void writeFile(String path, String content) throws IOException {
         Path filePath = Paths.get(path);
         Files.createDirectories(filePath.getParent());


### PR DESCRIPTION
## Summary
- add `addPolicyToTemplate` helper in TemplatePolicy
- implement controller endpoint to assign policies to templates

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a6b690df3883308823663c21342586