### PR TITLE
feat: add API to assign policy to template

### DIFF
--- a/src/main/java/com/aem/builder/controller/PolicyController.java
+++ b/src/main/java/com/aem/builder/controller/PolicyController.java
@@ -33,8 +33,7 @@ public class PolicyController {
             @RequestParam String templateName,
             @RequestBody PolicyRequest request) {
         try {
-            System.out.println(request);
-            // This should create OR update the policy:
+            log.debug("Policy request: {}", request);
             policyXmlUpdater.saveOrUpdatePolicy(projectName, templateName, request);
             return ResponseEntity.ok("Policy saved");
         } catch (Exception e) {
@@ -55,8 +54,22 @@ public class PolicyController {
         return "policies"; // Thymeleaf page for creating policy
     }
 
-    public String addPolicyToParticularTemplate() {
-        return "";
+    @PostMapping("/api/{project}/templates/{template}/policy")
+    @ResponseBody
+    public ResponseEntity<String> addPolicyToTemplate(@PathVariable String project,
+            @PathVariable String template,
+            @RequestBody PolicyRequest request) {
+        try {
+            String node = policyXmlUpdater.addPolicyToTemplate(project, template,
+                    request.getName(), request.getComponentPath(),
+                    request.getStyleDefaultClasses(),
+                    request.getStyleDefaultElement(), request.getStyles());
+            return ResponseEntity.ok(node);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("Error saving policy");
+        }
     }
 
 

--- a/src/main/java/com/aem/builder/service/TemplatePolicy.java
+++ b/src/main/java/com/aem/builder/service/TemplatePolicy.java
@@ -10,7 +10,12 @@ public interface TemplatePolicy {
     public String addPolicy(String projectname,String policyName, String componentGroups,String styleDefaultClasses,
                             String styleDefaultElement, Map<String, Map<String, String>> styles) throws Exception ;
     public void assignPolicyToTemplate(String projectName, String templateName,
-                                       String policyNodeName) throws Exception;
+                                       String componentPath, String policyNodeName) throws Exception;
+
+    String addPolicyToTemplate(String projectName, String templateName,
+                               String policyName, String componentPath,
+                               String styleDefaultClasses, String styleDefaultElement,
+                               Map<String, Map<String, String>> styles) throws Exception;
 
     public void saveOrUpdatePolicy(String projectName, String templateName, PolicyRequest request) throws Exception;
     List<String> getExistingPolicies(String projectName) throws Exception;


### PR DESCRIPTION
## Summary
- build policy nodes under component-specific hierarchy and normalize component paths
- update policy mapping to reference the correct component path within templates
- handle existing policy updates and lookups across the entire policies tree
- normalize component paths during assignment and add structured logging

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a6b690df3883308823663c21342586