### PR TITLE
fetch parent tabs from superType dialog

### DIFF
--- a/src/main/java/com/aem/builder/controller/ComponentController.java
+++ b/src/main/java/com/aem/builder/controller/ComponentController.java
@@ -3,9 +3,11 @@ package com.aem.builder.controller;
 import com.aem.builder.model.DTO.ComponentRequest;
 import com.aem.builder.model.Enum.FieldType;
 import com.aem.builder.service.ComponentService;
+import com.aem.builder.util.FileGenerationUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -60,6 +62,7 @@ public class ComponentController {
             return "create";
         }
     }
+
     //component creation
     @GetMapping("/createComponent/{project}")
     public String showComponentForm(@PathVariable String project, Model model) {
@@ -81,10 +84,10 @@ public class ComponentController {
         model.addAttribute("fieldTypes", sortedByKey);
         model.addAttribute("componentGroups", componentService.getComponentGroups(project));
         model.addAttribute("editMode", false);
-        Map<String, String> compMap= componentService.fetchComponentSuperTypes(project);
+        Map<String, String> compMap = componentService.fetchComponentSuperTypes(project);
 
         model.addAttribute("availableComponents", compMap);
-        log.info("superTypessss...{}",compMap);
+        log.info("superTypessss...{}", compMap);
 
         return "create-component"; // Thymeleaf template
     }
@@ -108,8 +111,8 @@ public class ComponentController {
         model.addAttribute("componentGroups", componentService.getComponentGroups(projectName));
         model.addAttribute("editMode", true);
 
-        Map<String, String> compMap= componentService.fetchComponentSuperTypes(projectName);
-        log.info("superTypessss...{}",compMap);
+        Map<String, String> compMap = componentService.fetchComponentSuperTypes(projectName);
+        log.info("superTypessss...{}", compMap);
 
         model.addAttribute("availableComponents", compMap);
         model.addAttribute("componentData", component);
@@ -122,9 +125,10 @@ public class ComponentController {
     public String createComponent(@PathVariable String project,
                                   @ModelAttribute ComponentRequest request,
                                   RedirectAttributes redirectAttributes) {
+        log.info("Request Details,{}",request);
         try {
             componentService.generateComponent(project, request);
-            redirectAttributes.addFlashAttribute("message", request.getComponentName()+" Component created successfully!");
+            redirectAttributes.addFlashAttribute("message", request.getComponentName() + " Component created successfully!");
             return "redirect:/view/" + project;
         } catch (Exception e) {
             log.error("Error creating component", e);
@@ -139,7 +143,7 @@ public class ComponentController {
                                   RedirectAttributes redirectAttributes) {
         try {
             componentService.updateComponent(project, request);
-            redirectAttributes.addFlashAttribute("message", request.getComponentName()+" Component updated successfully!");
+            redirectAttributes.addFlashAttribute("message", request.getComponentName() + " Component updated successfully!");
             return "redirect:/view/" + project;
         } catch (Exception e) {
             log.error("Error updating component", e);
@@ -154,7 +158,7 @@ public class ComponentController {
                                   RedirectAttributes redirectAttributes) {
         try {
             componentService.deleteComponent(project, componentName);
-            redirectAttributes.addFlashAttribute("message", componentName+" Component deleted successfully!");
+            redirectAttributes.addFlashAttribute("message", componentName + " Component deleted successfully!");
         } catch (Exception e) {
             log.error("Error deleting component", e);
             redirectAttributes.addFlashAttribute("error", "Failed to delete component: " + e.getMessage());
@@ -162,19 +166,18 @@ public class ComponentController {
         return "redirect:/view/" + project;
     }
 
-//component checking
+    //component checking
     @GetMapping("/check-componentName/{projectName}")
     public ResponseEntity<Boolean> checkComponentNameExists(
             @PathVariable String projectName,
             @RequestParam String componentName) {
 
-        log.info("{}",componentName);
+        log.info("{}", componentName);
         log.info("check-component");
         boolean isAvailable = componentService.isComponentNameAvailable(projectName, componentName);
-        log.info("{}",isAvailable);
+        log.info("{}", isAvailable);
         return ResponseEntity.ok(isAvailable); // true means name is available
     }
-
 
 
     @GetMapping("/grouped-components/{projectName}")
@@ -184,6 +187,7 @@ public class ComponentController {
 
         return componentService.getComponentsByGroup(projectName);
     }
+
     @GetMapping("/policies-components/{projectName}")
     @ResponseBody
     public Map<String, List<Map<String, String>>> getGroupedComponents(@PathVariable String projectName) throws IOException {
@@ -211,6 +215,31 @@ public class ComponentController {
 
         return response;
     }
+
+
+    /*
+    Multifield java class name check
+     */
+    @GetMapping("/checkChildJavaClassName")
+    public ResponseEntity<Boolean> checkChildJavaClassName(
+            @RequestParam String projectName,
+            @RequestParam String fieldName) throws IOException {
+
+        boolean exists = FileGenerationUtil.checkModelFileExists(projectName, fieldName);
+        return ResponseEntity.ok(exists); // returns true or false
+    }
+
+
+//    logic for Check Parent Having tabs
+@PostMapping("/checkTabs")
+public Map<String, Object> checkIfParentHasTabs(@RequestBody Map<String, String> request) throws Exception {
+    String projectName = request.get("projectName");
+    String superType = request.get("superType");
+
+    log.info("Parent Tabs........., {}", componentService.getParentTabs(projectName, superType));
+    return componentService.getParentTabs(projectName, superType);
+}
+
 
 
 }

--- a/src/main/java/com/aem/builder/model/DTO/ComponentField.java
+++ b/src/main/java/com/aem/builder/model/DTO/ComponentField.java
@@ -1,6 +1,7 @@
 package com.aem.builder.model.DTO;
 
 import com.aem.builder.model.Enum.FieldType;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -20,6 +21,8 @@ public class ComponentField {
     private String fieldLabel;                 // e.g., Title
     private String fieldName;                  // e.g., title
     private String fieldType;                  // from FieldType enum
+    @JsonProperty("isParentTab")
+    private boolean isParentTab;
     private List<ComponentField> nestedFields; // only for multifields
     private List<OptionItem> options;          // for select/checkboxgroup values
 

--- a/src/main/java/com/aem/builder/service/ComponentService.java
+++ b/src/main/java/com/aem/builder/service/ComponentService.java
@@ -47,4 +47,8 @@ public interface ComponentService {
 
     Map<String, String>fetchComponentSuperTypes(String projectName);
 
+    /*
+check parent having tabs or not
+ */
+    Map<String, Object> getParentTabs(String projectName, String superType);
 }

--- a/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
@@ -23,10 +23,8 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.io.FileUtils;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
+import org.w3c.dom.*;
+
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -598,12 +596,12 @@ public class ComponentServiceImpl implements ComponentService {
                 }
             }
 
-            result.add(new ComponentField(fieldLabel, tabName, "tabs", nested, null));
+            result.add(new ComponentField(fieldLabel, tabName, "tabs", false,nested, null));
             return result;
         }
 
         // --- Default: simple field
-        result.add(new ComponentField(fieldLabel, fieldName, fieldType, nested, options));
+        result.add(new ComponentField(fieldLabel, fieldName, fieldType, false,nested, options));
         return result;
     }
 
@@ -1229,7 +1227,210 @@ Updating logic below
         return superTypePath;
     }
 
+    @Override
+    public Map<String, Object> getParentTabs(String projectName, String superType) {
+        Map<String, Object> result = new HashMap<>();
+        Set<String> tabs = new LinkedHashSet<>(); // preserve order, avoid duplicates
 
+        try {
+            collectTabsRecursively(projectName, superType, tabs);
+
+            result.put("hasTabs", !tabs.isEmpty());
+            result.put("tabs", new ArrayList<>(tabs));
+            log.info("✅ Final merged tabs for {} -> {}", superType, tabs);
+
+        } catch (Exception e) {
+            log.error("❌ Error while fetching parent tabs for {}", superType, e);
+            result.put("hasTabs", false);
+            result.put("tabs", new ArrayList<>());
+        }
+
+        return result;
+    }
+
+    /**
+     * Recursively collects tabs from current component and its superTypes.
+     */
+    private void collectTabsRecursively(String projectName, String superType, Set<String> tabs) throws Exception {
+        boolean isCore = superType.startsWith("core/");
+        String basePath = System.getProperty("user.dir") +
+                (isCore
+                        ? "/src/main/resources/" + superType
+                        : "/generated-projects/" + projectName + "/ui.apps/src/main/content/jcr_root" + superType);
+
+        // Step 1: parse dialog
+        File dialogFile = new File(basePath + "/_cq_dialog/.content.xml");
+        if (dialogFile.exists()) {
+            List<String> currentTabs = isCore
+                    ? parseCoreTabsFromDialog(dialogFile)
+                    : parseProjectTabsFromDialog(dialogFile);
+            tabs.addAll(currentTabs);
+            log.info("➡️ Tabs collected from {}: {}", superType, currentTabs);
+        }
+
+        // Step 2: check superType in .content.xml
+        File compContentFile = new File(basePath + "/.content.xml");
+        if (compContentFile.exists()) {
+            log.info("componentFile for supertype,{}",compContentFile);
+            String parentSuperType = readSuperType(compContentFile);
+            log.info("parent,{}",parentSuperType);
+            if (parentSuperType != null && !parentSuperType.isEmpty()) {
+                if (parentSuperType.startsWith("core/")) {
+                    // Only collect core tabs once
+                    String corePath = System.getProperty("user.dir") + "/src/main/resources/" + parentSuperType;
+                    File coreDialog = new File(corePath + "/_cq_dialog/.content.xml");
+                    if (coreDialog.exists()) {
+                        List<String> coreTabs = parseCoreTabsFromDialog(coreDialog);
+                        tabs.addAll(coreTabs);
+                        log.info("➡️ Core Tabs collected from {}: {}", parentSuperType, coreTabs);
+                    } else {
+                        log.warn("⚠️ Core dialog not found at {}", coreDialog.getAbsolutePath());
+                    }
+                } else {
+                    // Recurse for project parent
+                    collectTabsRecursively(projectName, parentSuperType, tabs);
+                }
+            }
+        }
+    }
+
+    /**
+     * Parse dialog file and extract tab names for project (normal) components.
+     */
+    private List<String> parseProjectTabsFromDialog(File dialogFile) throws Exception {
+        List<String> tabs = new ArrayList<>();
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document doc = builder.parse(dialogFile);
+
+        NodeList nodes = doc.getElementsByTagName("*");
+        for (int i = 0; i < nodes.getLength(); i++) {
+            org.w3c.dom.Node node = nodes.item(i);
+            NamedNodeMap attrs = node.getAttributes();
+            if (attrs == null) continue;
+
+            org.w3c.dom.Node resType = attrs.getNamedItem("sling:resourceType");
+            if (resType != null && "granite/ui/components/coral/foundation/tabs".equals(resType.getNodeValue())) {
+                NodeList itemsNodes = node.getChildNodes();
+                for (int j = 0; j < itemsNodes.getLength(); j++) {
+                    org.w3c.dom.Node itemsNode = itemsNodes.item(j);
+                    if (!"items".equals(itemsNode.getNodeName())) continue;
+
+                    NodeList tabNodes = itemsNode.getChildNodes();
+                    for (int k = 0; k < tabNodes.getLength(); k++) {
+                        org.w3c.dom.Node tabNode = tabNodes.item(k);
+                        if (tabNode.getNodeType() != org.w3c.dom.Node.ELEMENT_NODE) continue;
+
+                        NamedNodeMap tabAttrs = tabNode.getAttributes();
+                        if (tabAttrs == null) continue;
+
+                        org.w3c.dom.Node tabResType = tabAttrs.getNamedItem("sling:resourceType");
+                        if (tabResType != null && "granite/ui/components/coral/foundation/container".equals(tabResType.getNodeValue())) {
+                            String tabTitle = tabAttrs.getNamedItem("jcr:title") != null
+                                    ? tabAttrs.getNamedItem("jcr:title").getNodeValue()
+                                    : tabNode.getNodeName();
+                            tabs.add(tabTitle);
+                            log.info("   ➕ Project Tab detected: {}", tabTitle);
+                        }
+                    }
+                }
+            }
+        }
+        return tabs;
+    }
+
+
+    /**
+     * Parse dialog file and extract tab names for Core components.
+     * Stops at first <tabs> found.
+     */
+    private List<String> parseCoreTabsFromDialog(File dialogFile) throws Exception {
+        List<String> tabs = new ArrayList<>();
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document doc = builder.parse(dialogFile);
+
+        org.w3c.dom.Node root = doc.getDocumentElement();
+        parseTabsRecursive(root, tabs);
+        return tabs;
+    }
+
+    private void parseTabsRecursive(org.w3c.dom.Node node, List<String> tabs) {
+        if (node.getNodeType() != org.w3c.dom.Node.ELEMENT_NODE) return;
+
+        NamedNodeMap attrs = node.getAttributes();
+
+        // Case 1: Node is <tabs>
+        if ("tabs".equals(node.getNodeName()) ||
+                (attrs != null && attrs.getNamedItem("sling:resourceType") != null &&
+                        "granite/ui/components/coral/foundation/tabs".equals(attrs.getNamedItem("sling:resourceType").getNodeValue()))) {
+
+            NodeList itemsNodes = node.getChildNodes();
+            for (int i = 0; i < itemsNodes.getLength(); i++) {
+                org.w3c.dom.Node itemsNode = itemsNodes.item(i);
+                if (!"items".equals(itemsNode.getNodeName())) continue;
+
+                NodeList tabNodes = itemsNode.getChildNodes();
+                for (int j = 0; j < tabNodes.getLength(); j++) {
+                    org.w3c.dom.Node tabNode = tabNodes.item(j);
+                    if (tabNode.getNodeType() != org.w3c.dom.Node.ELEMENT_NODE) continue;
+
+                    NamedNodeMap tabAttrs = tabNode.getAttributes();
+                    if (tabAttrs == null) continue;
+
+                    org.w3c.dom.Node resTypeAttr = tabAttrs.getNamedItem("sling:resourceType");
+                    if (resTypeAttr != null &&
+                            "granite/ui/components/coral/foundation/container".equals(resTypeAttr.getNodeValue())) {
+
+                        org.w3c.dom.Node titleAttr = tabAttrs.getNamedItem("jcr:title");
+                        if (titleAttr != null) {
+                            tabs.add(titleAttr.getNodeValue());
+                            log.info("   ➕ Core Tab detected: {}", titleAttr.getNodeValue());
+                        }
+                    }
+
+                    // Recurse into nested <tabs> inside this tab node
+                    parseTabsRecursive(tabNode, tabs);
+                }
+            }
+        } else {
+            // Recurse into child nodes
+            NodeList children = node.getChildNodes();
+            for (int i = 0; i < children.getLength(); i++) {
+                parseTabsRecursive(children.item(i), tabs);
+            }
+        }
+    }
+
+
+
+    /**
+     * Reads sling:resourceSuperType from .content.xml.
+     */
+    private String readSuperType(File compContentFile) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true); // important
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document doc = builder.parse(compContentFile);
+
+        NodeList rootNodes = doc.getElementsByTagName("*");
+        for (int i = 0; i < rootNodes.getLength(); i++) {
+            org.w3c.dom.Node node = rootNodes.item(i);
+            NamedNodeMap attrs = node.getAttributes();
+            if (attrs != null) {
+                for (int j = 0; j < attrs.getLength(); j++) {
+                    org.w3c.dom.Node attr = attrs.item(j);
+                    String name = attr.getNodeName();
+                    if ("sling:resourceSuperType".equals(name) || name.endsWith(":resourceSuperType")) {
+                        log.info("Super Type....,{}", attr.getNodeValue());
+                        return attr.getNodeValue();
+                    }
+                }
+            }
+        }
+        return null;
+    }
 }
 
 

--- a/src/main/java/com/aem/builder/util/FileGenerationUtil.java
+++ b/src/main/java/com/aem/builder/util/FileGenerationUtil.java
@@ -8,15 +8,27 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -321,7 +333,7 @@ public class FileGenerationUtil {
             return;
         }
 
-        logger.info("DIALOG: Generating dialog .content.xml for component '{}'", componentName);
+        logger.info("DIALOG: Starting dialog generation for component '{}'", componentName);
 
         String dialogTitle = componentName + " Dialog";
         StringBuilder sb = new StringBuilder();
@@ -335,45 +347,48 @@ public class FileGenerationUtil {
         for (ComponentField f : fields) {
             if ("tabs".equalsIgnoreCase(f.getFieldType())) {
                 tabFields.add(f);
+                logger.info("DIALOG: Found tab field '{}'", f.getFieldName());
             } else {
                 nonTabFields.add(f);
+                logger.info("DIALOG: Found non-tab field '{}'", f.getFieldName());
             }
         }
 
-        // If no tabs at all => flat dialog (better structure with fixedcolumns + column)
         if (tabFields.isEmpty()) {
+            logger.info("DIALOG: No tabs found. Generating flat dialog for '{}'", componentName);
             sb.append(String.format("""
-            <?xml version="1.0" encoding="UTF-8"?>
-            <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
-                      xmlns:cq="http://www.day.com/jcr/cq/1.0"
-                      xmlns:jcr="http://www.jcp.org/jcr/1.0"
-                      jcr:primaryType="nt:unstructured"
-                      jcr:title="%s"
-                      sling:resourceType="cq/gui/components/authoring/dialog"%s>
-                <content jcr:primaryType="nt:unstructured"
-                         sling:resourceType="granite/ui/components/coral/foundation/container">
-                    <layout jcr:primaryType="nt:unstructured"
-                            sling:resourceType="granite/ui/components/coral/foundation/layouts/fixedcolumns"/>
-                    <items jcr:primaryType="nt:unstructured">
-                        <column jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/container">
-                            <items jcr:primaryType="nt:unstructured">
-            """, dialogTitle, superTypeAttr));
+        <?xml version="1.0" encoding="UTF-8"?>
+        <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+                  xmlns:cq="http://www.day.com/jcr/cq/1.0"
+                  xmlns:jcr="http://www.jcp.org/jcr/1.0"
+                  jcr:primaryType="nt:unstructured"
+                  jcr:title="%s"
+                  sling:resourceType="cq/gui/components/authoring/dialog"%s>
+            <content jcr:primaryType="nt:unstructured"
+                     sling:resourceType="granite/ui/components/coral/foundation/container">
+                <layout jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/layouts/fixedcolumns"/>
+                <items jcr:primaryType="nt:unstructured">
+                    <column jcr:primaryType="nt:unstructured"
+                            sling:resourceType="granite/ui/components/coral/foundation/container">
+                        <items jcr:primaryType="nt:unstructured">
+        """, dialogTitle, superTypeAttr));
 
             for (ComponentField f : nonTabFields) {
+                logger.info("DIALOG: Generating field '{}' in flat dialog", f.getFieldName());
                 sb.append(generateFieldXml(safeNodeName(f.getFieldName(), "field"), f));
             }
 
             sb.append("""
-                            </items>
-                        </column>
-                    </items>
-                </content>
-            </jcr:root>
-            """);
-
+                        </items>
+                    </column>
+                </items>
+            </content>
+        </jcr:root>
+        """);
         } else {
-            // Tabs exist. Try to find an EXPLICIT "Main" tab among them.
+            logger.info("DIALOG: Tabs detected. Generating tabbed dialog for '{}'", componentName);
+
             ComponentField explicitMainTab = null;
             for (ComponentField tf : tabFields) {
                 String nodeName = safeNodeName(tf.getFieldName(), "tab");
@@ -381,44 +396,96 @@ public class FileGenerationUtil {
                 if ("main".equalsIgnoreCase(nodeName) ||
                         (title != null && title.trim().equalsIgnoreCase("Main"))) {
                     explicitMainTab = tf;
-                    break; // first match wins
+                    logger.info("DIALOG: Explicit main tab detected: '{}'", nodeName);
+                    break;
                 }
             }
 
             boolean willAutoCreateMain = explicitMainTab == null && !nonTabFields.isEmpty();
 
             sb.append(String.format("""
-            <?xml version="1.0" encoding="UTF-8"?>
-            <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
-                      xmlns:cq="http://www.day.com/jcr/cq/1.0"
-                      xmlns:jcr="http://www.jcp.org/jcr/1.0"
-                      jcr:primaryType="nt:unstructured"
-                      jcr:title="%s"
-                      sling:resourceType="cq/gui/components/authoring/dialog"%s>
-                <content jcr:primaryType="nt:unstructured"
-                         sling:resourceType="granite/ui/components/coral/foundation/container">
-                    <layout jcr:primaryType="nt:unstructured"
-                            sling:resourceType="granite/ui/components/coral/foundation/layouts/tabs"/>
-                    <items jcr:primaryType="nt:unstructured">
-                        <tabs jcr:primaryType="nt:unstructured"
-                              sling:resourceType="granite/ui/components/coral/foundation/tabs">
-                            <items jcr:primaryType="nt:unstructured">
-            """, dialogTitle, superTypeAttr));
+        <?xml version="1.0" encoding="UTF-8"?>
+        <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+                  xmlns:cq="http://www.day.com/jcr/cq/1.0"
+                  xmlns:jcr="http://www.jcp.org/jcr/1.0"
+                  jcr:primaryType="nt:unstructured"
+                  jcr:title="%s"
+                  sling:resourceType="cq/gui/components/authoring/dialog"%s>
+            <content jcr:primaryType="nt:unstructured"
+                     sling:resourceType="granite/ui/components/coral/foundation/container">
+                <layout jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/layouts/tabs"/>
+                <items jcr:primaryType="nt:unstructured">
+                    <tabs jcr:primaryType="nt:unstructured"
+                          sling:resourceType="granite/ui/components/coral/foundation/tabs">
+                        <items jcr:primaryType="nt:unstructured">
+        """, dialogTitle, superTypeAttr));
 
-            // Safety: avoid duplicate tab node names
-            java.util.Set<String> writtenTabNodeNames = new java.util.HashSet<>();
+            Set<String> writtenTabNodeNames = new HashSet<>();
 
             for (ComponentField field : tabFields) {
                 String tabNodeName = safeNodeName(field.getFieldName(), "tab");
-                String tabTitle = (field.getFieldLabel() != null && !field.getFieldLabel().isBlank())
-                        ? field.getFieldLabel() : tabNodeName;
-                String resourceType = getResourceType(field.getFieldType());
+                String tabTitle = (field.getFieldName() != null && !field.getFieldName().isBlank())
+                        ? field.getFieldName()
+                        : tabNodeName;
+
+
 
                 if (!writtenTabNodeNames.add(tabNodeName.toLowerCase())) {
                     logger.warn("DIALOG: Duplicate tab node name '{}' detected. Skipping duplicate.", tabNodeName);
                     continue;
                 }
+                log.info("tabtitle,{}",tabTitle);
+                log.info("parent....,{}",field.isParentTab());
+                if (field.isParentTab()) {
+                    logger.info("DIALOG: Processing parent tab '{}'", tabNodeName);
+                    String parentTabXml = null;
+                    try {
+                        log.info("extractTabsOnly,{},{}.{}",superType, "shell", List.of(tabTitle));
+                        parentTabXml = extractTabsOnly(superType, "shell", List.of(tabTitle));
+                        logger.info("DIALOG: Extracted parent tab XML for '{}':\n{}", tabNodeName, parentTabXml);
+                    } catch (Exception e) {
+                        logger.warn("DIALOG: Could not extract parent tab '{}' from superType '{}': {}", tabTitle, superType, e.getMessage());
+                    }
+                    if (parentTabXml != null && !parentTabXml.isBlank()) {
+                        StringBuilder tabBuilder = new StringBuilder(parentTabXml);
 
+                        // Find innermost <items> position
+                        int insertPos = findInnermostItems(tabBuilder, 0);
+
+                        StringBuilder fieldsBuilder = new StringBuilder();
+
+                        // Add nested fields inside the tab
+                        if (field.getNestedFields() != null) {
+                            for (ComponentField nf : field.getNestedFields()) {
+                                logger.info("DIALOG: Adding nested field '{}' to parent tab '{}'", nf.getFieldName(), tabNodeName);
+                                fieldsBuilder.append(generateFieldXml(safeNodeName(nf.getFieldName(), "field"), nf));
+                            }
+                        }
+
+                        // Add non-tab fields to the main tab
+                        if (explicitMainTab == field && !nonTabFields.isEmpty()) {
+                            for (ComponentField f : nonTabFields) {
+                                logger.info("DIALOG: Adding non-tab field '{}' to main parent tab '{}'", f.getFieldName(), tabNodeName);
+                                fieldsBuilder.append(generateFieldXml(safeNodeName(f.getFieldName(), "field"), f));
+                            }
+                        }
+
+                        // Inject fields at the innermost <items>
+                        tabBuilder.insert(insertPos, fieldsBuilder.toString());
+
+                        sb.append(tabBuilder);
+                        continue;
+                    }
+
+
+                    else {
+                        logger.info("DIALOG: Parent tab '{}' has no XML structure. Generating fresh tab", tabNodeName);
+                    }
+                }
+
+                logger.info("DIALOG: Generating normal tab '{}'", tabNodeName);
+                String resourceType = getResourceType(field.getFieldType());
                 sb.append("        <").append(tabNodeName).append("\n")
                         .append("            jcr:primaryType=\"nt:unstructured\"\n")
                         .append("            jcr:title=\"").append(tabTitle).append("\"\n")
@@ -427,12 +494,14 @@ public class FileGenerationUtil {
 
                 if (field.getNestedFields() != null) {
                     for (ComponentField nf : field.getNestedFields()) {
+                        logger.info("DIALOG: Adding nested field '{}' to tab '{}'", nf.getFieldName(), tabNodeName);
                         sb.append(generateFieldXml(safeNodeName(nf.getFieldName(), "field"), nf));
                     }
                 }
 
                 if (explicitMainTab == field && !nonTabFields.isEmpty()) {
                     for (ComponentField f : nonTabFields) {
+                        logger.info("DIALOG: Adding non-tab field '{}' to explicit main tab '{}'", f.getFieldName(), tabNodeName);
                         sb.append(generateFieldXml(safeNodeName(f.getFieldName(), "field"), f));
                     }
                 }
@@ -442,6 +511,7 @@ public class FileGenerationUtil {
             }
 
             if (willAutoCreateMain) {
+                logger.info("DIALOG: Auto-creating 'Main' tab for non-tab fields");
                 String resourceType = getResourceType("tabs");
                 String autoMainNodeName = "main";
                 if (!writtenTabNodeNames.add(autoMainNodeName)) {
@@ -456,6 +526,7 @@ public class FileGenerationUtil {
                         .append("            <items jcr:primaryType=\"nt:unstructured\">\n");
 
                 for (ComponentField f : nonTabFields) {
+                    logger.info("DIALOG: Adding non-tab field '{}' to auto-created Main tab", f.getFieldName());
                     sb.append(generateFieldXml(safeNodeName(f.getFieldName(), "field"), f));
                 }
 
@@ -464,19 +535,18 @@ public class FileGenerationUtil {
             }
 
             sb.append("""
-                            </items>
-                        </tabs>
-                    </items>
-                </content>
-            </jcr:root>
-            """);
+                        </items>
+                    </tabs>
+                </items>
+            </content>
+        </jcr:root>
+        """);
         }
 
-        // Write to file
         FileUtils.writeStringToFile(new File(dialogFolder + "/.content.xml"),
                 sb.toString(), StandardCharsets.UTF_8);
 
-        logger.info("DIALOG: Dialog .content.xml generated at {}/.content.xml", dialogFolder);
+        logger.info("DIALOG: Dialog .content.xml successfully generated at {}.content.xml", dialogFolder);
     }
 
     /** Utility: safe XML node name */
@@ -864,4 +934,233 @@ public class FileGenerationUtil {
             return "";
         }
     }
+
+
+    /*
+    checkMultifieldJavaClassNames
+     */
+    public static boolean checkModelFileExists(String projectName, String multifieldName) throws IOException {
+        // Build java source root
+        Path javaSourceRoot = Paths.get("generated-projects/" + projectName + "/core/src/main/java/");
+
+        // Resolve model path (your existing utility)
+        Path modelPath = findModelBasePath(javaSourceRoot);
+
+        // Capitalize field name -> class name
+        String className = capitalize(multifieldName);
+        String expectedFileName = className + ".java";
+
+        // Get list of all files under modelPath
+        List<String> fileNames = Files.list(modelPath)
+                .filter(Files::isRegularFile)
+                .map(path -> path.getFileName().toString())
+                .collect(Collectors.toList());
+
+        // Compare
+        return fileNames.contains(expectedFileName);
+    }
+
+    /*
+    tabs
+     */
+    public static String extractTabsOnly(String superType, String projectName, List<String> filterTabs) throws Exception {
+        log.info("extractTabsOnly called with superType='{}', projectName='{}', filterTabs={}", superType, projectName, filterTabs);
+        StringBuilder sb = new StringBuilder();
+        Set<String> visitedSuperTypes = new HashSet<>();
+
+        collectTabsRecursive(superType, projectName, sb, 0, superType.startsWith("core/"), filterTabs, visitedSuperTypes);
+
+        log.info("Final extracted tabs structure:\n{}", sb.toString());
+        return sb.toString().trim();
+    }
+
+    private static void collectTabsRecursive(String superType, String projectName,
+                                             StringBuilder sb, int indent,
+                                             boolean stopAtCore,
+                                             List<String> filterTabs,
+                                             Set<String> visitedSuperTypes) throws Exception {
+
+        if (visitedSuperTypes.contains(superType)) {
+            log.info("Already visited superType '{}', skipping recursion.", superType);
+            return;
+        }
+        visitedSuperTypes.add(superType);
+
+        boolean isCore = superType.startsWith("core");
+        String basePath = System.getProperty("user.dir") +
+                (isCore
+                        ? "/src/main/resources/" + superType
+                        : "/generated-projects/" + projectName + "/ui.apps/src/main/content/jcr_root" + superType);
+
+        File dialogFile = new File(basePath + "/_cq_dialog/.content.xml");
+        log.info("Looking for dialog file at '{}'", dialogFile.getAbsolutePath());
+
+        if (!dialogFile.exists()) {
+            log.warn("Dialog file does not exist at '{}'", dialogFile.getAbsolutePath());
+            return;
+        }
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document doc = builder.parse(dialogFile);
+        Node root = doc.getDocumentElement();
+
+        log.info("Processing root node '{}' for superType '{}'", root.getNodeName(), superType);
+
+        extractRequestedTabs(root, sb, indent, filterTabs);
+
+        if (root.getAttributes() != null && root.getAttributes().getNamedItem("sling:resourceSuperType") != null) {
+            String parentSuperType = root.getAttributes().getNamedItem("sling:resourceSuperType").getNodeValue();
+            if (parentSuperType != null && !parentSuperType.isBlank()) {
+                boolean parentIsCore = parentSuperType.startsWith("core/");
+                log.info("Recursing to parent superType '{}', parentIsCore={}, stopAtCore={}", parentSuperType, parentIsCore, stopAtCore);
+                if (!parentIsCore || !stopAtCore) {
+                    collectTabsRecursive(parentSuperType, projectName, sb, indent, parentIsCore, filterTabs, visitedSuperTypes);
+                }
+            }
+        }
+    }
+
+    private static void extractRequestedTabs(Node node, StringBuilder sb, int indent, List<String> filterTabs) {
+        if (node.getNodeType() != Node.ELEMENT_NODE) return;
+
+        NamedNodeMap attrs = node.getAttributes();
+        String nodeName = node.getNodeName();
+        String tabTitle = (attrs != null && attrs.getNamedItem("jcr:title") != null) ? attrs.getNamedItem("jcr:title").getNodeValue() : null;
+
+
+        boolean isTabCandidate = tabTitle != null;
+
+        if (isTabCandidate) {
+            boolean isRequested = filterTabs == null || filterTabs.isEmpty() ||
+                    filterTabs.stream().anyMatch(f -> f.equalsIgnoreCase(tabTitle));
+
+            log.info("Node '{}' is a tab candidate, isRequested={}", tabTitle, isRequested);
+
+            if (isRequested) {
+                String skeleton = buildTabSkeleton(node);
+                log.info("Built tab skeleton for '{}':\n{}", tabTitle, skeleton);
+                sb.append(skeleton).append("\n");
+                return;
+            }
+        }
+
+        NodeList children = node.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            extractRequestedTabs(children.item(i), sb, indent, filterTabs);
+        }
+    }
+
+    private static String buildTabSkeleton(Node tabNode) {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document newDoc = builder.newDocument();
+
+            Node copied = copyWithoutFields(tabNode, newDoc);
+            newDoc.appendChild(copied);
+
+            TransformerFactory tf = TransformerFactory.newInstance();
+            Transformer transformer = tf.newTransformer();
+            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
+            StringWriter writer = new StringWriter();
+            transformer.transform(new DOMSource(newDoc), new StreamResult(writer));
+            return writer.getBuffer().toString();
+
+        } catch (Exception e) {
+            log.error("Failed to build tab skeleton", e);
+            return "<error>Failed to build tab skeleton: " + e.getMessage() + "</error>";
+        }
+    }
+
+    private static Node copyWithoutFields(Node node, Document targetDoc) {
+        if (isFieldNode(node)) {
+            log.debug("Skipping field node '{}'", node.getNodeName());
+            return null;
+        }
+
+        Node newNode = targetDoc.importNode(node, false);
+        NodeList children = node.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node childCopy = copyWithoutFields(children.item(i), targetDoc);
+            if (childCopy != null) {
+                newNode.appendChild(childCopy);
+            }
+        }
+        return newNode;
+    }
+
+    private static boolean isFieldNode(Node node) {
+        if (node.getNodeType() != Node.ELEMENT_NODE) return false;
+
+        NamedNodeMap attrs = node.getAttributes();
+        if (attrs == null) return false;
+
+        Node resTypeNode = attrs.getNamedItem("sling:resourceType");
+        if (resTypeNode == null) return false;
+
+        String type = resTypeNode.getNodeValue();
+
+        // Exclude TABS container explicitly
+        if (FieldType.TABS.getResourceType().equals(type)) {
+            log.debug("Node '{}' is a TABS container, skipping", node.getNodeName());
+            return false;
+        }
+
+        // Get all FieldType resource types except TABS
+        Map<String, String> fieldMap = FieldType.getTypeResourceMap();
+
+        // Check if type matches any field type or is a WELL
+        boolean isField = fieldMap.values().stream()
+                .filter(rt -> !rt.equals(FieldType.TABS.getResourceType()))
+                .anyMatch(rt -> type.contains(rt)) ||
+                type.contains("granite/ui/components/coral/foundation/well")||type.contains("granite/ui/components/coral/foundation/text")||type.contains("granite/ui/components/coral/foundation/include"); // directly check WELL
+
+        if (isField) {
+            log.debug("Node '{}' detected as field type '{}'", node.getNodeName(), type);
+        }
+
+        return isField;
+    }
+
+    private static int findInnermostItems(StringBuilder xml, int startPos) {
+        int pos = startPos;
+        int deepestPos = -1;
+
+        while (true) {
+            int openTag = xml.indexOf("<items jcr:primaryType=\"nt:unstructured\"", pos);
+            if (openTag == -1) break;
+
+            // Move past opening tag
+            int endOfOpen = xml.indexOf(">", openTag) + 1;
+
+            // Find matching closing </items> for this open
+            int depth = 1;
+            int searchPos = endOfOpen;
+            while (depth > 0) {
+                int nextOpen = xml.indexOf("<items jcr:primaryType=\"nt:unstructured\"", searchPos);
+                int nextClose = xml.indexOf("</items>", searchPos);
+                if (nextClose == -1) break;
+
+                if (nextOpen != -1 && nextOpen < nextClose) {
+                    depth++;
+                    searchPos = nextOpen + 1;
+                } else {
+                    depth--;
+                    searchPos = nextClose + 1;
+                }
+            }
+
+            // Update deepest position to the current opening tag's content start
+            deepestPos = endOfOpen;
+            pos = endOfOpen;
+        }
+
+        return deepestPos != -1 ? deepestPos : xml.length();
+    }
+
+
 }


### PR DESCRIPTION
- Read cq:dialog XML from the specified superType
- Extract and return parent tab definitions and structure
- Added validation to ensure a child Java class name is provided when creating multifields