### PR TITLE
Added the logs, JavaDocs for all the methods in Componentserviceimpl

### DIFF
--- a/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
@@ -197,7 +197,7 @@ public class ComponentServiceImpl implements ComponentService {
             String fileName = resource.getFilename();
             if (fileName != null) {
                 components.add(fileName);
-                log.debug("[getAllComponents] Discovered component resource: {}", fileName);
+                log.info("[getAllComponents] Discovered component resource: {}", fileName);
             }
         }
 
@@ -246,7 +246,7 @@ public class ComponentServiceImpl implements ComponentService {
                 .collect(Collectors.toList());
 
         log.info("[getDistinctComponents] Distinct components found: {}", distinct.size());
-        log.debug("[getDistinctComponents] Distinct components list: {}", distinct);
+        log.info("[getDistinctComponents] Distinct components list: {}", distinct);
 
         return distinct;
     }
@@ -270,7 +270,7 @@ public class ComponentServiceImpl implements ComponentService {
         log.info("[getExistingProjects] Checking for existing projects in: {}", projectsPath);
 
         if (!projectsDir.exists() || !projectsDir.isDirectory()) {
-            log.warn("[getExistingProjects] No 'generated-projects' directory found at path: {}", projectsPath);
+            log.info("[getExistingProjects] No 'generated-projects' directory found at path: {}", projectsPath);
             return Collections.emptyList();
         }
 
@@ -282,7 +282,7 @@ public class ComponentServiceImpl implements ComponentService {
 
         List<String> existingProjects = Arrays.asList(names);
         log.info("[getExistingProjects] Found {} existing projects.", existingProjects.size());
-        log.debug("[getExistingProjects] Existing projects list: {}", existingProjects);
+        log.info("[getExistingProjects] Existing projects list: {}", existingProjects);
 
         return existingProjects;
     }
@@ -310,20 +310,20 @@ public class ComponentServiceImpl implements ComponentService {
         try {
             File contentXml = new File(basePath, CONTENT_XML);
             if (contentXml.exists()) {
-                log.debug("[loadComponent] Reading component metadata from '{}'", contentXml.getAbsolutePath());
+                log.info("[loadComponent] Reading component metadata from '{}'", contentXml.getAbsolutePath());
                 String content = FileGenerationUtil.readFile(contentXml);
 
                 group = extractProperty(content, COMPONENT_GROUP).trim();
                 superType = extractProperty(content, SLING_RESOURCE_SUPER_TYPE).trim();
 
-                log.debug("[loadComponent] Parsed component metadata: group='{}', superType='{}'", group, superType);
+                log.info("[loadComponent] Parsed component metadata: group='{}', superType='{}'", group, superType);
             } else {
-                log.warn("[loadComponent] .content.xml not found for component '{}'", componentName);
+                log.info("[loadComponent] .content.xml not found for component '{}'", componentName);
             }
 
             File dialogXml = new File(basePath + "/" + CQ_DIALOG + "/" + CONTENT_XML);
             if (dialogXml.exists()) {
-                log.debug("[loadComponent] Parsing dialog XML at '{}'", dialogXml.getAbsolutePath());
+                log.info("[loadComponent] Parsing dialog XML at '{}'", dialogXml.getAbsolutePath());
 
                 DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
                 factory.setNamespaceAware(false); // disabling namespaces for easier parsing
@@ -333,7 +333,7 @@ public class ComponentServiceImpl implements ComponentService {
                 collectFields(doc.getDocumentElement(), fields);
                 log.info("[loadComponent] Collected {} field(s) for component '{}'", fields.size(), componentName);
             } else {
-                log.warn("[loadComponent] Dialog XML not found for component '{}'", componentName);
+                log.info("[loadComponent] Dialog XML not found for component '{}'", componentName);
             }
 
         } catch (Exception e) {
@@ -369,13 +369,13 @@ public class ComponentServiceImpl implements ComponentService {
         String compPath = PROJECTS_DIR + "/" + projectName + "/" + CONTENT_ROOT_PATH + appId + COMPONENTS_FOLDER + request.getComponentName();
 
         log.info("[updateComponent] Updating component '{}' in project '{}'", request.getComponentName(), projectName);
-        log.debug("[updateComponent] Resolved component path for update: {}", compPath);
+        log.info("[updateComponent] Resolved component path for update: {}", compPath);
 
         try {
             FileUtils.deleteDirectory(new File(compPath));
             log.info("[updateComponent] Deleted existing component directory: {}", compPath);
         } catch (IOException e) {
-            log.warn("[updateComponent] Could not clean component folder before update for '{}'", request.getComponentName(), e);
+            log.info("[updateComponent] Could not clean component folder before update for '{}'", request.getComponentName(), e);
         }
 
         FileGenerationUtil.generateAllFiles(projectName, request);
@@ -406,15 +406,15 @@ public class ComponentServiceImpl implements ComponentService {
 
         String compPath = findComponentPathExact(projectName, componentName);
         if (compPath == null) {
-            log.warn("[deleteComponent] Component '{}' not found in project '{}'", componentName, projectName);
+            log.info("[deleteComponent] Component '{}' not found in project '{}'", componentName, projectName);
             return;
         }
-        log.debug("[deleteComponent] Component folder resolved at '{}'", compPath);
+        log.info("[deleteComponent] Component folder resolved at '{}'", compPath);
 
         Set<String> slingModels = new HashSet<>();
         try {
             slingModels = collectSlingModelsFromHTLFolder(new File(compPath));
-            log.debug("[deleteComponent] Sling Models found: {}", slingModels);
+            log.info("[deleteComponent] Sling Models found: {}", slingModels);
         } catch (IOException e) {
             log.error("[deleteComponent] Failed to read HTL files for component '{}'", componentName, e);
         }
@@ -424,7 +424,7 @@ public class ComponentServiceImpl implements ComponentService {
                 .filter(f -> TYPE_MULTIFIELD.equals(f.getFieldType()))
                 .map(ComponentField::getFieldName)
                 .collect(Collectors.toSet());
-        log.debug("[deleteComponent] Multifield names collected: {}", multifieldNames);
+        log.info("[deleteComponent] Multifield names collected: {}", multifieldNames);
 
         Set<String> javaClassesToDelete = new HashSet<>();
         Set<String> processedClasses = new HashSet<>();
@@ -438,7 +438,7 @@ public class ComponentServiceImpl implements ComponentService {
                 log.error("[deleteComponent] Failed to collect child classes for '{}'", fqcn, e);
             }
         }
-        log.debug("[deleteComponent] Java classes marked for deletion: {}", javaClassesToDelete);
+        log.info("[deleteComponent] Java classes marked for deletion: {}", javaClassesToDelete);
 
         try {
             FileUtils.deleteDirectory(new File(compPath));
@@ -472,7 +472,7 @@ public class ComponentServiceImpl implements ComponentService {
     private Set<String> collectSlingModelsFromHTLFolder(File dir) throws IOException {
         Set<String> slingModels = new HashSet<>();
         if (!dir.isDirectory()) {
-            log.warn("[collectSlingModelsFromHTLFolder] Provided path '{}' is not a directory", dir.getAbsolutePath());
+            log.info("[collectSlingModelsFromHTLFolder] Provided path '{}' is not a directory", dir.getAbsolutePath());
             return slingModels;
         }
 
@@ -481,10 +481,10 @@ public class ComponentServiceImpl implements ComponentService {
 
         for (File file : files) {
             if (file.isDirectory()) {
-                log.debug("[collectSlingModelsFromHTLFolder] Entering directory '{}'", file.getAbsolutePath());
+                log.info("[collectSlingModelsFromHTLFolder] Entering directory '{}'", file.getAbsolutePath());
                 slingModels.addAll(collectSlingModelsFromHTLFolder(file));
             } else if (file.isFile() && file.getName().endsWith(HTL_FILE_EXTENSION)) {
-                log.debug("[collectSlingModelsFromHTLFolder] Processing HTL file '{}'", file.getAbsolutePath());
+                log.info("[collectSlingModelsFromHTLFolder] Processing HTL file '{}'", file.getAbsolutePath());
                 slingModels.addAll(extractSlingModelsFromHTL(file));
             }
         }
@@ -507,7 +507,7 @@ public class ComponentServiceImpl implements ComponentService {
      */
     private Set<String> extractSlingModelsFromHTL(File htlFile) throws IOException {
         Set<String> classes = new HashSet<>();
-        log.debug("[extractSlingModelsFromHTL] Extracting Sling Models from HTL file '{}'", htlFile.getAbsolutePath());
+        log.info("[extractSlingModelsFromHTL] Extracting Sling Models from HTL file '{}'", htlFile.getAbsolutePath());
 
         List<String> lines = Files.readAllLines(htlFile.toPath());
         for (String line : lines) {
@@ -522,7 +522,7 @@ public class ComponentServiceImpl implements ComponentService {
 
                     if (ref.startsWith("com.")) {
                         classes.add(ref);
-                        log.debug("[extractSlingModelsFromHTL] Found Sling Model reference: '{}'", ref);
+                        log.info("[extractSlingModelsFromHTL] Found Sling Model reference: '{}'", ref);
                     }
                 }
             }
@@ -533,19 +533,23 @@ public class ComponentServiceImpl implements ComponentService {
     }
 
     /**
-     * Recursively collects a Java class and all its child classes.
+     * Recursively collects a Java class and its child classes for deletion.
      * <p>
-     * Child classes are identified via {@code @ChildResource} annotations
-     * or via multifield references in the parent class.
-     * All identified class names are added to {@code javaClassesToDelete}.
+     * The method processes a given Java class file to detect:
+     * <ul>
+     *     <li>@ChildResource annotated fields referencing other classes</li>
+     *     <li>Multifield child classes based on provided field names</li>
+     * </ul>
+     * It adds all discovered class file names to {@code javaClassesToDelete} and tracks processed
+     * classes in {@code processedClasses} to avoid infinite recursion.
      * </p>
      *
-     * @param javaRoot            Root path of the Java source folder
-     * @param className           Name of the class to process
-     * @param javaClassesToDelete Set to store class names to be deleted
-     * @param processedClasses    Set to avoid processing the same class multiple times
-     * @param multifieldNames     Set of multifield variable names to track child dependencies
-     * @throws IOException If reading the Java file fails
+     * @param javaRoot            the root directory of Java source files
+     * @param className           the simple name of the class to process
+     * @param javaClassesToDelete the set of Java class file names to delete
+     * @param processedClasses    the set of classes already processed to prevent recursion
+     * @param multifieldNames     the set of multifield names to detect child classes
+     * @throws IOException if there is an error reading Java class files
      */
     private void collectClassAndChildren(Path javaRoot, String className,
                                          Set<String> javaClassesToDelete,
@@ -553,25 +557,28 @@ public class ComponentServiceImpl implements ComponentService {
                                          Set<String> multifieldNames) throws IOException {
 
         if (processedClasses.contains(className)) {
-            log.debug("Class '{}' already processed, skipping recursion", className);
+            log.info("[collectClassAndChildren] Class '{}' already processed, skipping recursion", className);
             return;
         }
         processedClasses.add(className);
 
+        // Locate the Java class file
         Path classPath = findJavaClassRecursive(javaRoot, className + JAVA_EXTENSION);
         if (classPath == null) {
-            log.warn("Java class '{}' not found under '{}'", className, javaRoot);
+            log.info("[collectClassAndChildren] Java class '{}' not found under '{}'", className, javaRoot);
             return;
         }
-        log.info("Found Java class '{}' at '{}'", className, classPath);
+        log.info("[collectClassAndChildren] Found Java class '{}' at '{}'", className, classPath);
 
         javaClassesToDelete.add(classPath.getFileName().toString());
 
+        // Read all lines from the class
         List<String> lines = Files.readAllLines(classPath);
 
         for (int i = 0; i < lines.size(); i++) {
             String line = lines.get(i).trim();
 
+            // 1. Detect @ChildResource fields
             if (line.contains(CHILD_RESOURCE_ANNOTATION)) {
                 for (int j = i + 1; j < Math.min(i + 4, lines.size()); j++) {
                     String fieldLine = lines.get(j).trim();
@@ -580,17 +587,18 @@ public class ComponentServiceImpl implements ComponentService {
                         String childClass = m.group(1) != null ? m.group(1) :
                                 m.group(2) != null ? m.group(2) : m.group(3);
                         if (childClass != null && !childClass.equals(className)) {
-                            log.info("Found @ChildResource child class '{}' in '{}'", childClass, className);
+                            log.info("[collectClassAndChildren] Found @ChildResource child class '{}' in '{}'", childClass, className);
                             collectClassAndChildren(javaRoot, childClass, javaClassesToDelete, processedClasses, multifieldNames);
                         }
                     }
                 }
             }
 
+            // 2. Detect multifield child classes
             for (String mfName : multifieldNames) {
                 if (line.matches(".*\\b([A-Z]\\w+)\\s+" + mfName + ";.*")) {
                     String childClassName = line.replaceAll(".*\\b([A-Z]\\w+)\\s+" + mfName + ";.*", "$1");
-                    log.info("Found child class '{}' for multifield '{}' in '{}'", childClassName, mfName, className);
+                    log.info("[collectClassAndChildren] Found child class '{}' for multifield '{}' in '{}'", childClassName, mfName, className);
                     collectClassAndChildren(javaRoot, childClassName, javaClassesToDelete, processedClasses, multifieldNames);
                 }
             }
@@ -598,20 +606,21 @@ public class ComponentServiceImpl implements ComponentService {
     }
 
     /**
-     * Recursively searches for a Java class file by its simple name under the given root directory.
+     * Recursively searches for a Java class file within the given root directory.
      * <p>
-     * This method walks the directory tree starting from {@code javaRoot} and looks for a file
-     * whose name exactly matches {@code className}. If found, it returns the {@link Path} to the file;
-     * otherwise, returns {@code null}.
+     * This method performs a depth-first walk of the directory tree starting from
+     * {@code javaRoot} to locate a Java source file that matches the specified
+     * {@code className}. If found, it returns the {@link Path} to the matching file;
+     * otherwise, it returns {@code null}.
      * </p>
      *
-     * @param javaRoot  the root directory under which to search (typically {@code core/src/main/java})
-     * @param className the simple file name of the Java class to find (e.g., "MyComponentModel.java")
-     * @return {@link Path} to the Java class file if found; {@code null} otherwise
+     * @param javaRoot  the root directory to search for the Java class file
+     * @param className the name of the Java class file to locate (e.g., "MyModel.java")
+     * @return the {@link Path} of the found Java class file, or {@code null} if not found
      * @throws IOException if an I/O error occurs while walking the file tree
      */
     private Path findJavaClassRecursive(Path javaRoot, String className) throws IOException {
-        log.info("Searching for Java class '{}' under '{}'", className, javaRoot);
+        log.info("[findJavaClassRecursive] Starting search for Java class '{}' under '{}'", className, javaRoot);
 
         try (Stream<Path> paths = Files.walk(javaRoot)) {
             Path found = paths
@@ -620,29 +629,37 @@ public class ComponentServiceImpl implements ComponentService {
                     .orElse(null);
 
             if (found != null) {
-                log.info("Java class '{}' found at '{}'", className, found);
+                log.info("[findJavaClassRecursive] Java class '{}' found at '{}'", className, found);
             } else {
-                log.warn("Java class '{}' not found under '{}'", className, javaRoot);
+                log.info("[findJavaClassRecursive] Java class '{}' not found under '{}'", className, javaRoot);
             }
+
+            log.info("[findJavaClassRecursive] Search completed for class '{}'", className);
             return found;
         }
     }
 
     /**
-     * Reads and returns the HTML content of a specific AEM component.
+     * Retrieves the HTML (HTL) content of a specified AEM component within a given project.
+     * <p>
+     * This method locates the exact component path using the project and component names,
+     * constructs the HTL file path, and reads its content. If the component or its HTL file
+     * cannot be found or read, it returns an empty string.
+     * </p>
      *
-     * @param projectName   the name of the project containing the component
-     * @param componentName the name of the component
-     * @return the HTML content as a {@link String}; empty string if reading fails
+     * @param projectName   the name of the AEM project where the component resides
+     * @param componentName the name of the AEM component whose HTML content is to be retrieved
+     * @return the HTML (HTL) content of the component as a {@link String}, or an empty string
+     * if the component is not found or the file cannot be read
      */
     @Override
     public String getComponentHtml(String projectName, String componentName) {
 
-        log.info("Fetching HTML for component '{}' in project '{}'", componentName, projectName);
+        log.info("[getComponentHtml] Fetching HTML for component '{}' in project '{}'", componentName, projectName);
 
         String componentPathExact = findComponentPathExact(projectName, componentName);
         if (componentPathExact == null) {
-            log.warn("Component '{}' not found in project '{}'", componentName, projectName);
+            log.info("[getComponentHtml] Component '{}' not found in project '{}'", componentName, projectName);
             return "";
         }
 
@@ -650,34 +667,50 @@ public class ComponentServiceImpl implements ComponentService {
 
         try {
             String htmlContent = Files.readString(htmlPath);
-            log.info("Successfully read HTML for component '{}'", componentName);
+            log.info("[getComponentHtml] Successfully read HTML content for component '{}'", componentName);
             return htmlContent;
         } catch (IOException e) {
-            log.error("Failed to read HTML for component '{}' at '{}'", componentName, htmlPath, e);
+            log.error("[getComponentHtml] Failed to read HTML for component '{}' at '{}'", componentName, htmlPath, e);
             return "";
         }
     }
 
     /**
-     * Reads and returns the Java code of the Sling Model(s) used in a specific AEM component.
-     * It recursively collects the main model and potential child classes referenced in the code.
+     * Retrieves the complete Java (Sling Model) code for a specified AEM component.
+     * <p>
+     * This method first reads the HTL (HTML) of the given component to locate the
+     * Sling Model binding using the {@code data-sly-use} pattern. Once the primary
+     * model class is identified, it recursively resolves all referenced Java classes
+     * to collect their source code. The final result includes the main model class
+     * and all dependent classes, each separated by a visual delimiter.
+     * </p>
      *
-     * @param projectName   the name of the project containing the component
-     * @param componentName the name of the component
-     * @return concatenated Java source code as a {@link String}; returns comment if HTL or model is missing
+     * <p><b>Behavior:</b></p>
+     * <ul>
+     *     <li>If no HTL file is found for the component, a comment message is returned.</li>
+     *     <li>If no Sling Model binding is found in the HTL, a comment message is returned.</li>
+     *     <li>If any Java file cannot be read, it is skipped, and the process continues.</li>
+     * </ul>
+     *
+     * @param projectName   the name of the AEM project containing the component
+     * @param componentName the name of the AEM component whose Sling Model Java code is to be retrieved
+     * @return a {@link String} containing the Java code of the Sling Model and all dependent classes,
+     * or a comment message if the HTL or Sling Model binding cannot be resolved
      */
     @Override
     public String getComponentJava(String projectName, String componentName) {
-        log.info("Fetching Sling Model Java code for component '{}' in project '{}'", componentName, projectName);
+        log.info("[getComponentJava] Fetching Sling Model Java code for component '{}' in project '{}'", componentName, projectName);
 
         try {
+            // Step 1: Read the HTL file content for the component
             String htlContent = getComponentHtml(projectName, componentName);
 
             if (htlContent == null || htlContent.isEmpty()) {
-                log.warn("No HTL found for component '{}'", componentName);
+                log.info("[getComponentJava] No HTL found for component '{}'", componentName);
                 return "// No HTL found for component: " + componentName;
             }
 
+            // Step 2: Extract Sling Model binding from HTL
             Pattern pattern = Pattern.compile(DATA_SLY_USE_PATTERN);
             Matcher matcher = pattern.matcher(htlContent);
 
@@ -691,10 +724,11 @@ public class ComponentServiceImpl implements ComponentService {
             }
 
             if (modelClass == null) {
-                log.warn("No Sling Model binding found in HTL for component '{}'", componentName);
+                log.info("[getComponentJava] No Sling Model binding found in HTL for component '{}'", componentName);
                 return "// No Sling Model binding found in HTL for: " + componentName;
             }
 
+            // Step 3: Recursively resolve and read all referenced Java classes
             StringBuilder result = new StringBuilder();
             Set<String> processed = new HashSet<>();
             Deque<String> stack = new ArrayDeque<>();
@@ -718,6 +752,7 @@ public class ComponentServiceImpl implements ComponentService {
                         .append(simpleName).append(" =====\n\n")
                         .append(code).append("\n\n");
 
+                // Find and add referenced classes from the current Java file
                 Matcher refMatcher = Pattern.compile(JAVA_CLASS_REF_PATTERN).matcher(code);
                 while (refMatcher.find()) {
                     String refClass = refMatcher.group(1);
@@ -727,34 +762,31 @@ public class ComponentServiceImpl implements ComponentService {
                 }
             }
 
-            log.info("Successfully fetched Java code for component '{}'", componentName);
+            log.info("[getComponentJava] Successfully fetched Java code for component '{}'", componentName);
             return result.toString();
 
         } catch (Exception e) {
-            log.error("Failed while resolving Sling Model for component '{}'", componentName, e);
+            log.error("[getComponentJava] Failed while resolving Sling Model for component '{}'", componentName, e);
             return "// Error while resolving Sling Model: " + e.getMessage();
         }
     }
 
-    private static String capitalize(String input) {
-        return (input == null || input.isEmpty()) ? input
-                : input.substring(0, 1).toUpperCase() + input.substring(1);
-    }
-
     /**
-     * Determines the field type corresponding to a given AEM resource type.
+     * Determines the dialog field type corresponding to a given AEM resource type.
      * <p>
-     * This method iterates through all {@link FieldType} enum values and performs
-     * a reverse lookup based on the resource type. If multiple enums match,
-     * the last match takes precedence.
+     * This method iterates through all {@link FieldType} enum values to find a match for the
+     * provided {@code resourceType}. If a match is found, the associated field type is returned.
+     * If no match exists or the input is null/empty, an empty string is returned.
      * </p>
      *
-     * @param resourceType the AEM resource type (e.g., "cq/gui/components/authoring/dialog")
-     * @return the corresponding field type as a string, or an empty string if not found
+     * @param resourceType the AEM resource type (e.g., "granite/ui/components/foundation/form/textfield")
+     * @return the matching field type as a {@link String}, or an empty string if no match is found
      */
     private String getFieldTypeFromResource(String resourceType) {
+        log.info("[getFieldTypeFromResource] Resolving field type for resourceType '{}'", resourceType);
+
         if (resourceType == null || resourceType.isEmpty()) {
-            log.warn("Resource type is null or empty, returning empty string");
+            log.info("[getFieldTypeFromResource] Resource type is null or empty, returning empty string");
             return "";
         }
 
@@ -762,68 +794,87 @@ public class ComponentServiceImpl implements ComponentService {
         for (FieldType ft : FieldType.values()) {
             if (ft.getResourceType().equals(resourceType)) {
                 fieldType = ft.getType();
-                log.debug("Matched resourceType '{}' to fieldType '{}'", resourceType, fieldType);
+                log.info("[getFieldTypeFromResource] Matched resourceType '{}' to fieldType '{}'", resourceType, fieldType);
             }
         }
 
         if (fieldType.isEmpty()) {
-            log.info("No matching fieldType found for resourceType '{}'", resourceType);
+            log.info("[getFieldTypeFromResource] No matching fieldType found for resourceType '{}'", resourceType);
+        } else {
+            log.info("[getFieldTypeFromResource] Successfully resolved fieldType '{}' for resourceType '{}'", fieldType, resourceType);
         }
 
         return fieldType;
     }
 
     /**
-     * Determines the field type for a given XML element from the component dialog.
+     * Determines the dialog field type for the given XML {@link Element}.
      * <p>
-     * Checks the element's {@code sling:resourceType} and certain attributes to
-     * categorize it into a field type like "multifield", "multiselect", "fileupload", or "image".
+     * This method inspects the element's {@code sling:resourceType} and other
+     * attributes to map it to a specific field type used in AEM component dialogs.
+     * The detection order is:
+     * <ol>
+     *     <li>Checks {@code sling:resourceType} for a direct match using
+     *         {@link #getFieldTypeFromResource(String)}</li>
+     *     <li>Overrides the type if the element represents a multifield</li>
+     *     <li>Overrides the type if the element represents a multiselect</li>
+     *     <li>Detects file or image upload types based on the node name</li>
+     * </ol>
      * </p>
      *
-     * @param elem the XML element representing a dialog field
-     * @return the determined field type as a string, or the default from {@link #getFieldTypeFromResource(String)}
+     * @param elem the XML {@link Element} representing the dialog field
+     * @return the resolved field type as a {@link String}; may be an empty string if no match is found
      */
     private String determineFieldType(Element elem) {
+        log.info("[determineFieldType] Determining field type for element '{}'", elem.getNodeName());
+
+        // 1. Start with the resourceType-based mapping
         String resourceType = elem.getAttribute(SLING_RESOURCE_TYPE);
         String type = getFieldTypeFromResource(resourceType);
 
-        log.debug("Determining field type for resourceType '{}'", resourceType);
+        log.info("[determineFieldType] Initial type '{}' detected from resourceType '{}'", type, resourceType);
 
+        // 2. Override for specific dialog components
         if (GRANITE_MULTIFIELD.equals(resourceType)) {
             type = TYPE_MULTIFIELD;
-            log.debug("Detected multifield for element '{}'", elem.getNodeName());
-        }
-
-        else if (GRANITE_SELECT.equals(resourceType)
+            log.info("[determineFieldType] Detected multifield for element '{}'", elem.getNodeName());
+        } else if (GRANITE_SELECT.equals(resourceType)
                 && "true".equalsIgnoreCase(elem.getAttribute("multiple"))) {
             type = TYPE_MULTISELECT;
-            log.debug("Detected multiselect for element '{}'", elem.getNodeName());
-        }
-        else if (CQ_FILEUPLOAD.equals(resourceType)) {
+            log.info("[determineFieldType] Detected multiselect for element '{}'", elem.getNodeName());
+        } else if (CQ_FILEUPLOAD.equals(resourceType)) {
             String node = elem.getNodeName().toLowerCase();
             if (node.contains("file")) {
                 type = FILEUPLOAD;
             } else if (node.contains(IMAGE)) {
                 type = IMAGE;
             }
-            log.debug("Detected '{}' upload for element '{}'", type, elem.getNodeName());
+            log.info("[determineFieldType] Detected '{}' upload type for element '{}'", type, elem.getNodeName());
         }
 
-        log.info("Final field type for element '{}': '{}'", elem.getNodeName(), type);
+        // 3. Final result
+        log.info("[determineFieldType] Final field type resolved for element '{}': '{}'", elem.getNodeName(), type);
         return type;
     }
 
     /**
-     * Parses a dialog XML element into one or more {@link ComponentField} objects.
+     * Parses an XML {@link Element} representing a dialog field into a {@link ComponentField} object.
      * <p>
-     * Handles multifields, selects, multiselects, radiogroups, file/image uploads, and tabs.
-     * Recurses into nested items for multifields and tabs.
+     * This method determines the field's type, name, label, and nested fields or options based
+     * on the element's attributes and child elements. Special handling is included for:
+     * <ul>
+     *     <li>Multifields: recursively collects nested fields</li>
+     *     <li>Select, multiselect, and radiogroup fields: extracts option items</li>
+     *     <li>Tabs: collects child fields and sets tab name and label</li>
+     * </ul>
      * </p>
      *
-     * @param elem the XML element representing a dialog field
-     * @return a list of parsed {@link ComponentField} objects
+     * @param elem the XML {@link Element} representing the field in the component dialog
+     * @return a {@link List} containing one or more {@link ComponentField} objects parsed from the element
      */
     private List<ComponentField> parseField(Element elem) {
+        log.info("[parseField] Parsing field element '{}'", elem.getNodeName());
+
         List<ComponentField> result = new ArrayList<>();
 
         String fieldLabel = elem.getAttribute(ATTR_FIELD_LABEL);
@@ -834,8 +885,9 @@ public class ComponentServiceImpl implements ComponentService {
 
         String fieldName = null;
 
-        log.debug("Parsing field element '{}', resourceType='{}'", elem.getNodeName(), resourceType);
+        log.info("[parseField] Initial resourceType='{}', fieldType='{}'", resourceType, fieldType);
 
+        // Resolve multifield name if necessary
         if (TYPE_MULTIFIELD.equals(fieldType) && (nameAttr == null || nameAttr.isBlank())) {
             NodeList fieldNodes = elem.getElementsByTagName(ATTR_FIELD);
             if (fieldNodes.getLength() > 0) {
@@ -845,9 +897,10 @@ public class ComponentServiceImpl implements ComponentService {
                     fieldName = nestedFieldName.startsWith("./") ? nestedFieldName.substring(2) : nestedFieldName;
                 }
             }
-            log.debug("Resolved multifield name: '{}'", fieldName);
+            log.info("[parseField] Resolved multifield name: '{}'", fieldName);
         }
 
+        // Fallback to main field name or file reference
         if (fieldName == null && nameAttr != null && !nameAttr.isBlank()) {
             if (FILEUPLOAD.equals(fieldType) && fileRefAttr != null && !fileRefAttr.isBlank()) {
                 fieldName = fileRefAttr.startsWith("./") ? fileRefAttr.substring(2) : fileRefAttr;
@@ -856,12 +909,13 @@ public class ComponentServiceImpl implements ComponentService {
             }
         }
 
-        log.info("Field parsed: label='{}', name='{}', type='{}', resourceType='{}'",
+        log.info("[parseField] Field parsed: label='{}', name='{}', type='{}', resourceType='{}'",
                 fieldLabel, fieldName, fieldType, resourceType);
 
         List<OptionItem> options = null;
         List<ComponentField> nested = null;
 
+        // Handle nested/multifield elements
         if (TYPE_MULTIFIELD.equals(fieldType)) {
             nested = new ArrayList<>();
             NodeList fieldNodes = elem.getElementsByTagName(ITEMS);
@@ -870,6 +924,7 @@ public class ComponentServiceImpl implements ComponentService {
                 collectFields(itemsElem, nested);
             }
         }
+        // Handle select/multiselect/radiogroup options
         else if (SELECT.equals(fieldType) || TYPE_MULTISELECT.equals(fieldType) || RADIOGROUP.equals(fieldType)) {
             if (SELECT.equals(fieldType)) {
                 String multipleAttr = elem.getAttribute(ATTR_MULTIPLE);
@@ -894,7 +949,7 @@ public class ComponentServiceImpl implements ComponentService {
                 }
             }
         }
-
+        // Handle tab fields
         else if (TYPE_TABS.equals(fieldType)) {
             String jcrTitle = elem.getAttribute(JCR_TITLE);
             if (jcrTitle != null && !jcrTitle.isBlank()) {
@@ -920,15 +975,24 @@ public class ComponentServiceImpl implements ComponentService {
     }
 
     /**
-     * Recursively collects dialog fields from the given parent XML element.
-     * Skips technical containers but continues traversing into their children.
+     * Recursively collects {@link ComponentField} objects from the given parent XML {@link Element}.
+     * <p>
+     * This method traverses all child nodes of the parent element and:
+     * <ul>
+     *     <li>Determines the field type of each child using {@link #determineFieldType(Element)}</li>
+     *     <li>Parses individual fields with {@link #parseField(Element)}</li>
+     *     <li>Handles special cases such as containers and tabs</li>
+     *     <li>Recursively collects nested fields for multifields or unknown types</li>
+     * </ul>
+     * The resulting {@link ComponentField} objects are added to the provided {@code fields} list.
+     * </p>
      *
-     * @param parent the parent XML element (dialog node) to parse
-     * @param fields the list to accumulate parsed ComponentField objects
+     * @param parent the parent XML {@link Element} to parse for fields
+     * @param fields the {@link List} where parsed {@link ComponentField} objects will be collected
      */
     private void collectFields(Element parent, List<ComponentField> fields) {
         NodeList children = parent.getChildNodes();
-        log.info("Collecting fields from parent node '{}', child count={}", parent.getNodeName(), children.getLength());
+        log.info("[collectFields] Collecting fields from parent node '{}', child count={}", parent.getNodeName(), children.getLength());
 
         for (int i = 0; i < children.getLength(); i++) {
             Node node = children.item(i);
@@ -939,128 +1003,162 @@ public class ComponentServiceImpl implements ComponentService {
             String resourceType = elem.getAttribute(SLING_RESOURCE_TYPE);
             String type = determineFieldType(elem);
 
+            // Handle container elements
             if (GRANITE_CONTAINER.equals(resourceType)) {
                 String parentResourceType = getParentResourceType(elem);
 
-                log.info("Checking container: nodeName='{}', resourceType='{}', parentResourceType='{}'",
+                log.info("[collectFields] Checking container: nodeName='{}', resourceType='{}', parentResourceType='{}'",
                         elem.getNodeName(), resourceType, parentResourceType);
 
                 if (!GRANITE_TABS.equals(parentResourceType)) {
-                    log.info("Skipping container '{}' as field, but parsing its children", elem.getNodeName());
+                    log.info("[collectFields] Skipping container '{}' as a field, but parsing its children", elem.getNodeName());
                     collectFields(elem, fields);
                     continue;
                 }
             }
 
+            // Parse valid fields
             if (!type.isEmpty()) {
                 List<ComponentField> parsed = parseField(elem);
                 if (parsed != null && !parsed.isEmpty()) {
-                    log.info("Adding {} parsed field(s) from node '{}'", parsed.size(), elem.getNodeName());
+                    log.info("[collectFields] Adding {} parsed field(s) from node '{}'", parsed.size(), elem.getNodeName());
                     fields.addAll(parsed);
                 } else {
-                    log.info("No valid fields parsed from node '{}'", elem.getNodeName());
+                    log.info("[collectFields] No valid fields parsed from node '{}'", elem.getNodeName());
                 }
             } else {
-                log.info("Recursing into children of node '{}' with unknown or empty type", elem.getNodeName());
+                // Recursively collect children if type is unknown or empty
+                log.info("[collectFields] Recursing into children of node '{}' with unknown or empty type", elem.getNodeName());
                 collectFields(elem, fields);
             }
         }
     }
 
     /**
-     * Finds the nearest ancestor element that defines a sling:resourceType.
-     * Useful for cases where wrapper nodes (e.g., <items>) don't have their own resourceType.
+     * Retrieves the {@code sling:resourceType} of the nearest parent element in the XML hierarchy.
+     * <p>
+     * This method traverses the ancestor nodes of the given element and returns the first
+     * {@code sling:resourceType} it finds. If no parent with a resource type exists, it returns
+     * an empty string.
+     * </p>
      *
-     * @param elem the starting XML element
-     * @return the sling:resourceType of the nearest ancestor, or empty string if none found
+     * @param elem the XML {@link Element} whose parent resource type is to be determined
+     * @return the {@code sling:resourceType} of the nearest parent element, or an empty string if none is found
      */
     private String getParentResourceType(Element elem) {
+        log.info("[getParentResourceType] Searching for parent resourceType of node '{}'", elem.getNodeName());
+
         Node parent = elem.getParentNode();
         while (parent instanceof Element parentElem) {
             if (parentElem.hasAttribute(SLING_RESOURCE_TYPE)) {
                 String resourceType = parentElem.getAttribute(SLING_RESOURCE_TYPE);
-                log.info("Found parent resourceType '{}' at node '{}'", resourceType, parentElem.getNodeName());
+                log.info("[getParentResourceType] Found parent resourceType '{}' at node '{}'", resourceType, parentElem.getNodeName());
                 return resourceType;
             }
             parent = parent.getParentNode();
         }
-        log.info("No parent resourceType found for node '{}'", elem.getNodeName());
+
+        log.info("[getParentResourceType] No parent resourceType found for node '{}'", elem.getNodeName());
         return "";
     }
 
-
     /**
-     * Retrieves a list of all component names for a given project.
+     * Retrieves a list of component names for a given AEM project.
+     * <p>
+     * This method fetches all components along with their groups using
+     * {@link #fetchComponentsWithGroups(String)} and returns only the component names.
+     * If no components are found, it returns an empty list.
+     * </p>
      *
-     * @param projectName the name of the project
-     * @return list of component names (empty list if none found)
+     * @param projectName the name of the AEM project
+     * @return a {@link List} of component names, or an empty list if no components exist
      */
     @Override
     public List<String> getProjectComponentsMap(String projectName) {
+        log.info("[getProjectComponentsMap] Fetching components for project '{}'", projectName);
+
         Map<String, String> components = fetchComponentsWithGroups(projectName);
         if (components == null || components.isEmpty()) {
-            log.warn("No components found for project '{}'", projectName);
+            log.info("[getProjectComponentsMap] No components found for project '{}'", projectName);
             return Collections.emptyList();
         }
-        return new ArrayList<>(components.keySet());
+
+        List<String> componentNames = new ArrayList<>(components.keySet());
+        log.info("[getProjectComponentsMap] Found {} component(s) for project '{}'", componentNames.size(), projectName);
+        return componentNames;
     }
 
     /**
-     * Adds the selected AEM components to an existing project by copying them into the project's
-     * content folder. This does not overwrite existing components unless explicitly handled in
-     * copySelectedComponents().
+     * Adds the specified components to an existing AEM project.
+     * <p>
+     * This method calculates the target content folder path based on the project name
+     * and application ID, then copies the selected components into the project structure.
+     * All key operations are logged for traceability.
+     * </p>
      *
-     * @param projectName        the name of the target project
-     * @param selectedComponents list of component names to add
+     * @param projectName        the name of the existing AEM project
+     * @param selectedComponents a {@link List} of component names to be added to the project
      */
     @Override
     public void addComponentsToExistingProject(String projectName, List<String> selectedComponents) {
-        log.info("Adding {} components to existing project '{}'", selectedComponents.size(), projectName);
+        log.info("[addComponentsToExistingProject] Adding {} component(s) to existing project '{}'",
+                selectedComponents.size(), projectName);
 
         try {
-
+            // Determine base directory and app ID
             String baseDir = System.getProperty(USER_DIR_SYS_PROP) + "/" + PROJECTS_DIR + "/";
             String appId = AemUtil.getAppId(PROJECTS_DIR, projectName);
 
             String contentFolderPath = baseDir + projectName + CONTENT_ROOT_PATH +
                     appId + "/" + COMPONENTS_FOLDER;
 
-            log.info("Copying components {} to '{}'", selectedComponents, contentFolderPath);
+            log.info("[addComponentsToExistingProject] Copying components {} to '{}'",
+                    selectedComponents, contentFolderPath);
 
+            // Copy selected components to the project
             copySelectedComponents(selectedComponents, contentFolderPath, projectName);
 
-            log.info("Successfully added components to project '{}'", projectName);
+            log.info("[addComponentsToExistingProject] Successfully added components to project '{}'", projectName);
 
         } catch (Exception e) {
-            log.error("Error while adding components to project '{}'", projectName, e);
+            log.error("[addComponentsToExistingProject] Error while adding components to project '{}'", projectName, e);
         }
     }
 
     /**
-     * Copies the selected AEM components into the project.
+     * Copies the selected AEM components into the target project directory, including
+     * updating content and HTL files, and copying associated Sling Models with dependencies.
      * <p>
-     * - Copies component files from source folder.
-     * - Updates .content.xml sling:resourceType.
-     * - Updates HTL files to reference the correct Sling Model.
-     * - Copies the Sling Model and dependencies.
+     * Steps performed for each component:
+     * <ol>
+     *     <li>Check if the source component exists.</li>
+     *     <li>Delete the destination folder if it already exists.</li>
+     *     <li>Copy the component folder to the target path.</li>
+     *     <li>Update the {@code sling:resourceType} in the component's {@code .content.xml}.</li>
+     *     <li>Update HTL file's {@code data-sly-use} reference to the fully qualified Sling Model class.</li>
+     *     <li>Copy the corresponding Sling Model and its dependencies.</li>
+     * </ol>
      * </p>
      *
-     * @param selectedComponents List of component names to copy
-     * @param targetPath         Target folder path in project
-     * @param projectName        Project name
+     * @param selectedComponents a {@link List} of component names to copy
+     * @param targetPath         the target directory where components will be copied
+     * @param projectName        the name of the project for logging and resource path updates
      */
     @Override
     public void copySelectedComponents(List<String> selectedComponents, String targetPath, String projectName) {
         if (selectedComponents == null || selectedComponents.isEmpty()) {
-            log.warn("No components selected to copy for project '{}'", projectName);
+            log.info("[copySelectedComponents] No components selected to copy for project '{}'", projectName);
             return;
         }
+
+        log.info("[copySelectedComponents] Starting to copy {} component(s) to project '{}'",
+                selectedComponents.size(), projectName);
 
         String slingModelsSourcePath = System.getProperty(USER_DIR_SYS_PROP) + "/" + SLING_MODELS_SOURCE;
         Path javaSourceRoot = Paths.get(PROJECTS_DIR, projectName, JAVA_SRC_PATH);
 
         Path modelPath = findModelBasePath(javaSourceRoot);
-        log.info("Model path found: {}", modelPath);
+        log.info("[copySelectedComponents] Model base path found: {}", modelPath);
 
         String modelBasePath = modelPath.toString();
         String packageName = javaSourceRoot.relativize(modelPath).toString().replace(File.separatorChar, '.');
@@ -1073,30 +1171,33 @@ public class ComponentServiceImpl implements ComponentService {
                 File destination = new File(targetPath + "/" + component);
 
                 if (!source.exists()) {
-                    log.warn("Source component not found: {}", source.getAbsolutePath());
+                    log.info("[copySelectedComponents] Source component not found: {}", source.getAbsolutePath());
                     continue;
                 }
 
                 if (destination.exists()) {
                     FileUtils.deleteDirectory(destination);
-                    log.info("Deleted existing component folder: {}", destination.getAbsolutePath());
+                    log.info("[copySelectedComponents] Deleted existing component folder: {}", destination.getAbsolutePath());
                 }
 
                 FileUtils.copyDirectory(source, destination);
-                log.info("Copied component '{}' to '{}'", component, destination.getAbsolutePath());
+                log.info("[copySelectedComponents] Copied component '{}' to '{}'", component, destination.getAbsolutePath());
 
+                // Update sling:resourceType in content.xml
                 File contentXml = new File(destination, CONTENT_XML);
                 if (contentXml.exists()) {
                     String content = FileUtils.readFileToString(contentXml, UTF_8);
                     content = content.replaceAll(SLING_RESOURCE_TYPE_PATTERN,
-                            SLING_RESOURCE_TYPE_ATTR + projectName + "/" + COMPONENTS_FOLDER + "/" + component.toLowerCase() + "\"");
+                            SLING_RESOURCE_TYPE_ATTR + projectName + "/" + COMPONENTS_FOLDER + "/" +
+                                    component.toLowerCase() + "\"");
                     FileUtils.writeStringToFile(contentXml, content, UTF_8);
-                    log.info("Updated sling:resourceType in {}", contentXml.getAbsolutePath());
+                    log.info("[copySelectedComponents] Updated sling:resourceType in '{}'", contentXml.getAbsolutePath());
                 }
 
+                // Update HTL model reference
                 File html = new File(destination, component + HTL_FILE_EXTENSION);
                 File parentModel = findMatchingModelFile(slingModelsSourcePath, component);
-                log.info("ParentModel......{}", parentModel);
+                log.info("[copySelectedComponents] Parent model for '{}': {}", component, parentModel);
                 if (html.exists() && parentModel != null) {
                     String htmlContent = FileUtils.readFileToString(html, UTF_8);
                     String fqcn = extractFullyQualifiedClassName(parentModel, packageName);
@@ -1104,36 +1205,40 @@ public class ComponentServiceImpl implements ComponentService {
                         htmlContent = htmlContent.replaceAll(DATA_SLY_USE_MODEL_PATTERN,
                                 DATA_SLY_USE_MODEL + fqcn + "\"");
                         FileUtils.writeStringToFile(html, htmlContent, UTF_8);
-                        log.info("Updated HTL model reference in {}", html.getAbsolutePath());
+                        log.info("[copySelectedComponents] Updated HTL model reference in '{}'", html.getAbsolutePath());
                     }
                 }
 
+                // Copy model and dependencies
                 if (parentModel != null && parentModel.exists()) {
                     copyModelAndDependencies(parentModel, slingModelsSourcePath, modelBasePath, packageName, copiedModels);
-                    log.info("Copied Sling Model and dependencies for component '{}'", component);
+                    log.info("[copySelectedComponents] Copied Sling Model and dependencies for component '{}'", component);
                 } else {
-                    log.warn("No matching Sling Model found for component '{}'", component);
+                    log.info("[copySelectedComponents] No matching Sling Model found for component '{}'", component);
                 }
 
             } catch (IOException e) {
-                log.error("Failed to process component '{}'", component, e);
+                log.error("[copySelectedComponents] Failed to process component '{}'", component, e);
             }
         }
+
+        log.info("[copySelectedComponents] Finished copying selected components for project '{}'", projectName);
     }
 
     /**
-     * Recursively searches for the first "models" directory under the given Java source root.
+     * Searches recursively for the 'models' directory under the given Java source root.
      * <p>
-     * This is typically used to locate the base package for Sling Models within the project's
-     * Java source directory.
+     * This method traverses the directory tree starting from {@code javaSourceRoot} and
+     * returns the first directory named {@code models}. If no such directory is found,
+     * an exception is thrown.
      * </p>
      *
-     * @param javaSourceRoot The root path of the Java source folder (e.g., core/src/main/java)
-     * @return Path to the "models" directory
-     * @throws RuntimeException if the "models" directory is not found or an I/O error occurs
+     * @param javaSourceRoot the root path of Java source files to search
+     * @return the {@link Path} to the 'models' directory
+     * @throws RuntimeException if an I/O error occurs or the 'models' directory is not found
      */
     private static Path findModelBasePath(Path javaSourceRoot) {
-        log.info("Searching for 'models' directory under Java source root: {}", javaSourceRoot);
+        log.info("[findModelBasePath] Searching for 'models' directory under Java source root: {}", javaSourceRoot);
 
         try (Stream<Path> paths = Files.walk(javaSourceRoot)) {
 
@@ -1143,102 +1248,115 @@ public class ComponentServiceImpl implements ComponentService {
                     .findFirst();
 
             if (modelPath.isPresent()) {
-                log.info("'models' directory found at: {}", modelPath.get());
+                log.info("[findModelBasePath] 'models' directory found at: {}", modelPath.get());
                 return modelPath.get();
             } else {
                 String errorMsg = "models directory not found under: " + javaSourceRoot;
-                log.error(errorMsg);
+                log.error("[findModelBasePath] " + errorMsg);
                 throw new IOException(errorMsg);
             }
 
         } catch (IOException e) {
-            log.error("Error while searching for 'models' directory under {}", javaSourceRoot, e);
+            log.error("[findModelBasePath] Error while searching for 'models' directory under {}", javaSourceRoot, e);
             throw new RuntimeException(e);
         }
     }
 
-
     /**
-     * Finds the Java Sling Model file corresponding to a given component.
+     * Searches for a matching Sling Model Java file for the given component in the specified models directory.
      * <p>
-     * The method first attempts an exact match using the pattern
-     * "{componentName}Model.java" (case-insensitive). If not found, it falls back
-     * to a partial match where the file name contains the component name and ends with "Model.java".
+     * The search prioritizes an exact match (componentName + MODEL_FILE_SUFFIX) and then falls back
+     * to partial matches that contain the component name and end with the model suffix.
      * </p>
      *
-     * @param modelsDirPath The absolute path to the directory containing Sling Model Java files.
-     * @param componentName The component name for which the model is being searched.
-     * @return The File object representing the matching Java model, or null if none is found.
+     * @param modelsDirPath the path to the directory containing Sling Model Java files
+     * @param componentName the name of the component whose Sling Model is to be found
+     * @return the {@link File} representing the matching Sling Model, or {@code null} if none is found
      */
     private File findMatchingModelFile(String modelsDirPath, String componentName) {
-        log.info("Searching for Sling Model for component '{}' in directory '{}'", componentName, modelsDirPath);
+        log.info("[findMatchingModelFile] Searching for Sling Model for component '{}' in directory '{}'",
+                componentName, modelsDirPath);
 
         File dir = new File(modelsDirPath);
         if (!dir.exists() || !dir.isDirectory()) {
-            log.warn("Models directory '{}' does not exist or is not a directory", modelsDirPath);
+            log.info("[findMatchingModelFile] Models directory '{}' does not exist or is not a directory", modelsDirPath);
             return null;
         }
 
         File[] files = dir.listFiles((d, name) -> name.endsWith(JAVA_EXTENSION));
         if (files == null || files.length == 0) {
-            log.warn("No Java files found in models directory '{}'", modelsDirPath);
+            log.info("[findMatchingModelFile] No Java files found in models directory '{}'", modelsDirPath);
             return null;
         }
 
         String lcComponent = componentName.toLowerCase();
 
+        // Check exact match first
         for (File file : files) {
             String lcFile = file.getName().toLowerCase();
             if (lcFile.equals(lcComponent + MODEL_FILE_SUFFIX)) {
-                log.info("Exact match found for component '{}' → '{}'", componentName, file.getName());
+                log.info("[findMatchingModelFile] Exact match found for component '{}' → '{}'", componentName, file.getName());
                 return file;
             }
         }
 
+        // Check partial matches
         for (File file : files) {
             String lcFile = file.getName().toLowerCase();
             if (lcFile.contains(lcComponent) && lcFile.endsWith(MODEL_FILE_SUFFIX)) {
-                log.info("Partial match found for component '{}' → '{}'", componentName, file.getName());
+                log.info("[findMatchingModelFile] Partial match found for component '{}' → '{}'", componentName, file.getName());
                 return file;
             }
         }
 
-        log.warn("No matching Sling Model found for component '{}'", componentName);
+        log.info("[findMatchingModelFile] No matching Sling Model found for component '{}'", componentName);
         return null;
     }
 
     /**
-     * Copies a Sling Model Java file to the target location, updating the package
-     * and internal imports, and recursively copies any dependent model classes.
+     * Copies a Sling Model Java file and its dependent models to the target package.
+     * <p>
+     * This method performs the following steps:
+     * <ol>
+     *     <li>Checks if the model file exists and if it has already been copied.</li>
+     *     <li>Updates the package declaration to the target package.</li>
+     *     <li>Updates import statements to reference the target package.</li>
+     *     <li>Writes the updated model file to the target directory.</li>
+     *     <li>Recursively copies all dependent Sling Models referenced in the model.</li>
+     * </ol>
+     * </p>
      *
-     * @param modelFile         The Java file representing the Sling Model to copy.
-     * @param sourceBase        The source directory containing the original models.
-     * @param targetBase        The target directory where the models should be copied.
-     * @param targetPackageName The Java package name to apply in the copied model.
-     * @param copiedModels      A set of model names that have already been copied to avoid duplication.
-     * @throws IOException If reading or writing files fails.
+     * @param modelFile         the source Sling Model Java file to copy
+     * @param sourceBase        the base directory of the source Sling Models
+     * @param targetBase        the target directory to copy the model into
+     * @param targetPackageName the target Java package name
+     * @param copiedModels      a {@link Set} tracking already copied models to avoid duplication
+     * @throws IOException if reading or writing files fails
      */
-    private void copyModelAndDependencies(File modelFile, String sourceBase, String targetBase, String targetPackageName, Set<String> copiedModels) throws IOException {
+    private void copyModelAndDependencies(File modelFile, String sourceBase, String targetBase,
+                                          String targetPackageName, Set<String> copiedModels) throws IOException {
         if (modelFile == null || !modelFile.exists()) {
-            log.warn("Model file is null or does not exist: {}", modelFile);
+            log.info("[copyModelAndDependencies] Model file is null or does not exist: {}", modelFile);
             return;
         }
 
         String modelName = modelFile.getName();
         if (copiedModels.contains(modelName)) {
-            log.info("Model '{}' already copied, skipping", modelName);
+            log.info("[copyModelAndDependencies] Model '{}' already copied, skipping", modelName);
             return;
         }
 
-        log.info("Copying Sling Model '{}'", modelName);
+        log.info("[copyModelAndDependencies] Copying Sling Model '{}'", modelName);
 
         String originalContent = FileUtils.readFileToString(modelFile, UTF_8);
 
+        // Update package declaration
         String content = originalContent.replaceFirst(
                 PACKAGE_DECLARATION_REGEX,
                 "package " + targetPackageName + ";"
         );
 
+        // Update import statements
         Pattern importPattern = Pattern.compile(IMPORT_STATEMENT_REGEX);
         Matcher importMatcher = importPattern.matcher(content);
         StringBuffer updatedContent = new StringBuffer();
@@ -1246,49 +1364,58 @@ public class ComponentServiceImpl implements ComponentService {
             String className = importMatcher.group(1);
             String newImport = "import " + targetPackageName + "." + className + ";";
             importMatcher.appendReplacement(updatedContent, Matcher.quoteReplacement(newImport));
-            log.info("Updated import for '{}' in model '{}'", className, modelName);
+            log.info("[copyModelAndDependencies] Updated import for '{}' in model '{}'", className, modelName);
         }
         importMatcher.appendTail(updatedContent);
         content = updatedContent.toString();
 
+        // Write updated model to target
         File destFile = new File(targetBase, modelFile.getName());
         destFile.getParentFile().mkdirs();
         FileUtils.writeStringToFile(destFile, content, UTF_8);
         copiedModels.add(modelName);
-        log.info("Sling Model '{}' copied to '{}'", modelName, destFile.getAbsolutePath());
+        log.info("[copyModelAndDependencies] Sling Model '{}' copied to '{}'", modelName, destFile.getAbsolutePath());
 
+        // Recursively copy dependent models
         Set<String> dependentTypes = extractReferencedModelTypes(originalContent);
         for (String type : dependentTypes) {
             File depFile = new File(sourceBase, type + JAVA_EXTENSION);
             if (depFile.exists()) {
-                log.info("Copying dependent model '{}' for '{}'", type, modelName);
+                log.info("[copyModelAndDependencies] Copying dependent model '{}' for '{}'", type, modelName);
                 copyModelAndDependencies(depFile, sourceBase, targetBase, targetPackageName, copiedModels);
             } else {
-                log.warn("Dependent model '{}' not found for '{}'", type, modelName);
+                log.info("[copyModelAndDependencies] Dependent model '{}' not found for '{}'", type, modelName);
             }
         }
     }
 
     /**
-     * Extracts referenced Sling Model class names from a given Java source content.
-     * This includes classes referenced via imports and direct usage in the code.
+     * Extracts the names of Sling Model classes referenced within a given Java source content.
+     * <p>
+     * This method detects references in two ways:
+     * <ol>
+     *     <li>Via import statements matching {@code IMPORT_STATEMENT_REGEX}.</li>
+     *     <li>Via usage of class names that exist in the Sling Models source directory.</li>
+     * </ol>
+     * </p>
      *
-     * @param content The Java source content as a string.
-     * @return A set of Sling Model class names referenced in the content.
+     * @param content the Java source code content to analyze
+     * @return a {@link Set} of referenced Sling Model class names
      */
     private Set<String> extractReferencedModelTypes(String content) {
         Set<String> types = new HashSet<>();
 
+        // 1. Extract types via import statements
         Pattern importPattern = Pattern.compile(IMPORT_STATEMENT_REGEX);
         Matcher importMatcher = importPattern.matcher(content);
         while (importMatcher.find()) {
             String type = importMatcher.group(1);
             types.add(type);
-            log.info("Found referenced model via import: {}", type);
+            log.info("[extractReferencedModelTypes] Found referenced model via import: {}", type);
         }
 
+        // 2. Extract types via direct usage in code
         File modelsDir = new File(System.getProperty(USER_DIR_SYS_PROP) + "/" + SLING_MODELS_SOURCE);
-
         if (modelsDir.exists() && modelsDir.isDirectory()) {
             File[] modelFiles = modelsDir.listFiles((dir, name) -> name.endsWith(JAVA_EXTENSION));
             if (modelFiles != null) {
@@ -1298,28 +1425,31 @@ public class ComponentServiceImpl implements ComponentService {
                     Matcher usageMatcher = usagePattern.matcher(content);
                     if (usageMatcher.find()) {
                         types.add(className);
-                        log.info("Found referenced model via usage: {}", className);
+                        log.info("[extractReferencedModelTypes] Found referenced model via usage: {}", className);
                     }
                 }
             }
         } else {
-            log.warn("Sling Models directory not found: {}", modelsDir.getAbsolutePath());
+            log.info("[extractReferencedModelTypes] Sling Models directory not found: {}", modelsDir.getAbsolutePath());
         }
 
         return types;
     }
 
     /**
-     * Extracts the fully qualified class name (FQCN) from a Java file.
-     * Uses the target package name to construct the FQCN.
+     * Extracts the fully qualified class name (FQCN) from a given Java file.
+     * <p>
+     * The FQCN is constructed using the provided target package and the public class
+     * name declared in the Java file.
+     * </p>
      *
-     * @param javaFile      The Java source file
-     * @param targetPackage The package name to prepend
-     * @return Fully qualified class name, or null if not found
+     * @param javaFile      the Java source file to extract the class name from
+     * @param targetPackage the target package name to prepend to the class name
+     * @return the fully qualified class name, or {@code null} if not found
      */
     private String extractFullyQualifiedClassName(File javaFile, String targetPackage) {
         if (javaFile == null || !javaFile.exists()) {
-            log.warn("Java file does not exist: {}", javaFile);
+            log.info("[extractFullyQualifiedClassName] Java file does not exist: {}", javaFile);
             return null;
         }
 
@@ -1331,52 +1461,60 @@ public class ComponentServiceImpl implements ComponentService {
             if (matcher.find()) {
                 String className = matcher.group(1);
                 String fqcn = targetPackage + "." + className;
-                log.info("Extracted FQCN '{}' from file '{}'", fqcn, javaFile.getAbsolutePath());
+                log.info("[extractFullyQualifiedClassName] Extracted FQCN '{}' from file '{}'", fqcn, javaFile.getAbsolutePath());
                 return fqcn;
             } else {
-                log.warn("No public class found in file '{}'", javaFile.getAbsolutePath());
+                log.info("[extractFullyQualifiedClassName] No public class found in file '{}'", javaFile.getAbsolutePath());
             }
         } catch (IOException e) {
-            log.error("Failed to extract FQCN from file '{}'", javaFile.getAbsolutePath(), e);
+            log.error("[extractFullyQualifiedClassName] Failed to extract FQCN from file '{}'", javaFile.getAbsolutePath(), e);
         }
         return null;
     }
 
     /**
-     * Fetches all component groups for a given project.
+     * Retrieves the list of component groups for the specified AEM project.
      * <p>
-     * This method scans the project's components folder recursively and collects all
-     * component groups. It excludes technical groups like Structure, hidden, or Form groups.
+     * This method reads the application title from the POM file (if available),
+     * determines the components folder path, and recursively collects all
+     * component groups. Technical or hidden groups (like structure or form groups)
+     * are excluded from the final list.
+     * </p>
      *
-     * @param projectName the name of the project
-     * @return a list of component groups; if none found, returns a list with the project name
+     * @param projectName the name of the project for which to fetch component groups
+     * @return a list of component group names, or a single entry containing the
+     * project/app title if no groups are found
      */
     @Override
     public List<String> getComponentGroups(String projectName) {
-        log.info("Starting to fetch component groups for project '{}'", projectName);
+        log.info("[getComponentGroups] Starting to fetch component groups for project '{}'", projectName);
 
+        // Resolve application title from POM or fallback to project name
         String appTitle = readAppTitleFromPom(projectName);
         if (appTitle == null || appTitle.isBlank()) {
-            log.info("App title not found in POM, using project name '{}'", projectName);
+            log.info("[getComponentGroups] App title not found in POM, using project name '{}'", projectName);
             appTitle = projectName;
         }
         String appId = AemUtil.getAppId(PROJECTS_DIR, projectName);
 
+        // Resolve the absolute components folder path
         String componentsPath = PROJECTS_DIR + "/" + projectName + CONTENT_ROOT_PATH + appId + "/" + COMPONENTS_FOLDER;
-        log.info("Components folder path resolved to '{}'", componentsPath);
+        log.info("[getComponentGroups] Components folder path resolved to '{}'", componentsPath);
 
         File folder = new File(componentsPath);
         Set<String> groups = new HashSet<>();
-        groups.add(appTitle);
+        groups.add(appTitle); // Ensure app title is always present as a group
 
+        // Collect groups if the folder exists
         if (folder.exists() && folder.isDirectory()) {
-            log.info("Collecting component groups from folder '{}'", componentsPath);
+            log.info("[getComponentGroups] Collecting component groups from folder '{}'", componentsPath);
             collectComponentGroupsRecursive(folder, groups);
-            log.info("Groups collected (before filtering): {}", groups);
+            log.info("[getComponentGroups] Groups collected (before filtering): {}", groups);
         } else {
-            log.warn("Components folder '{}' does not exist for project '{}'", componentsPath, projectName);
+            log.info("[getComponentGroups] Components folder '{}' does not exist for project '{}'", componentsPath, projectName);
         }
 
+        // Filter out technical/hidden groups
         final String finalAppTitle = appTitle;
         groups.removeIf(g -> {
             String trimmed = g.trim();
@@ -1384,34 +1522,39 @@ public class ComponentServiceImpl implements ComponentService {
                     || trimmed.equals(HIDDEN_GROUP)
                     || trimmed.contains(FORM_GROUP_SUFFIX);
             if (remove) {
-                log.debug("Excluding group '{}' as technical or hidden", trimmed);
+                log.info("[getComponentGroups] Excluding group '{}' as technical or hidden", trimmed);
             }
             return remove;
         });
-        log.info("Groups after filtering: {}", groups);
+        log.info("[getComponentGroups] Groups after filtering: {}", groups);
 
+        // Finalize the result, falling back to app title if no groups remain
         List<String> result = groups.isEmpty() ? List.of(appTitle) : new ArrayList<>(groups);
-        log.info("Final component groups for project '{}': {}", projectName, result);
+        log.info("[getComponentGroups] Final component groups for project '{}': {}", projectName, result);
 
         return result;
     }
 
     /**
-     * Recursively collects component groups from a directory.
-     * Skips technical or excluded folders like _cq_, hidden, backup, etc.
+     * Recursively collects component group names from a directory and its subdirectories.
+     * <p>
+     * This method scans each folder for a {@code .content.xml} file and extracts the
+     * {@code componentGroup} property. All found groups are added to the provided {@code groups} set.
+     * Excluded folders are skipped, and filtering of technical/hidden groups is performed later.
+     * </p>
      *
-     * @param dir    the current folder to scan
-     * @param groups the set of collected component groups
+     * @param dir    the directory to scan for component groups
+     * @param groups the set to collect component group names
      */
     private void collectComponentGroupsRecursive(File dir, Set<String> groups) {
         if (!dir.isDirectory()) {
-            log.debug("Skipping non-directory: {}", dir.getAbsolutePath());
+            log.info("[collectComponentGroupsRecursive] Skipping non-directory: {}", dir.getAbsolutePath());
             return;
         }
 
         String dirName = dir.getName();
         if (EXCLUDED_FOLDERS.stream().anyMatch(ex -> dirName.equalsIgnoreCase(ex) || dirName.startsWith(ex))) {
-            log.debug("Skipping excluded folder '{}'", dir.getAbsolutePath());
+            log.info("[collectComponentGroupsRecursive] Skipping excluded folder '{}'", dir.getAbsolutePath());
             return;
         }
 
@@ -1420,10 +1563,10 @@ public class ComponentServiceImpl implements ComponentService {
             String content = FileGenerationUtil.readFile(contentXml);
             String group = extractProperty(content, COMPONENT_GROUP).trim();
             if (!group.isEmpty()) {
-                log.info("Found component group '{}' in folder '{}'", group, dir.getAbsolutePath());
-                groups.add(group); // add all groups; filtering is done later
+                log.info("[collectComponentGroupsRecursive] Found component group '{}' in folder '{}'", group, dir.getAbsolutePath());
+                groups.add(group); // Add all groups; filtering is done later
             } else {
-                log.debug("No componentGroup property found in '{}'", contentXml.getAbsolutePath());
+                log.info("[collectComponentGroupsRecursive] No componentGroup property found in '{}'", contentXml.getAbsolutePath());
             }
         }
 
@@ -1433,21 +1576,25 @@ public class ComponentServiceImpl implements ComponentService {
                 collectComponentGroupsRecursive(subDir, groups);
             }
         } else {
-            log.debug("No subdirectories found in '{}'", dir.getAbsolutePath());
+            log.info("[collectComponentGroupsRecursive] No subdirectories found in '{}'", dir.getAbsolutePath());
         }
     }
 
     /**
-     * Reads the app title (componentGroupName) from a project's pom.xml file.
+     * Reads the application title from the project's pom.xml file.
+     * <p>
+     * The method looks for the {@code <componentGroupName>} element inside the POM.
+     * If found, it returns the trimmed text content; otherwise, it returns {@code null}.
+     * </p>
      *
-     * @param projectName the project folder name
-     * @return the componentGroupName from pom.xml, or null if not found
+     * @param projectName the name of the project whose POM is to be read
+     * @return the application title from the POM, or {@code null} if not found or on error
      */
     public String readAppTitleFromPom(String projectName) {
         File pom = new File(PROJECTS_DIR + "/" + projectName + "/" + POM_FILE_NAME);
 
         if (!pom.exists()) {
-            log.warn("pom.xml not found for project '{}'", projectName);
+            log.info("[readAppTitleFromPom] pom.xml not found for project '{}'", projectName);
             return null;
         }
 
@@ -1458,37 +1605,48 @@ public class ComponentServiceImpl implements ComponentService {
             Node node = doc.getElementsByTagName("componentGroupName").item(0);
             if (node != null) {
                 String title = node.getTextContent().trim();
-                log.info("Read app title '{}' from pom.xml for project '{}'", title, projectName);
+                log.info("[readAppTitleFromPom] Read app title '{}' from pom.xml for project '{}'", title, projectName);
                 return title;
             } else {
-                log.warn("No <componentGroupName> element found in pom.xml for project '{}'", projectName);
+                log.info("[readAppTitleFromPom] No <componentGroupName> element found in pom.xml for project '{}'", projectName);
                 return null;
             }
         } catch (Exception e) {
-            log.error("Failed to read app title from pom.xml for project '{}'", projectName, e);
+            log.error("[readAppTitleFromPom] Failed to read app title from pom.xml for project '{}'", projectName, e);
             return null;
         }
     }
 
     /**
-     * Generates all files for a given component request within the specified project.
+     * Generates a new AEM component for the given project based on the provided request.
+     * <p>
+     * This method delegates the actual file generation to {@link FileGenerationUtil#generateAllFiles(String, ComponentRequest)}.
+     * Logs are added before and after generation for tracking purposes.
+     * </p>
      *
-     * @param projectName the name of the project
-     * @param request     the component request containing metadata and configuration
+     * @param projectName the name of the project where the component will be generated
+     * @param request     the component request containing details like component name and configuration
      */
     @Override
     public void generateComponent(String projectName, ComponentRequest request) {
-        log.info("Generating component '{}' for project '{}'", request.getComponentName(), projectName);
+        String componentName = request.getComponentName();
+        log.info("[generateComponent] Generating component '{}' for project '{}'", componentName, projectName);
+
         FileGenerationUtil.generateAllFiles(projectName, request);
-        log.info("Component '{}' generation completed for project '{}'", request.getComponentName(), projectName);
+
+        log.info("[generateComponent] Component '{}' generation completed for project '{}'", componentName, projectName);
     }
 
     /**
-     * Checks if a given component name is available within a project.
+     * Checks if a component name is available for creation in a given project.
+     * <p>
+     * The method resolves the exact path of the component using {@link #findComponentPathExact(String, String)}.
+     * If the path does not exist or is empty, the component is considered available.
+     * </p>
      *
-     * @param projectName   the name of the project
+     * @param projectName   the project in which to check for component availability
      * @param componentName the component name to check
-     * @return true if the component name is available (does not exist), false otherwise
+     * @return {@code true} if the component name is available, {@code false} otherwise
      */
     @Override
     public boolean isComponentNameAvailable(String projectName, String componentName) {
@@ -1496,55 +1654,66 @@ public class ComponentServiceImpl implements ComponentService {
         String basePath = findComponentPathExact(projectName, componentName);
 
         if (basePath == null || basePath.isBlank()) {
-            log.warn("Base path not found for project '{}' and component '{}'. Assuming available.", projectName, componentName);
+            log.info("[isComponentNameAvailable] Base path not found for project '{}' and component '{}'. Assuming available.", projectName, componentName);
             return true;
         }
 
         File componentDir = new File(basePath);
 
         if (componentDir.exists() && componentDir.isDirectory()) {
-            log.info("Component '{}' already exists at path '{}'", componentName, basePath);
+            log.info("[isComponentNameAvailable] Component '{}' already exists at path '{}'", componentName, basePath);
             return false;
         }
 
-        log.info("Component '{}' is available at path '{}'", componentName, basePath);
+        log.info("[isComponentNameAvailable] Component '{}' is available at path '{}'", componentName, basePath);
         return true;
     }
 
     /**
-     * Fetch all components from the local project structure, grouped by their component group.
+     * Retrieves all components of a project grouped by their component groups.
+     * <p>
+     * The method constructs the components folder path using the project name and app ID,
+     * then recursively scans for components, grouping them by their respective component group names.
+     * </p>
      *
-     * @param projectName the name of the project
-     * @return a map where key = component group, value = list of component names
+     * @param projectName the name of the project whose components are to be fetched
+     * @return a map where the key is the component group name and the value is a list of component names
      */
+    @Override
     public Map<String, List<String>> getComponentsByGroup(String projectName) {
 
         String appId = AemUtil.getAppId(PROJECTS_DIR, projectName);
 
         String componentsPath = PROJECTS_DIR + "/" + projectName + CONTENT_ROOT_PATH + appId + "/" + COMPONENTS_FOLDER;
 
-        log.info("Fetching components for project '{}' from '{}'", projectName, componentsPath);
+        log.info("[getComponentsByGroup] Fetching components for project '{}' from '{}'", projectName, componentsPath);
 
         Map<String, List<String>> groupedComponents = new HashMap<>();
 
         scanComponents(new File(componentsPath), groupedComponents, APPS_PATH_PREFIX + appId + "/" + COMPONENTS_FOLDER);
 
-        log.info("Completed fetching components. Total groups found: {}", groupedComponents.size());
+        log.info("[getComponentsByGroup] Completed fetching components. Total groups found: {}", groupedComponents.size());
 
         return groupedComponents;
     }
 
 
     /**
-     * Recursively scans a folder to find AEM components and groups them by component group.
+     * Recursively scans a folder for AEM components and groups them by their component group names.
+     * <p>
+     * Components are identified by the presence of a `.content.xml` file and validated via {@link #isComponent(File)}.
+     * Skips any folders listed in {@link com.aem.builder.constants.ComponentConstants#EXCLUDED_FOLDERS}.
+     * Updates the provided map with component group names as keys
+     * and a list of relative component paths as values.
+     * </p>
      *
-     * @param folder            the current folder to scan
-     * @param groupedComponents map of component group → list of component paths
-     * @param basePath          the relative base path to prepend to each component path
+     * @param folder            the folder to scan for components
+     * @param groupedComponents the map to populate with components grouped by their component groups
+     * @param basePath          the base path used to calculate relative component paths
      */
     private void scanComponents(File folder, Map<String, List<String>> groupedComponents, String basePath) {
         if (folder == null || !folder.exists() || !folder.isDirectory()) {
-            log.warn("Folder does not exist or is not a directory: {}", folder);
+            log.info("[scanComponents] Folder does not exist or is not a directory: {}", folder);
             return;
         }
 
@@ -1557,7 +1726,7 @@ public class ComponentServiceImpl implements ComponentService {
             String name = file.getName();
 
             if (EXCLUDED_FOLDERS.stream().anyMatch(ex -> name.equalsIgnoreCase(ex) || name.startsWith(ex))) {
-                log.debug("Skipping excluded folder: {}", name);
+                log.info("[scanComponents] Skipping excluded folder: {}", name);
                 continue;
             }
 
@@ -1566,7 +1735,7 @@ public class ComponentServiceImpl implements ComponentService {
             if (contentXml.exists() && isComponent(contentXml)) {
                 String group = getComponentGroup(contentXml);
                 if (group == null) {
-                    log.debug("Skipping hidden or invalid component in folder: {}", file.getAbsolutePath());
+                    log.info("[scanComponents] Skipping hidden or invalid component in folder: {}", file.getAbsolutePath());
                     continue;
                 }
 
@@ -1576,23 +1745,31 @@ public class ComponentServiceImpl implements ComponentService {
 
                 if (!groupedComponents.get(group).contains(relativePath)) {
                     groupedComponents.get(group).add(relativePath);
-                    log.info("Added component '{}' under group '{}'", relativePath, group);
+                    log.info("[scanComponents] Added component '{}' under group '{}'", relativePath, group);
                 }
             }
 
+            // Recurse into subdirectories
             scanComponents(file, groupedComponents, basePath + "/" + name);
         }
     }
 
     /**
-     * Checks whether the given .content.xml file represents an actual AEM component.
+     * Determines whether a given .content.xml file represents a valid AEM component.
+     * <p>
+     * This method parses the XML and checks if the root element's <code>jcr:primaryType</code>
+     * matches the constant <code>CQ_COMPONENT_PRIMARY_TYPE</code> defined in {@link com.aem.builder.constants.ComponentConstants}.
+     * Logs are generated at the start, during validation, and on success or failure.
+     * </p>
      *
      * @param contentXml The .content.xml file to check.
-     * @return true if it represents a component; false otherwise.
+     * @return {@code true} if the file represents a valid AEM component; {@code false} otherwise.
      */
     private boolean isComponent(File contentXml) {
+        log.info("[isComponent] Checking if file '{}' is an AEM component", contentXml);
+
         if (contentXml == null || !contentXml.exists() || !contentXml.isFile()) {
-            log.warn("Invalid .content.xml file: {}", contentXml);
+            log.info("[isComponent] Invalid .content.xml file: {}", contentXml);
             return false;
         }
 
@@ -1600,29 +1777,38 @@ public class ComponentServiceImpl implements ComponentService {
             Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(contentXml);
             Element root = doc.getDocumentElement();
 
-            String primaryType = root.getAttribute(JCR_PRIMARY_TYPE); // use constant if defined
+            String primaryType = root.getAttribute(JCR_PRIMARY_TYPE);
             boolean isComponent = CQ_COMPONENT_PRIMARY_TYPE.equals(primaryType);
 
-            log.debug("Checked file '{}', jcr:primaryType='{}', isComponent={}",
+            log.info("[isComponent] Checked file '{}', jcr:primaryType='{}', isComponent={}",
                     contentXml.getAbsolutePath(), primaryType, isComponent);
 
+            log.info("[isComponent] Result for file '{}': {}", contentXml.getAbsolutePath(), isComponent);
             return isComponent;
 
         } catch (Exception e) {
-            log.error("Error parsing .content.xml: {}", contentXml.getAbsolutePath(), e);
+            log.error("[isComponent] Error parsing .content.xml file '{}'", contentXml.getAbsolutePath(), e);
             return false;
         }
     }
 
     /**
-     * Retrieves the component group from the given .content.xml file.
+     * Retrieves the component group for a given .content.xml file.
+     * <p>
+     * Parses the XML file and returns the value of the <code>componentGroup</code> attribute.
+     * If the component is marked as hidden (via {@link com.aem.builder.constants.ComponentConstants#HIDDEN_GROUP}),
+     * this method returns {@code null}. If no group is defined, returns the default group
+     * ({@link com.aem.builder.constants.ComponentConstants#DEFAULT_COMPONENT_GROUP}).
+     * </p>
      *
      * @param contentXml The .content.xml file of the component.
-     * @return The component group name, or null if it is hidden, or "Others" if not defined.
+     * @return The component group name, {@code null} if hidden, or the default group if undefined.
      */
     private String getComponentGroup(File contentXml) {
+        log.info("[getComponentGroup] Fetching component group for file '{}'", contentXml);
+
         if (contentXml == null || !contentXml.exists() || !contentXml.isFile()) {
-            log.warn("Invalid .content.xml file: {}", contentXml);
+            log.info("[getComponentGroup] Invalid .content.xml file: {}", contentXml);
             return DEFAULT_COMPONENT_GROUP;
         }
 
@@ -1634,67 +1820,84 @@ public class ComponentServiceImpl implements ComponentService {
                 String group = root.getAttribute(COMPONENT_GROUP).trim();
 
                 if (HIDDEN_GROUP.equalsIgnoreCase(group)) {
-                    log.debug("Component '{}' is hidden; skipping group.", contentXml.getName());
+                    log.info("[getComponentGroup] Component '{}' is hidden; skipping group.", contentXml.getName());
                     return null;
                 }
 
-                log.debug("Component '{}' belongs to group '{}'", contentXml.getName(), group);
+                log.info("[getComponentGroup] Component '{}' belongs to group '{}'", contentXml.getName(), group);
                 return group;
             }
         } catch (Exception e) {
-            log.error("Error reading component group from '{}'", contentXml.getAbsolutePath(), e);
+            log.error("[getComponentGroup] Error reading component group from '{}'", contentXml.getAbsolutePath(), e);
         }
 
-        log.debug("Component '{}' has no group defined; assigning default group '{}'", contentXml.getName(), DEFAULT_COMPONENT_GROUP);
+        log.info("[getComponentGroup] Component '{}' has no group defined; assigning default group '{}'",
+                contentXml.getName(), DEFAULT_COMPONENT_GROUP);
         return DEFAULT_COMPONENT_GROUP;
     }
 
     /**
-     * Search for a component anywhere under the project's components folder.
-     * Stops at the first match since component names are unique.
+     * Searches for the exact path of a component within a given AEM project.
+     * <p>
+     * The method constructs the components root folder path based on the project name and app ID,
+     * then recursively searches for a component folder whose name exactly matches the provided component name.
+     * </p>
      *
-     * @param projectName   The AEM project name
-     * @param componentName The exact name of the component to search
-     * @return Full path of the component if found, otherwise null
+     * @param projectName   The name of the AEM project.
+     * @param componentName The exact name of the component to find.
+     * @return The absolute path of the component if found; {@code null} otherwise.
      */
     public String findComponentPathExact(String projectName, String componentName) {
+        log.info("[findComponentPathExact] Searching for component '{}' in project '{}'", componentName, projectName);
+
         String appId = AemUtil.getAppId(PROJECTS_DIR, projectName);
 
-        File componentsRoot = new File(PROJECTS_DIR + "/" + projectName + CONTENT_ROOT_PATH + appId + "/" + COMPONENTS_FOLDER);
+        File componentsRoot = new File(PROJECTS_DIR + "/" + projectName
+                + CONTENT_ROOT_PATH + appId + "/" + COMPONENTS_FOLDER);
 
-        log.debug("Searching for component '{}' in project '{}', under path '{}'", componentName, projectName, componentsRoot.getAbsolutePath());
+        log.info("[findComponentPathExact] Components root path: '{}'", componentsRoot.getAbsolutePath());
 
         if (componentsRoot.exists() && componentsRoot.isDirectory()) {
             String foundPath = searchComponentRecursiveExact(componentsRoot, componentName);
+
             if (foundPath != null) {
-                log.info("Component '{}' found at path '{}'", componentName, foundPath);
+                log.info("[findComponentPathExact] Component '{}' found at '{}'", componentName, foundPath);
             } else {
-                log.warn("Component '{}' not found in project '{}'", componentName, projectName);
+                log.info("[findComponentPathExact] Component '{}' not found in project '{}'", componentName, projectName);
             }
             return foundPath;
         } else {
-            log.error("Components root folder does not exist for project '{}': {}", projectName, componentsRoot.getAbsolutePath());
+            log.error("[findComponentPathExact] Components root folder does not exist for project '{}': {}",
+                    projectName, componentsRoot.getAbsolutePath());
             return null;
         }
     }
 
     /**
-     * Recursively search for a component folder by exact case-sensitive name.
-     * Stops at the first match since component names are unique.
+     * Recursively searches for a component folder that exactly matches the given component name.
+     * <p>
+     * Performs a case-sensitive match against folder names. If the component folder is found, returns its absolute path.
+     * Recurses into all subdirectories otherwise.
+     * </p>
      *
-     * @param dir           Current directory to search
-     * @param componentName The exact name of the component to match
-     * @return Full path of the component if found, otherwise null
+     * @param dir           The directory to start searching from.
+     * @param componentName The exact name of the component to search for.
+     * @return The absolute path of the matching component folder if found; {@code null} otherwise.
      */
     public String searchComponentRecursiveExact(File dir, String componentName) {
+        log.info("[searchComponentRecursiveExact] Searching for component '{}' in directory '{}'",
+                componentName, dir != null ? dir.getPath() : "null");
+
         if (dir == null || !dir.isDirectory()) {
-            log.debug("Skipping non-directory or null path: {}", (dir != null ? dir.getPath() : "null"));
+            log.info("[searchComponentRecursiveExact] Skipping non-directory or null path: {}",
+                    (dir != null ? dir.getPath() : "null"));
             return null;
         }
 
         // Exact case-sensitive match
         if (dir.getName().equals(componentName)) {
-            log.info("Exact match found for component '{}' at '{}'", componentName, dir.getPath());
+            log.info("[searchComponentRecursiveExact] Exact match found for component '{}' at '{}'",
+                    componentName, dir.getPath());
             return dir.getPath();
         }
 
@@ -1708,37 +1911,39 @@ public class ComponentServiceImpl implements ComponentService {
             }
         }
 
-        log.trace("Component '{}' not found in directory '{}'", componentName, dir.getPath());
+        log.trace("[searchComponentRecursiveExact] Component '{}' not found in directory '{}'",
+                componentName, dir.getPath());
         return null;
     }
 
     /**
-     * Fetch all component supertypes defined in the given AEM project.
+     * Fetches the super types of all components in the specified AEM project.
      * <p>
-     * Reads each component's `.content.xml`, extracts the {@code sling:resourceSuperType},
-     * and builds a normalized mapping of component paths → display labels.
-     * The map is returned sorted alphabetically by the label (value).
+     * Iterates through all components, reads their `.content.xml` files, and extracts the
+     * `sling:resourceSuperType` attribute. Returns a map where the key is the component path
+     * or supertype path, and the value is the last segment of the component/supertype name.
+     * Handles missing `.content.xml` files or components gracefully.
+     * </p>
      *
-     * @param projectName The name of the AEM project
-     * @return A sorted map of component path → label
+     * @param projectName The name of the project to fetch component supertypes from.
+     * @return A map of component or supertype paths to their last path segment, sorted alphabetically.
      */
     @Override
     public Map<String, String> fetchComponentSuperTypes(String projectName) {
-        Map<String, String> superTypeMap = new LinkedHashMap<>();
+        log.info("[fetchComponentSuperTypes] Starting to fetch component supertypes for project '{}'", projectName);
 
-        // Constants
+        Map<String, String> superTypeMap = new LinkedHashMap<>();
         final String CONTENT_XML = ".content.xml";
         final String ATTR_SUPER_TYPE = "sling:resourceSuperType";
 
         try {
             Map<String, String> components = fetchComponentsWithGroups(projectName);
-            log.info("Fetching component supertypes for project '{}', found {} components",
-                    projectName, components.size());
+            log.info("[fetchComponentSuperTypes] Found {} components in project '{}'", components.size(), projectName);
 
             for (String componentName : components.keySet()) {
                 String componentPath = findComponentPathExact(projectName, componentName);
                 if (componentPath == null) {
-                    log.warn("Component '{}' not found under project '{}'", componentName, projectName);
+                    log.info("[fetchComponentSuperTypes] Component '{}' not found under project '{}'", componentName, projectName);
                     continue;
                 }
 
@@ -1755,13 +1960,13 @@ public class ComponentServiceImpl implements ComponentService {
                         Element root = doc.getDocumentElement();
                         if (root.hasAttribute(ATTR_SUPER_TYPE)) {
                             superType = root.getAttribute(ATTR_SUPER_TYPE);
-                            log.debug("Found supertype '{}' for component '{}'", superType, componentName);
+                            log.info("[fetchComponentSuperTypes] Found supertype '{}' for component '{}'", superType, componentName);
                         }
                     } catch (Exception e) {
-                        log.error("Error parsing {} for component '{}'", CONTENT_XML, componentName, e);
+                        log.error("[fetchComponentSuperTypes] Error parsing '{}' for component '{}'", CONTENT_XML, componentName, e);
                     }
                 } else {
-                    log.warn("{} not found for component '{}'", CONTENT_XML, componentName);
+                    log.info("[fetchComponentSuperTypes] '{}' not found for component '{}'", CONTENT_XML, componentName);
                 }
 
                 String normalized = componentPath.replace(File.separatorChar, '/');
@@ -1784,8 +1989,10 @@ public class ComponentServiceImpl implements ComponentService {
                     putIfNotExists(superTypeMap, componentRepoPath, compLastName);
                 }
             }
+
+            log.info("[fetchComponentSuperTypes] Successfully fetched supertypes for project '{}'", projectName);
         } catch (Exception e) {
-            log.error("Error fetching component supertypes for project '{}'", projectName, e);
+            log.error("[fetchComponentSuperTypes] Error fetching component supertypes for project '{}'", projectName, e);
         }
 
         return superTypeMap.entrySet().stream()
@@ -1797,50 +2004,46 @@ public class ComponentServiceImpl implements ComponentService {
                         LinkedHashMap::new
                 ));
     }
+
     /**
-     * Inserts a key-value pair into the provided map only if:
-     * <ul>
-     *   <li>The key is not already present</li>
-     *   <li>The value is not already present</li>
-     * </ul>
-     * This helps prevent duplicate entries both by path (key) and by label (value).
+     * Adds a key-value mapping to the provided map if neither the key nor the value already exists.
+     * <p>
+     * This ensures that duplicate keys or values are not inserted. Logs addition and skip decisions
+     * for traceability.
+     * </p>
      *
-     * @param map   Target map of component path → label
-     * @param key   Component path (e.g., /apps/project/components/mycomp)
-     * @param value Display label for the component
+     * @param map   The map to update.
+     * @param key   The key to add.
+     * @param value The value to add.
      */
     private void putIfNotExists(Map<String, String> map, String key, String value) {
+        log.info("[putIfNotExists] Attempting to add mapping [{}] -> [{}]", key, value);
+
         if (!map.containsKey(key) && !map.containsValue(value)) {
             map.put(key, value);
-            log.debug("Added mapping: [{}] -> [{}]", key, value);
+            log.info("[putIfNotExists] Added mapping: [{}] -> [{}]", key, value);
         } else {
-            log.trace("Skipping duplicate entry for key [{}] or value [{}]", key, value);
+            log.trace("[putIfNotExists] Skipping duplicate entry for key [{}] or value [{}]", key, value);
         }
     }
 
     /**
-     * Extracts a human-readable, version-aware label from a component supertype path.
+     * Extracts a version-aware component name from a given superType path.
      * <p>
-     * Examples:
-     * <ul>
-     *   <li>{@code core/wcm/components/button/v1/button} → {@code button (v1)}</li>
-     *   <li>{@code core/wcm/components/container/v2/container} → {@code container (v2)}</li>
-     *   <li>{@code custom/components/teaser} → {@code teaser}</li>
-     * </ul>
+     * If the superType path contains a version segment (e.g., "v1"), it appends the version
+     * in parentheses to the last segment of the path. Otherwise, returns the last segment.
      * </p>
      *
-     * <p>If the path does not contain a version segment (e.g., v1, v2), the method
-     * simply returns the last segment of the path. If parsing fails, the original
-     * {@code superTypePath} is returned unchanged.</p>
-     *
-     * @param superTypePath full supertype path (e.g., {@code core/wcm/components/button/v1/button})
-     * @return version-aware display name
+     * @param superTypePath The full superType path (e.g., "/apps/project/components/v1/button").
+     * @return The version-aware name (e.g., "button (v1)") or the last segment if no version detected.
      */
     private String extractVersionAwareName(String superTypePath) {
         final String VERSION_PATTERN = "v\\d+";
 
+        log.info("[extractVersionAwareName] Extracting version-aware name from '{}'", superTypePath);
+
         if (superTypePath == null || superTypePath.isBlank()) {
-            log.warn("Received blank or null superTypePath for version-aware extraction.");
+            log.info("[extractVersionAwareName] Received blank or null superTypePath.");
             return "";
         }
 
@@ -1851,52 +2054,53 @@ public class ComponentServiceImpl implements ComponentService {
 
             if (secondLast.matches(VERSION_PATTERN)) {
                 String result = last + " (" + secondLast + ")";
-                log.debug("Extracted version-aware name '{}' from superType '{}'", result, superTypePath);
+                log.info("[extractVersionAwareName] Extracted version-aware name '{}' from '{}'", result, superTypePath);
                 return result;
             }
 
-            log.debug("Extracted simple name '{}' from superType '{}'", last, superTypePath);
+            log.info("[extractVersionAwareName] Extracted simple name '{}' from '{}'", last, superTypePath);
             return last;
         }
 
-        log.debug("Could not parse '{}', returning as-is.", superTypePath);
+        log.info("[extractVersionAwareName] Could not parse '{}', returning as-is.", superTypePath);
         return superTypePath;
     }
 
     /**
-     * Fetches all parent dialog tabs from a given component's supertype hierarchy.
+     * Retrieves all parent tabs for a given component superType in a project.
      * <p>
-     * This method traverses up the inheritance chain of the specified superType
-     * and collects all dialog tabs (if present). Tabs are merged into a set to
-     * preserve insertion order and avoid duplicates.
+     * This method recursively collects tabs from the specified superType and aggregates them
+     * into a set to avoid duplicates. The resulting map contains a flag indicating whether any
+     * tabs were found and a list of the collected tab names.
      * </p>
      *
-     * @param projectName the name of the AEM project
-     * @param superType   the component's sling:resourceSuperType path
-     * @return a result map with:
+     * @param projectName The name of the AEM project.
+     * @param superType   The sling:resourceSuperType of the component to fetch tabs for.
+     * @return A map containing:
      * <ul>
-     *     <li>{@code hasTabs} → boolean, true if any tabs were found</li>
-     *     <li>{@code tabs} → list of tab names</li>
+     *     <li>"hasTabs": {@code true} if any tabs were found; {@code false} otherwise.</li>
+     *     <li>"tabs": A list of tab names (empty if none found).</li>
      * </ul>
      */
     @Override
     public Map<String, Object> getParentTabs(String projectName, String superType) {
+        log.info("[getParentTabs] Fetching parent tabs for superType '{}' in project '{}'", superType, projectName);
+
         Map<String, Object> result = new HashMap<>();
         Set<String> tabs = new LinkedHashSet<>();
 
         try {
-
             collectTabsRecursively(projectName, superType, tabs);
 
             boolean hasTabs = !tabs.isEmpty();
             result.put("hasTabs", hasTabs);
             result.put("tabs", new ArrayList<>(tabs));
 
-            log.info("Final merged tabs for superType '{}' in project '{}': {}",
+            log.info("[getParentTabs] Final merged tabs for superType '{}' in project '{}': {}",
                     superType, projectName, tabs);
 
         } catch (Exception e) {
-            log.error(" Error while fetching parent tabs for superType '{}' in project '{}'",
+            log.error("[getParentTabs] Error while fetching parent tabs for superType '{}' in project '{}'",
                     superType, projectName, e);
 
             result.put("hasTabs", false);
@@ -1907,23 +2111,23 @@ public class ComponentServiceImpl implements ComponentService {
     }
 
     /**
-     * Recursively collects dialog tabs from the given component and its superTypes.
+     * Recursively collects all tabs defined for a component and its parent superTypes.
      * <p>
-     * The method works by:
-     * <ol>
-     *     <li>Checking if the component has a {@code _cq_dialog/.content.xml} and extracting its tabs.</li>
-     *     <li>Looking for a {@code .content.xml} to identify its {@code sling:resourceSuperType}.</li>
-     *     <li>Recursively traversing into the parent superType if found.</li>
-     * </ol>
+     * This method traverses the superType hierarchy of a component, parsing dialog files
+     * to collect tab names. Tabs from core components and project-specific components are
+     * merged into the provided {@code tabs} set to avoid duplicates.
+     * </p>
      *
-     * @param projectName the AEM project name
-     * @param superType   the sling:resourceSuperType path to process
-     * @param tabs        the set to which tab names are added
-     * @throws Exception if file parsing fails
+     * @param projectName The name of the AEM project.
+     * @param superType   The sling:resourceSuperType of the component whose tabs are being collected.
+     * @param tabs        A set to accumulate tab names; duplicates are ignored.
+     * @throws Exception If there is an error reading or parsing dialog files.
      */
     private void collectTabsRecursively(String projectName, String superType, Set<String> tabs) throws Exception {
+        log.info("[collectTabsRecursively] Collecting tabs for superType '{}' in project '{}'", superType, projectName);
+
         if (superType == null || superType.isBlank()) {
-            log.warn("Skipping empty superType for project '{}'", projectName);
+            log.info("[collectTabsRecursively] Skipping empty superType for project '{}'", projectName);
             return;
         }
 
@@ -1941,23 +2145,23 @@ public class ComponentServiceImpl implements ComponentService {
 
             if (!currentTabs.isEmpty()) {
                 tabs.addAll(currentTabs);
-                log.info("Tabs collected from '{}' [{}]: {}", superType, (isCore ? "core" : "project"), currentTabs);
+                log.info("[collectTabsRecursively] Tabs collected from '{}' [{}]: {}", superType, (isCore ? "core" : "project"), currentTabs);
             }
         }
 
         File compContentFile = new File(basePath, CONTENT_XML);
         if (!compContentFile.exists()) {
-            log.debug("No .content.xml found for '{}'", superType);
+            log.info("[collectTabsRecursively] No .content.xml found for '{}'", superType);
             return;
         }
 
         String parentSuperType = readSuperType(compContentFile);
         if (parentSuperType == null || parentSuperType.isBlank()) {
-            log.debug("No parent superType defined for '{}'", superType);
+            log.info("[collectTabsRecursively] No parent superType defined for '{}'", superType);
             return;
         }
 
-        log.info(" '{}' extends '{}'", superType, parentSuperType);
+        log.info("[collectTabsRecursively] '{}' extends '{}'", superType, parentSuperType);
 
         if (parentSuperType.startsWith(CORE_PREFIX)) {
             String corePath = System.getProperty(USER_DIR_SYS_PROP) + CORE_RESOURCE_PATH_PREFIX + parentSuperType;
@@ -1967,10 +2171,10 @@ public class ComponentServiceImpl implements ComponentService {
                 List<String> coreTabs = parseCoreTabsFromDialog(coreDialog);
                 if (!coreTabs.isEmpty()) {
                     tabs.addAll(coreTabs);
-                    log.info("Core Tabs collected from '{}': {}", parentSuperType, coreTabs);
+                    log.info("[collectTabsRecursively] Core Tabs collected from '{}': {}", parentSuperType, coreTabs);
                 }
             } else {
-                log.warn("Core dialog not found for '{}': {}", parentSuperType, coreDialog.getAbsolutePath());
+                log.info("[collectTabsRecursively] Core dialog not found for '{}': {}", parentSuperType, coreDialog.getAbsolutePath());
             }
         } else {
             collectTabsRecursively(projectName, parentSuperType, tabs);
@@ -1978,18 +2182,18 @@ public class ComponentServiceImpl implements ComponentService {
     }
 
     /**
-     * Parse dialog file (.content.xml) and extract tab names for project-specific (non-core) components.
+     * Parses a project-specific dialog file to extract all defined tab titles.
      * <p>
-     * It looks for nodes with sling:resourceType = granite/ui/components/coral/foundation/tabs
-     * and then iterates through their <items> children to collect tab containers.
+     * The method searches for nodes with sling:resourceType = "granite/ui/components/coral/foundation/tabs"
+     * and then iterates through their child items to collect tab titles from granite containers.
      * </p>
      *
-     * @param dialogFile the dialog .content.xml file for the component
-     * @return list of tab titles detected (may be empty if no tabs found)
-     * @throws Exception if XML parsing fails
+     * @param dialogFile The dialog XML file to parse.
+     * @return A list of tab titles defined in the dialog. Returns an empty list if no tabs are found.
+     * @throws Exception If an error occurs while reading or parsing the dialog file.
      */
     private List<String> parseProjectTabsFromDialog(File dialogFile) throws Exception {
-        log.info("Parsing project dialog for tabs: {}", dialogFile.getAbsolutePath());
+        log.info("[parseProjectTabsFromDialog] Parsing project dialog for tabs: {}", dialogFile.getAbsolutePath());
 
         List<String> tabs = new ArrayList<>();
 
@@ -2006,7 +2210,7 @@ public class ComponentServiceImpl implements ComponentService {
             // Check if this node is a <tabs> definition (granite resource type)
             org.w3c.dom.Node resType = attrs.getNamedItem(SLING_RESOURCE_TYPE);
             if (resType != null && GRANITE_TABS.equals(resType.getNodeValue())) {
-                log.debug(" Found granite tabs node at index {}", i);
+                log.info("[parseProjectTabsFromDialog] Found granite tabs node at index {}", i);
 
                 NodeList itemsNodes = node.getChildNodes();
                 for (int j = 0; j < itemsNodes.getLength(); j++) {
@@ -2029,7 +2233,7 @@ public class ComponentServiceImpl implements ComponentService {
                                     : tabNode.getNodeName();
 
                             tabs.add(tabTitle);
-                            log.info("   ➕ Project Tab detected: {}", tabTitle);
+                            log.info("[parseProjectTabsFromDialog] ➕ Project Tab detected: {}", tabTitle);
                         }
                     }
                 }
@@ -2037,23 +2241,28 @@ public class ComponentServiceImpl implements ComponentService {
         }
 
         if (tabs.isEmpty()) {
-            log.warn("No project tabs found in {}", dialogFile.getName());
+            log.info("[parseProjectTabsFromDialog] No project tabs found in {}", dialogFile.getName());
         } else {
-            log.info("Total project tabs collected: {}", tabs.size());
+            log.info("[parseProjectTabsFromDialog] Total project tabs collected: {}", tabs.size());
         }
 
         return tabs;
     }
 
     /**
-     * Parse dialog file and extract tab names for Core components.
-     * This method searches recursively until the first <tabs> node is found.
+     * Parses a core AEM dialog file to extract all tab titles recursively.
+     * <p>
+     * This method handles core components where tabs can be nested within containers.
+     * It delegates the recursive extraction to {@link #parseTabsRecursive(org.w3c.dom.Node, List)}.
+     * </p>
      *
-     * @param dialogFile the .content.xml dialog file
-     * @return list of tab titles found in the Core component
-     * @throws Exception if parsing fails
+     * @param dialogFile The core dialog XML file to parse.
+     * @return A list of tab titles found in the core dialog. Returns an empty list if none are found.
+     * @throws Exception If an error occurs while reading or parsing the dialog file.
      */
     private List<String> parseCoreTabsFromDialog(File dialogFile) throws Exception {
+        log.info("[parseCoreTabsFromDialog] Parsing core dialog for tabs: {}", dialogFile.getAbsolutePath());
+
         List<String> tabs = new ArrayList<>();
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);
@@ -2061,23 +2270,31 @@ public class ComponentServiceImpl implements ComponentService {
         Document doc = builder.parse(dialogFile);
 
         org.w3c.dom.Node root = doc.getDocumentElement();
-        log.debug("Starting recursive parsing for Core tabs in file: {}", dialogFile.getAbsolutePath());
+        log.info("[parseCoreTabsFromDialog] Starting recursive parsing from root element: {}", root.getNodeName());
 
         parseTabsRecursive(root, tabs);
 
-        log.info("Core tabs parsed from {}: {}", dialogFile.getName(), tabs);
+        if (tabs.isEmpty()) {
+            log.info("[parseCoreTabsFromDialog] No core tabs found in {}", dialogFile.getName());
+        } else {
+            log.info("[parseCoreTabsFromDialog] Core tabs parsed from {}: {}", dialogFile.getName(), tabs);
+        }
+
         return tabs;
     }
 
+
     /**
-     * Recursively parses XML nodes to extract tab names.
-     * Supports both Core and project components.
+     * Recursively parses an XML node to extract tab titles for core AEM dialogs.
      * <p>
-     * Stops at <tabs> nodes or nodes with sling:resourceType = coral/foundation/tabs,
-     * and extracts <container> nodes with jcr:title as tab titles.
+     * This method traverses all child nodes, identifies <tabs> nodes (or nodes with
+     * granite/ui/components/coral/foundation/tabs resource type), and collects the titles
+     * of each tab container. It adds detected tab titles to the provided list and
+     * continues recursion for nested containers.
+     * </p>
      *
-     * @param node current XML node being inspected
-     * @param tabs collection of tab titles found so far
+     * @param node The XML node to inspect recursively.
+     * @param tabs The list to populate with discovered tab titles.
      */
     private void parseTabsRecursive(org.w3c.dom.Node node, List<String> tabs) {
         if (node.getNodeType() != org.w3c.dom.Node.ELEMENT_NODE) {
@@ -2086,11 +2303,12 @@ public class ComponentServiceImpl implements ComponentService {
 
         NamedNodeMap attrs = node.getAttributes();
 
-        if (TYPE_TABS.equals(node.getNodeName()) ||
+        boolean isTabsNode = TYPE_TABS.equals(node.getNodeName()) ||
                 (attrs != null && attrs.getNamedItem(SLING_RESOURCE_TYPE) != null &&
-                        GRANITE_TABS.equals(attrs.getNamedItem(SLING_RESOURCE_TYPE).getNodeValue()))) {
+                        GRANITE_TABS.equals(attrs.getNamedItem(SLING_RESOURCE_TYPE).getNodeValue()));
 
-            log.debug(" Found <tabs> node at: {}", node.getNodeName());
+        if (isTabsNode) {
+            log.info("[parseTabsRecursive] Found <tabs> node at '{}'", node.getNodeName());
 
             NodeList itemsNodes = node.getChildNodes();
             for (int i = 0; i < itemsNodes.getLength(); i++) {
@@ -2106,20 +2324,18 @@ public class ComponentServiceImpl implements ComponentService {
                     if (tabAttrs == null) continue;
 
                     org.w3c.dom.Node resTypeAttr = tabAttrs.getNamedItem(SLING_RESOURCE_TYPE);
-                    if (resTypeAttr != null &&
-                            GRANITE_CONTAINER.equals(resTypeAttr.getNodeValue())) {
-
+                    if (resTypeAttr != null && GRANITE_CONTAINER.equals(resTypeAttr.getNodeValue())) {
                         org.w3c.dom.Node titleAttr = tabAttrs.getNamedItem(JCR_TITLE);
                         String tabTitle = (titleAttr != null) ? titleAttr.getNodeValue() : tabNode.getNodeName();
                         tabs.add(tabTitle);
-                        log.info("   ➕ Core Tab detected: {}", tabTitle);
+                        log.info("[parseTabsRecursive] ➕ Core Tab detected: {}", tabTitle);
                     }
 
+                    // Recursive call for nested structures
                     parseTabsRecursive(tabNode, tabs);
                 }
             }
         } else {
-
             NodeList children = node.getChildNodes();
             for (int i = 0; i < children.getLength(); i++) {
                 parseTabsRecursive(children.item(i), tabs);
@@ -2127,18 +2343,21 @@ public class ComponentServiceImpl implements ComponentService {
         }
     }
 
-
-
     /**
-     * Reads sling:resourceSuperType from .content.xml.
-     * This method parses the given component's .content.xml file
-     * and looks for the sling:resourceSuperType attribute.
+     * Reads the superType of an AEM component from its .content.xml file.
+     * <p>
+     * This method parses the XML file, inspects all attributes of all nodes, and
+     * returns the value of the attribute representing the component's super type.
+     * It checks for both the standard {@code sling:resourceSuperType} attribute
+     * and any attribute ending with the configured suffix {@code :resourceSuperType}.
+     * </p>
      *
-     * @param compContentFile the .content.xml file of the component
-     * @return the value of sling:resourceSuperType if found, otherwise null
+     * @param compContentFile The .content.xml file of the component.
+     * @return The superType as a string if found; {@code null} otherwise.
+     * @throws Exception If there is an error parsing the XML file.
      */
     private String readSuperType(File compContentFile) throws Exception {
-        log.info(" Reading superType from file: {}", compContentFile.getAbsolutePath());
+        log.info("[readSuperType] Reading superType from file: {}", compContentFile.getAbsolutePath());
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);
@@ -2156,42 +2375,63 @@ public class ComponentServiceImpl implements ComponentService {
                     String name = attr.getNodeName();
                     String value = attr.getNodeValue();
 
-                    log.debug("Attribute found: {} = {}", name, value);
+                    log.info("[readSuperType] Attribute found: {} = {}", name, value);
 
                     if (SLING_RESOURCE_SUPER_TYPE.equals(name) || name.endsWith(SUFFIX_RESOURCE_SUPER_TYPE)) {
-                        log.info(" Found superType: {}", value);
+                        log.info("[readSuperType] Found superType: {}", value);
                         return value;
                     }
                 }
             }
         }
 
-        log.warn("No sling:resourceSuperType found in {}", compContentFile.getName());
+        log.info("[readSuperType] No sling:resourceSuperType found in {}", compContentFile.getName());
         return null;
     }
+
     /**
-     * Returns a list of editable components by filtering out hidden/system structure components.
+     * Filters and returns a list of editable AEM components from the provided component map.
+     * <p>
+     * A component is considered editable if its component group is either:
+     * <ul>
+     *     <li>null</li>
+     *     <li>not a structure group (i.e., does not equal "{@code appTitle - Structure}")</li>
+     *     <li>not hidden (i.e., does not equal ".hidden")</li>
+     * </ul>
+     * </p>
      *
-     * @param compMap Map of componentName → componentGroup
-     * @param appTitle The title of the application/project (used to filter "Structure" group)
-     * @return List of editable component names
+     * @param compMap  A map of component paths to their respective groups.
+     * @param appTitle The application title used to identify structure groups.
+     * @return A list of component paths that are editable.
      */
     public List<String> getEditableComponents(Map<String, String> compMap, String appTitle) {
+        log.info("[getEditableComponents] Filtering editable components for app '{}'", appTitle);
+
         if (compMap == null || compMap.isEmpty()) {
+            log.info("[getEditableComponents] Component map is null or empty. Returning empty list.");
             return List.of();
         }
 
-        return compMap.entrySet()
+        List<String> editableComponents = compMap.entrySet()
                 .stream()
                 .filter(entry -> {
                     String group = Optional.ofNullable(entry.getValue())
                             .map(String::trim)
                             .orElse(null);
-                    // Editable if group is null, or not structure, and not hidden
-                    return group == null
+                    boolean isEditable = group == null
                             || (!group.equals(appTitle + " - Structure") && !group.equals(".hidden"));
+                    if (!isEditable) {
+                        log.info("[getEditableComponents] Excluding component '{}' in group '{}'", entry.getKey(), group);
+                    } else {
+                        log.info("[getEditableComponents] Including editable component '{}'", entry.getKey());
+                    }
+                    return isEditable;
                 })
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toList());
+
+        log.info("[getEditableComponents] Total editable components found: {}", editableComponents.size());
+        return editableComponents;
     }
+
 }

--- a/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
@@ -178,7 +178,7 @@ public class ComponentServiceImpl implements ComponentService {
             String fileName = resource.getFilename();
             if (fileName != null) {
                 components.add(fileName);
-                log.debug("[getAllComponents] Discovered component resource: {}", fileName);
+                log.info("[getAllComponents] Discovered component resource: {}", fileName);
             }
         }
 
@@ -227,10 +227,21 @@ public class ComponentServiceImpl implements ComponentService {
                 .collect(Collectors.toList());
 
         log.info("[getDistinctComponents] Distinct components found: {}", distinct.size());
-        log.debug("[getDistinctComponents] Distinct components list: {}", distinct);
+        log.info("[getDistinctComponents] Distinct components list: {}", distinct);
 
         return distinct;
     }
+
+    /**
+     * Retrieves a list of existing generated projects from the workspace.
+     * <p>
+     * This method checks the default generated projects directory and returns
+     * the names of all existing projects. If the directory does not exist or
+     * is empty, it returns an empty list.
+     * </p>
+     *
+     * @return a list of existing project names; empty if none are found
+     */
 
     /**
      * Loads a component's metadata and dialog fields for a given project and component name.
@@ -255,20 +266,20 @@ public class ComponentServiceImpl implements ComponentService {
         try {
             File contentXml = new File(basePath, CONTENT_XML);
             if (contentXml.exists()) {
-                log.debug("[loadComponent] Reading component metadata from '{}'", contentXml.getAbsolutePath());
+                log.info("[loadComponent] Reading component metadata from '{}'", contentXml.getAbsolutePath());
                 String content = FileGenerationUtil.readFile(contentXml);
 
                 group = extractProperty(content, COMPONENT_GROUP).trim();
                 superType = extractProperty(content, SLING_RESOURCE_SUPER_TYPE).trim();
 
-                log.debug("[loadComponent] Parsed component metadata: group='{}', superType='{}'", group, superType);
+                log.info("[loadComponent] Parsed component metadata: group='{}', superType='{}'", group, superType);
             } else {
-                log.warn("[loadComponent] .content.xml not found for component '{}'", componentName);
+                log.info("[loadComponent] .content.xml not found for component '{}'", componentName);
             }
 
             File dialogXml = new File(basePath + "/" + CQ_DIALOG + "/" + CONTENT_XML);
             if (dialogXml.exists()) {
-                log.debug("[loadComponent] Parsing dialog XML at '{}'", dialogXml.getAbsolutePath());
+                log.info("[loadComponent] Parsing dialog XML at '{}'", dialogXml.getAbsolutePath());
 
                 DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
                 factory.setNamespaceAware(false); // disabling namespaces for easier parsing
@@ -278,7 +289,7 @@ public class ComponentServiceImpl implements ComponentService {
                 collectFields(doc.getDocumentElement(), fields);
                 log.info("[loadComponent] Collected {} field(s) for component '{}'", fields.size(), componentName);
             } else {
-                log.warn("[loadComponent] Dialog XML not found for component '{}'", componentName);
+                log.info("[loadComponent] Dialog XML not found for component '{}'", componentName);
             }
 
         } catch (Exception e) {
@@ -314,13 +325,13 @@ public class ComponentServiceImpl implements ComponentService {
         String compPath = PROJECTS_DIR + "/" + projectName + "/" + CONTENT_ROOT_PATH + appId + COMPONENTS_FOLDER + request.getComponentName();
 
         log.info("[updateComponent] Updating component '{}' in project '{}'", request.getComponentName(), projectName);
-        log.debug("[updateComponent] Resolved component path for update: {}", compPath);
+        log.info("[updateComponent] Resolved component path for update: {}", compPath);
 
         try {
             FileUtils.deleteDirectory(new File(compPath));
             log.info("[updateComponent] Deleted existing component directory: {}", compPath);
         } catch (IOException e) {
-            log.warn("[updateComponent] Could not clean component folder before update for '{}'", request.getComponentName(), e);
+            log.info("[updateComponent] Could not clean component folder before update for '{}'", request.getComponentName(), e);
         }
 
         FileGenerationUtil.generateAllFiles(projectName, request);
@@ -351,15 +362,15 @@ public class ComponentServiceImpl implements ComponentService {
 
         String compPath = findComponentPathExact(projectName, componentName);
         if (compPath == null) {
-            log.warn("[deleteComponent] Component '{}' not found in project '{}'", componentName, projectName);
+            log.info("[deleteComponent] Component '{}' not found in project '{}'", componentName, projectName);
             return;
         }
-        log.debug("[deleteComponent] Component folder resolved at '{}'", compPath);
+        log.info("[deleteComponent] Component folder resolved at '{}'", compPath);
 
         Set<String> slingModels = new HashSet<>();
         try {
             slingModels = collectSlingModelsFromHTLFolder(new File(compPath));
-            log.debug("[deleteComponent] Sling Models found: {}", slingModels);
+            log.info("[deleteComponent] Sling Models found: {}", slingModels);
         } catch (IOException e) {
             log.error("[deleteComponent] Failed to read HTL files for component '{}'", componentName, e);
         }
@@ -369,7 +380,7 @@ public class ComponentServiceImpl implements ComponentService {
                 .filter(f -> TYPE_MULTIFIELD.equals(f.getFieldType()))
                 .map(ComponentField::getFieldName)
                 .collect(Collectors.toSet());
-        log.debug("[deleteComponent] Multifield names collected: {}", multifieldNames);
+        log.info("[deleteComponent] Multifield names collected: {}", multifieldNames);
 
         Set<String> javaClassesToDelete = new HashSet<>();
         Set<String> processedClasses = new HashSet<>();
@@ -383,7 +394,7 @@ public class ComponentServiceImpl implements ComponentService {
                 log.error("[deleteComponent] Failed to collect child classes for '{}'", fqcn, e);
             }
         }
-        log.debug("[deleteComponent] Java classes marked for deletion: {}", javaClassesToDelete);
+        log.info("[deleteComponent] Java classes marked for deletion: {}", javaClassesToDelete);
 
         try {
             FileUtils.deleteDirectory(new File(compPath));
@@ -417,7 +428,7 @@ public class ComponentServiceImpl implements ComponentService {
     private Set<String> collectSlingModelsFromHTLFolder(File dir) throws IOException {
         Set<String> slingModels = new HashSet<>();
         if (!dir.isDirectory()) {
-            log.warn("[collectSlingModelsFromHTLFolder] Provided path '{}' is not a directory", dir.getAbsolutePath());
+            log.info("[collectSlingModelsFromHTLFolder] Provided path '{}' is not a directory", dir.getAbsolutePath());
             return slingModels;
         }
 
@@ -426,10 +437,10 @@ public class ComponentServiceImpl implements ComponentService {
 
         for (File file : files) {
             if (file.isDirectory()) {
-                log.debug("[collectSlingModelsFromHTLFolder] Entering directory '{}'", file.getAbsolutePath());
+                log.info("[collectSlingModelsFromHTLFolder] Entering directory '{}'", file.getAbsolutePath());
                 slingModels.addAll(collectSlingModelsFromHTLFolder(file));
             } else if (file.isFile() && file.getName().endsWith(HTL_FILE_EXTENSION)) {
-                log.debug("[collectSlingModelsFromHTLFolder] Processing HTL file '{}'", file.getAbsolutePath());
+                log.info("[collectSlingModelsFromHTLFolder] Processing HTL file '{}'", file.getAbsolutePath());
                 slingModels.addAll(extractSlingModelsFromHTL(file));
             }
         }
@@ -452,7 +463,7 @@ public class ComponentServiceImpl implements ComponentService {
      */
     private Set<String> extractSlingModelsFromHTL(File htlFile) throws IOException {
         Set<String> classes = new HashSet<>();
-        log.debug("[extractSlingModelsFromHTL] Extracting Sling Models from HTL file '{}'", htlFile.getAbsolutePath());
+        log.info("[extractSlingModelsFromHTL] Extracting Sling Models from HTL file '{}'", htlFile.getAbsolutePath());
 
         List<String> lines = Files.readAllLines(htlFile.toPath());
         for (String line : lines) {
@@ -467,7 +478,7 @@ public class ComponentServiceImpl implements ComponentService {
 
                     if (ref.startsWith("com.")) {
                         classes.add(ref);
-                        log.debug("[extractSlingModelsFromHTL] Found Sling Model reference: '{}'", ref);
+                        log.info("[extractSlingModelsFromHTL] Found Sling Model reference: '{}'", ref);
                     }
                 }
             }
@@ -478,19 +489,23 @@ public class ComponentServiceImpl implements ComponentService {
     }
 
     /**
-     * Recursively collects a Java class and all its child classes.
+     * Recursively collects a Java class and its child classes for deletion.
      * <p>
-     * Child classes are identified via {@code @ChildResource} annotations
-     * or via multifield references in the parent class.
-     * All identified class names are added to {@code javaClassesToDelete}.
+     * The method processes a given Java class file to detect:
+     * <ul>
+     *     <li>@ChildResource annotated fields referencing other classes</li>
+     *     <li>Multifield child classes based on provided field names</li>
+     * </ul>
+     * It adds all discovered class file names to {@code javaClassesToDelete} and tracks processed
+     * classes in {@code processedClasses} to avoid infinite recursion.
      * </p>
      *
-     * @param javaRoot            Root path of the Java source folder
-     * @param className           Name of the class to process
-     * @param javaClassesToDelete Set to store class names to be deleted
-     * @param processedClasses    Set to avoid processing the same class multiple times
-     * @param multifieldNames     Set of multifield variable names to track child dependencies
-     * @throws IOException If reading the Java file fails
+     * @param javaRoot            the root directory of Java source files
+     * @param className           the simple name of the class to process
+     * @param javaClassesToDelete the set of Java class file names to delete
+     * @param processedClasses    the set of classes already processed to prevent recursion
+     * @param multifieldNames     the set of multifield names to detect child classes
+     * @throws IOException if there is an error reading Java class files
      */
     private void collectClassAndChildren(Path javaRoot, String className,
                                          Set<String> javaClassesToDelete,
@@ -498,25 +513,28 @@ public class ComponentServiceImpl implements ComponentService {
                                          Set<String> multifieldNames) throws IOException {
 
         if (processedClasses.contains(className)) {
-            log.debug("Class '{}' already processed, skipping recursion", className);
+            log.info("[collectClassAndChildren] Class '{}' already processed, skipping recursion", className);
             return;
         }
         processedClasses.add(className);
 
+        // Locate the Java class file
         Path classPath = findJavaClassRecursive(javaRoot, className + JAVA_EXTENSION);
         if (classPath == null) {
-            log.warn("Java class '{}' not found under '{}'", className, javaRoot);
+            log.info("[collectClassAndChildren] Java class '{}' not found under '{}'", className, javaRoot);
             return;
         }
-        log.info("Found Java class '{}' at '{}'", className, classPath);
+        log.info("[collectClassAndChildren] Found Java class '{}' at '{}'", className, classPath);
 
         javaClassesToDelete.add(classPath.getFileName().toString());
 
+        // Read all lines from the class
         List<String> lines = Files.readAllLines(classPath);
 
         for (int i = 0; i < lines.size(); i++) {
             String line = lines.get(i).trim();
 
+            // 1. Detect @ChildResource fields
             if (line.contains(CHILD_RESOURCE_ANNOTATION)) {
                 for (int j = i + 1; j < Math.min(i + 4, lines.size()); j++) {
                     String fieldLine = lines.get(j).trim();
@@ -525,17 +543,18 @@ public class ComponentServiceImpl implements ComponentService {
                         String childClass = m.group(1) != null ? m.group(1) :
                                 m.group(2) != null ? m.group(2) : m.group(3);
                         if (childClass != null && !childClass.equals(className)) {
-                            log.info("Found @ChildResource child class '{}' in '{}'", childClass, className);
+                            log.info("[collectClassAndChildren] Found @ChildResource child class '{}' in '{}'", childClass, className);
                             collectClassAndChildren(javaRoot, childClass, javaClassesToDelete, processedClasses, multifieldNames);
                         }
                     }
                 }
             }
 
+            // 2. Detect multifield child classes
             for (String mfName : multifieldNames) {
                 if (line.matches(".*\\b([A-Z]\\w+)\\s+" + mfName + ";.*")) {
                     String childClassName = line.replaceAll(".*\\b([A-Z]\\w+)\\s+" + mfName + ";.*", "$1");
-                    log.info("Found child class '{}' for multifield '{}' in '{}'", childClassName, mfName, className);
+                    log.info("[collectClassAndChildren] Found child class '{}' for multifield '{}' in '{}'", childClassName, mfName, className);
                     collectClassAndChildren(javaRoot, childClassName, javaClassesToDelete, processedClasses, multifieldNames);
                 }
             }
@@ -543,20 +562,21 @@ public class ComponentServiceImpl implements ComponentService {
     }
 
     /**
-     * Recursively searches for a Java class file by its simple name under the given root directory.
+     * Recursively searches for a Java class file within the given root directory.
      * <p>
-     * This method walks the directory tree starting from {@code javaRoot} and looks for a file
-     * whose name exactly matches {@code className}. If found, it returns the {@link Path} to the file;
-     * otherwise, returns {@code null}.
+     * This method performs a depth-first walk of the directory tree starting from
+     * {@code javaRoot} to locate a Java source file that matches the specified
+     * {@code className}. If found, it returns the {@link Path} to the matching file;
+     * otherwise, it returns {@code null}.
      * </p>
      *
-     * @param javaRoot  the root directory under which to search (typically {@code core/src/main/java})
-     * @param className the simple file name of the Java class to find (e.g., "MyComponentModel.java")
-     * @return {@link Path} to the Java class file if found; {@code null} otherwise
+     * @param javaRoot  the root directory to search for the Java class file
+     * @param className the name of the Java class file to locate (e.g., "MyModel.java")
+     * @return the {@link Path} of the found Java class file, or {@code null} if not found
      * @throws IOException if an I/O error occurs while walking the file tree
      */
     private Path findJavaClassRecursive(Path javaRoot, String className) throws IOException {
-        log.info("Searching for Java class '{}' under '{}'", className, javaRoot);
+        log.info("[findJavaClassRecursive] Starting search for Java class '{}' under '{}'", className, javaRoot);
 
         try (Stream<Path> paths = Files.walk(javaRoot)) {
             Path found = paths
@@ -565,29 +585,37 @@ public class ComponentServiceImpl implements ComponentService {
                     .orElse(null);
 
             if (found != null) {
-                log.info("Java class '{}' found at '{}'", className, found);
+                log.info("[findJavaClassRecursive] Java class '{}' found at '{}'", className, found);
             } else {
-                log.warn("Java class '{}' not found under '{}'", className, javaRoot);
+                log.info("[findJavaClassRecursive] Java class '{}' not found under '{}'", className, javaRoot);
             }
+
+            log.info("[findJavaClassRecursive] Search completed for class '{}'", className);
             return found;
         }
     }
 
     /**
-     * Reads and returns the HTML content of a specific AEM component.
+     * Retrieves the HTML (HTL) content of a specified AEM component within a given project.
+     * <p>
+     * This method locates the exact component path using the project and component names,
+     * constructs the HTL file path, and reads its content. If the component or its HTL file
+     * cannot be found or read, it returns an empty string.
+     * </p>
      *
-     * @param projectName   the name of the project containing the component
-     * @param componentName the name of the component
-     * @return the HTML content as a {@link String}; empty string if reading fails
+     * @param projectName   the name of the AEM project where the component resides
+     * @param componentName the name of the AEM component whose HTML content is to be retrieved
+     * @return the HTML (HTL) content of the component as a {@link String}, or an empty string
+     * if the component is not found or the file cannot be read
      */
     @Override
     public String getComponentHtml(String projectName, String componentName) {
 
-        log.info("Fetching HTML for component '{}' in project '{}'", componentName, projectName);
+        log.info("[getComponentHtml] Fetching HTML for component '{}' in project '{}'", componentName, projectName);
 
         String componentPathExact = findComponentPathExact(projectName, componentName);
         if (componentPathExact == null) {
-            log.warn("Component '{}' not found in project '{}'", componentName, projectName);
+            log.info("[getComponentHtml] Component '{}' not found in project '{}'", componentName, projectName);
             return "";
         }
 
@@ -595,34 +623,50 @@ public class ComponentServiceImpl implements ComponentService {
 
         try {
             String htmlContent = Files.readString(htmlPath);
-            log.info("Successfully read HTML for component '{}'", componentName);
+            log.info("[getComponentHtml] Successfully read HTML content for component '{}'", componentName);
             return htmlContent;
         } catch (IOException e) {
-            log.error("Failed to read HTML for component '{}' at '{}'", componentName, htmlPath, e);
+            log.error("[getComponentHtml] Failed to read HTML for component '{}' at '{}'", componentName, htmlPath, e);
             return "";
         }
     }
 
     /**
-     * Reads and returns the Java code of the Sling Model(s) used in a specific AEM component.
-     * It recursively collects the main model and potential child classes referenced in the code.
+     * Retrieves the complete Java (Sling Model) code for a specified AEM component.
+     * <p>
+     * This method first reads the HTL (HTML) of the given component to locate the
+     * Sling Model binding using the {@code data-sly-use} pattern. Once the primary
+     * model class is identified, it recursively resolves all referenced Java classes
+     * to collect their source code. The final result includes the main model class
+     * and all dependent classes, each separated by a visual delimiter.
+     * </p>
      *
-     * @param projectName   the name of the project containing the component
-     * @param componentName the name of the component
-     * @return concatenated Java source code as a {@link String}; returns comment if HTL or model is missing
+     * <p><b>Behavior:</b></p>
+     * <ul>
+     *     <li>If no HTL file is found for the component, a comment message is returned.</li>
+     *     <li>If no Sling Model binding is found in the HTL, a comment message is returned.</li>
+     *     <li>If any Java file cannot be read, it is skipped, and the process continues.</li>
+     * </ul>
+     *
+     * @param projectName   the name of the AEM project containing the component
+     * @param componentName the name of the AEM component whose Sling Model Java code is to be retrieved
+     * @return a {@link String} containing the Java code of the Sling Model and all dependent classes,
+     * or a comment message if the HTL or Sling Model binding cannot be resolved
      */
     @Override
     public String getComponentJava(String projectName, String componentName) {
-        log.info("Fetching Sling Model Java code for component '{}' in project '{}'", componentName, projectName);
+        log.info("[getComponentJava] Fetching Sling Model Java code for component '{}' in project '{}'", componentName, projectName);
 
         try {
+            // Step 1: Read the HTL file content for the component
             String htlContent = getComponentHtml(projectName, componentName);
 
             if (htlContent == null || htlContent.isEmpty()) {
-                log.warn("No HTL found for component '{}'", componentName);
+                log.info("[getComponentJava] No HTL found for component '{}'", componentName);
                 return "// No HTL found for component: " + componentName;
             }
 
+            // Step 2: Extract Sling Model binding from HTL
             Pattern pattern = Pattern.compile(DATA_SLY_USE_PATTERN);
             Matcher matcher = pattern.matcher(htlContent);
 
@@ -636,10 +680,11 @@ public class ComponentServiceImpl implements ComponentService {
             }
 
             if (modelClass == null) {
-                log.warn("No Sling Model binding found in HTL for component '{}'", componentName);
+                log.info("[getComponentJava] No Sling Model binding found in HTL for component '{}'", componentName);
                 return "// No Sling Model binding found in HTL for: " + componentName;
             }
 
+            // Step 3: Recursively resolve and read all referenced Java classes
             StringBuilder result = new StringBuilder();
             Set<String> processed = new HashSet<>();
             Deque<String> stack = new ArrayDeque<>();
@@ -663,6 +708,7 @@ public class ComponentServiceImpl implements ComponentService {
                         .append(simpleName).append(" =====\n\n")
                         .append(code).append("\n\n");
 
+                // Find and add referenced classes from the current Java file
                 Matcher refMatcher = Pattern.compile(JAVA_CLASS_REF_PATTERN).matcher(code);
                 while (refMatcher.find()) {
                     String refClass = refMatcher.group(1);
@@ -672,34 +718,31 @@ public class ComponentServiceImpl implements ComponentService {
                 }
             }
 
-            log.info("Successfully fetched Java code for component '{}'", componentName);
+            log.info("[getComponentJava] Successfully fetched Java code for component '{}'", componentName);
             return result.toString();
 
         } catch (Exception e) {
-            log.error("Failed while resolving Sling Model for component '{}'", componentName, e);
+            log.error("[getComponentJava] Failed while resolving Sling Model for component '{}'", componentName, e);
             return "// Error while resolving Sling Model: " + e.getMessage();
         }
     }
 
-    private static String capitalize(String input) {
-        return (input == null || input.isEmpty()) ? input
-                : input.substring(0, 1).toUpperCase() + input.substring(1);
-    }
-
     /**
-     * Determines the field type corresponding to a given AEM resource type.
+     * Determines the dialog field type corresponding to a given AEM resource type.
      * <p>
-     * This method iterates through all {@link FieldType} enum values and performs
-     * a reverse lookup based on the resource type. If multiple enums match,
-     * the last match takes precedence.
+     * This method iterates through all {@link FieldType} enum values to find a match for the
+     * provided {@code resourceType}. If a match is found, the associated field type is returned.
+     * If no match exists or the input is null/empty, an empty string is returned.
      * </p>
      *
-     * @param resourceType the AEM resource type (e.g., "cq/gui/components/authoring/dialog")
-     * @return the corresponding field type as a string, or an empty string if not found
+     * @param resourceType the AEM resource type (e.g., "granite/ui/components/foundation/form/textfield")
+     * @return the matching field type as a {@link String}, or an empty string if no match is found
      */
     private String getFieldTypeFromResource(String resourceType) {
+        log.info("[getFieldTypeFromResource] Resolving field type for resourceType '{}'", resourceType);
+
         if (resourceType == null || resourceType.isEmpty()) {
-            log.warn("Resource type is null or empty, returning empty string");
+            log.info("[getFieldTypeFromResource] Resource type is null or empty, returning empty string");
             return "";
         }
 
@@ -707,68 +750,87 @@ public class ComponentServiceImpl implements ComponentService {
         for (FieldType ft : FieldType.values()) {
             if (ft.getResourceType().equals(resourceType)) {
                 fieldType = ft.getType();
-                log.debug("Matched resourceType '{}' to fieldType '{}'", resourceType, fieldType);
+                log.info("[getFieldTypeFromResource] Matched resourceType '{}' to fieldType '{}'", resourceType, fieldType);
             }
         }
 
         if (fieldType.isEmpty()) {
-            log.info("No matching fieldType found for resourceType '{}'", resourceType);
+            log.info("[getFieldTypeFromResource] No matching fieldType found for resourceType '{}'", resourceType);
+        } else {
+            log.info("[getFieldTypeFromResource] Successfully resolved fieldType '{}' for resourceType '{}'", fieldType, resourceType);
         }
 
         return fieldType;
     }
 
     /**
-     * Determines the field type for a given XML element from the component dialog.
+     * Determines the dialog field type for the given XML {@link Element}.
      * <p>
-     * Checks the element's {@code sling:resourceType} and certain attributes to
-     * categorize it into a field type like "multifield", "multiselect", "fileupload", or "image".
+     * This method inspects the element's {@code sling:resourceType} and other
+     * attributes to map it to a specific field type used in AEM component dialogs.
+     * The detection order is:
+     * <ol>
+     *     <li>Checks {@code sling:resourceType} for a direct match using
+     *         {@link #getFieldTypeFromResource(String)}</li>
+     *     <li>Overrides the type if the element represents a multifield</li>
+     *     <li>Overrides the type if the element represents a multiselect</li>
+     *     <li>Detects file or image upload types based on the node name</li>
+     * </ol>
      * </p>
      *
-     * @param elem the XML element representing a dialog field
-     * @return the determined field type as a string, or the default from {@link #getFieldTypeFromResource(String)}
+     * @param elem the XML {@link Element} representing the dialog field
+     * @return the resolved field type as a {@link String}; may be an empty string if no match is found
      */
     private String determineFieldType(Element elem) {
+        log.info("[determineFieldType] Determining field type for element '{}'", elem.getNodeName());
+
+        // 1. Start with the resourceType-based mapping
         String resourceType = elem.getAttribute(SLING_RESOURCE_TYPE);
         String type = getFieldTypeFromResource(resourceType);
 
-        log.debug("Determining field type for resourceType '{}'", resourceType);
+        log.info("[determineFieldType] Initial type '{}' detected from resourceType '{}'", type, resourceType);
 
+        // 2. Override for specific dialog components
         if (GRANITE_MULTIFIELD.equals(resourceType)) {
             type = TYPE_MULTIFIELD;
-            log.debug("Detected multifield for element '{}'", elem.getNodeName());
-        }
-
-        else if (GRANITE_SELECT.equals(resourceType)
+            log.info("[determineFieldType] Detected multifield for element '{}'", elem.getNodeName());
+        } else if (GRANITE_SELECT.equals(resourceType)
                 && "true".equalsIgnoreCase(elem.getAttribute("multiple"))) {
             type = TYPE_MULTISELECT;
-            log.debug("Detected multiselect for element '{}'", elem.getNodeName());
-        }
-        else if (CQ_FILEUPLOAD.equals(resourceType)) {
+            log.info("[determineFieldType] Detected multiselect for element '{}'", elem.getNodeName());
+        } else if (CQ_FILEUPLOAD.equals(resourceType)) {
             String node = elem.getNodeName().toLowerCase();
             if (node.contains("file")) {
                 type = FILEUPLOAD;
             } else if (node.contains(IMAGE)) {
                 type = IMAGE;
             }
-            log.debug("Detected '{}' upload for element '{}'", type, elem.getNodeName());
+            log.info("[determineFieldType] Detected '{}' upload type for element '{}'", type, elem.getNodeName());
         }
 
-        log.info("Final field type for element '{}': '{}'", elem.getNodeName(), type);
+        // 3. Final result
+        log.info("[determineFieldType] Final field type resolved for element '{}': '{}'", elem.getNodeName(), type);
         return type;
     }
 
     /**
-     * Parses a dialog XML element into one or more {@link ComponentField} objects.
+     * Parses an XML {@link Element} representing a dialog field into a {@link ComponentField} object.
      * <p>
-     * Handles multifields, selects, multiselects, radiogroups, file/image uploads, and tabs.
-     * Recurses into nested items for multifields and tabs.
+     * This method determines the field's type, name, label, and nested fields or options based
+     * on the element's attributes and child elements. Special handling is included for:
+     * <ul>
+     *     <li>Multifields: recursively collects nested fields</li>
+     *     <li>Select, multiselect, and radiogroup fields: extracts option items</li>
+     *     <li>Tabs: collects child fields and sets tab name and label</li>
+     * </ul>
      * </p>
      *
-     * @param elem the XML element representing a dialog field
-     * @return a list of parsed {@link ComponentField} objects
+     * @param elem the XML {@link Element} representing the field in the component dialog
+     * @return a {@link List} containing one or more {@link ComponentField} objects parsed from the element
      */
     private List<ComponentField> parseField(Element elem) {
+        log.info("[parseField] Parsing field element '{}'", elem.getNodeName());
+
         List<ComponentField> result = new ArrayList<>();
 
         String fieldLabel = elem.getAttribute(ATTR_FIELD_LABEL);
@@ -779,8 +841,9 @@ public class ComponentServiceImpl implements ComponentService {
 
         String fieldName = null;
 
-        log.debug("Parsing field element '{}', resourceType='{}'", elem.getNodeName(), resourceType);
+        log.info("[parseField] Initial resourceType='{}', fieldType='{}'", resourceType, fieldType);
 
+        // Resolve multifield name if necessary
         if (TYPE_MULTIFIELD.equals(fieldType) && (nameAttr == null || nameAttr.isBlank())) {
             NodeList fieldNodes = elem.getElementsByTagName(ATTR_FIELD);
             if (fieldNodes.getLength() > 0) {
@@ -790,9 +853,10 @@ public class ComponentServiceImpl implements ComponentService {
                     fieldName = nestedFieldName.startsWith("./") ? nestedFieldName.substring(2) : nestedFieldName;
                 }
             }
-            log.debug("Resolved multifield name: '{}'", fieldName);
+            log.info("[parseField] Resolved multifield name: '{}'", fieldName);
         }
 
+        // Fallback to main field name or file reference
         if (fieldName == null && nameAttr != null && !nameAttr.isBlank()) {
             if (FILEUPLOAD.equals(fieldType) && fileRefAttr != null && !fileRefAttr.isBlank()) {
                 fieldName = fileRefAttr.startsWith("./") ? fileRefAttr.substring(2) : fileRefAttr;
@@ -801,12 +865,13 @@ public class ComponentServiceImpl implements ComponentService {
             }
         }
 
-        log.info("Field parsed: label='{}', name='{}', type='{}', resourceType='{}'",
+        log.info("[parseField] Field parsed: label='{}', name='{}', type='{}', resourceType='{}'",
                 fieldLabel, fieldName, fieldType, resourceType);
 
         List<OptionItem> options = null;
         List<ComponentField> nested = null;
 
+        // Handle nested/multifield elements
         if (TYPE_MULTIFIELD.equals(fieldType)) {
             nested = new ArrayList<>();
             NodeList fieldNodes = elem.getElementsByTagName(ITEMS);
@@ -815,6 +880,7 @@ public class ComponentServiceImpl implements ComponentService {
                 collectFields(itemsElem, nested);
             }
         }
+        // Handle select/multiselect/radiogroup options
         else if (SELECT.equals(fieldType) || TYPE_MULTISELECT.equals(fieldType) || RADIOGROUP.equals(fieldType)) {
             if (SELECT.equals(fieldType)) {
                 String multipleAttr = elem.getAttribute(ATTR_MULTIPLE);
@@ -839,7 +905,7 @@ public class ComponentServiceImpl implements ComponentService {
                 }
             }
         }
-
+        // Handle tab fields
         else if (TYPE_TABS.equals(fieldType)) {
             String jcrTitle = elem.getAttribute(JCR_TITLE);
             if (jcrTitle != null && !jcrTitle.isBlank()) {
@@ -865,15 +931,24 @@ public class ComponentServiceImpl implements ComponentService {
     }
 
     /**
-     * Recursively collects dialog fields from the given parent XML element.
-     * Skips technical containers but continues traversing into their children.
+     * Recursively collects {@link ComponentField} objects from the given parent XML {@link Element}.
+     * <p>
+     * This method traverses all child nodes of the parent element and:
+     * <ul>
+     *     <li>Determines the field type of each child using {@link #determineFieldType(Element)}</li>
+     *     <li>Parses individual fields with {@link #parseField(Element)}</li>
+     *     <li>Handles special cases such as containers and tabs</li>
+     *     <li>Recursively collects nested fields for multifields or unknown types</li>
+     * </ul>
+     * The resulting {@link ComponentField} objects are added to the provided {@code fields} list.
+     * </p>
      *
-     * @param parent the parent XML element (dialog node) to parse
-     * @param fields the list to accumulate parsed ComponentField objects
+     * @param parent the parent XML {@link Element} to parse for fields
+     * @param fields the {@link List} where parsed {@link ComponentField} objects will be collected
      */
     private void collectFields(Element parent, List<ComponentField> fields) {
         NodeList children = parent.getChildNodes();
-        log.info("Collecting fields from parent node '{}', child count={}", parent.getNodeName(), children.getLength());
+        log.info("[collectFields] Collecting fields from parent node '{}', child count={}", parent.getNodeName(), children.getLength());
 
         for (int i = 0; i < children.getLength(); i++) {
             Node node = children.item(i);
@@ -884,128 +959,162 @@ public class ComponentServiceImpl implements ComponentService {
             String resourceType = elem.getAttribute(SLING_RESOURCE_TYPE);
             String type = determineFieldType(elem);
 
+            // Handle container elements
             if (GRANITE_CONTAINER.equals(resourceType)) {
                 String parentResourceType = getParentResourceType(elem);
 
-                log.info("Checking container: nodeName='{}', resourceType='{}', parentResourceType='{}'",
+                log.info("[collectFields] Checking container: nodeName='{}', resourceType='{}', parentResourceType='{}'",
                         elem.getNodeName(), resourceType, parentResourceType);
 
                 if (!GRANITE_TABS.equals(parentResourceType)) {
-                    log.info("Skipping container '{}' as field, but parsing its children", elem.getNodeName());
+                    log.info("[collectFields] Skipping container '{}' as a field, but parsing its children", elem.getNodeName());
                     collectFields(elem, fields);
                     continue;
                 }
             }
 
+            // Parse valid fields
             if (!type.isEmpty()) {
                 List<ComponentField> parsed = parseField(elem);
                 if (parsed != null && !parsed.isEmpty()) {
-                    log.info("Adding {} parsed field(s) from node '{}'", parsed.size(), elem.getNodeName());
+                    log.info("[collectFields] Adding {} parsed field(s) from node '{}'", parsed.size(), elem.getNodeName());
                     fields.addAll(parsed);
                 } else {
-                    log.info("No valid fields parsed from node '{}'", elem.getNodeName());
+                    log.info("[collectFields] No valid fields parsed from node '{}'", elem.getNodeName());
                 }
             } else {
-                log.info("Recursing into children of node '{}' with unknown or empty type", elem.getNodeName());
+                // Recursively collect children if type is unknown or empty
+                log.info("[collectFields] Recursing into children of node '{}' with unknown or empty type", elem.getNodeName());
                 collectFields(elem, fields);
             }
         }
     }
 
     /**
-     * Finds the nearest ancestor element that defines a sling:resourceType.
-     * Useful for cases where wrapper nodes (e.g., <items>) don't have their own resourceType.
+     * Retrieves the {@code sling:resourceType} of the nearest parent element in the XML hierarchy.
+     * <p>
+     * This method traverses the ancestor nodes of the given element and returns the first
+     * {@code sling:resourceType} it finds. If no parent with a resource type exists, it returns
+     * an empty string.
+     * </p>
      *
-     * @param elem the starting XML element
-     * @return the sling:resourceType of the nearest ancestor, or empty string if none found
+     * @param elem the XML {@link Element} whose parent resource type is to be determined
+     * @return the {@code sling:resourceType} of the nearest parent element, or an empty string if none is found
      */
     private String getParentResourceType(Element elem) {
+        log.info("[getParentResourceType] Searching for parent resourceType of node '{}'", elem.getNodeName());
+
         Node parent = elem.getParentNode();
         while (parent instanceof Element parentElem) {
             if (parentElem.hasAttribute(SLING_RESOURCE_TYPE)) {
                 String resourceType = parentElem.getAttribute(SLING_RESOURCE_TYPE);
-                log.info("Found parent resourceType '{}' at node '{}'", resourceType, parentElem.getNodeName());
+                log.info("[getParentResourceType] Found parent resourceType '{}' at node '{}'", resourceType, parentElem.getNodeName());
                 return resourceType;
             }
             parent = parent.getParentNode();
         }
-        log.info("No parent resourceType found for node '{}'", elem.getNodeName());
+
+        log.info("[getParentResourceType] No parent resourceType found for node '{}'", elem.getNodeName());
         return "";
     }
 
-
     /**
-     * Retrieves a list of all component names for a given project.
+     * Retrieves a list of component names for a given AEM project.
+     * <p>
+     * This method fetches all components along with their groups using
+     * {@link #fetchComponentsWithGroups(String)} and returns only the component names.
+     * If no components are found, it returns an empty list.
+     * </p>
      *
-     * @param projectName the name of the project
-     * @return list of component names (empty list if none found)
+     * @param projectName the name of the AEM project
+     * @return a {@link List} of component names, or an empty list if no components exist
      */
     @Override
     public List<String> getProjectComponentsMap(String projectName) {
+        log.info("[getProjectComponentsMap] Fetching components for project '{}'", projectName);
+
         Map<String, String> components = fetchComponentsWithGroups(projectName);
         if (components == null || components.isEmpty()) {
-            log.warn("No components found for project '{}'", projectName);
+            log.info("[getProjectComponentsMap] No components found for project '{}'", projectName);
             return Collections.emptyList();
         }
-        return new ArrayList<>(components.keySet());
+
+        List<String> componentNames = new ArrayList<>(components.keySet());
+        log.info("[getProjectComponentsMap] Found {} component(s) for project '{}'", componentNames.size(), projectName);
+        return componentNames;
     }
 
     /**
-     * Adds the selected AEM components to an existing project by copying them into the project's
-     * content folder. This does not overwrite existing components unless explicitly handled in
-     * copySelectedComponents().
+     * Adds the specified components to an existing AEM project.
+     * <p>
+     * This method calculates the target content folder path based on the project name
+     * and application ID, then copies the selected components into the project structure.
+     * All key operations are logged for traceability.
+     * </p>
      *
-     * @param projectName        the name of the target project
-     * @param selectedComponents list of component names to add
+     * @param projectName        the name of the existing AEM project
+     * @param selectedComponents a {@link List} of component names to be added to the project
      */
     @Override
     public void addComponentsToExistingProject(String projectName, List<String> selectedComponents) {
-        log.info("Adding {} components to existing project '{}'", selectedComponents.size(), projectName);
+        log.info("[addComponentsToExistingProject] Adding {} component(s) to existing project '{}'",
+                selectedComponents.size(), projectName);
 
         try {
-
+            // Determine base directory and app ID
             String baseDir = System.getProperty(USER_DIR_SYS_PROP) + "/" + PROJECTS_DIR + "/";
             String appId = AemUtil.getAppId(PROJECTS_DIR, projectName);
 
             String contentFolderPath = baseDir + projectName + CONTENT_ROOT_PATH +
                     appId + "/" + COMPONENTS_FOLDER;
 
-            log.info("Copying components {} to '{}'", selectedComponents, contentFolderPath);
+            log.info("[addComponentsToExistingProject] Copying components {} to '{}'",
+                    selectedComponents, contentFolderPath);
 
+            // Copy selected components to the project
             copySelectedComponents(selectedComponents, contentFolderPath, projectName);
 
-            log.info("Successfully added components to project '{}'", projectName);
+            log.info("[addComponentsToExistingProject] Successfully added components to project '{}'", projectName);
 
         } catch (Exception e) {
-            log.error("Error while adding components to project '{}'", projectName, e);
+            log.error("[addComponentsToExistingProject] Error while adding components to project '{}'", projectName, e);
         }
     }
 
     /**
-     * Copies the selected AEM components into the project.
+     * Copies the selected AEM components into the target project directory, including
+     * updating content and HTL files, and copying associated Sling Models with dependencies.
      * <p>
-     * - Copies component files from source folder.
-     * - Updates .content.xml sling:resourceType.
-     * - Updates HTL files to reference the correct Sling Model.
-     * - Copies the Sling Model and dependencies.
+     * Steps performed for each component:
+     * <ol>
+     *     <li>Check if the source component exists.</li>
+     *     <li>Delete the destination folder if it already exists.</li>
+     *     <li>Copy the component folder to the target path.</li>
+     *     <li>Update the {@code sling:resourceType} in the component's {@code .content.xml}.</li>
+     *     <li>Update HTL file's {@code data-sly-use} reference to the fully qualified Sling Model class.</li>
+     *     <li>Copy the corresponding Sling Model and its dependencies.</li>
+     * </ol>
      * </p>
      *
-     * @param selectedComponents List of component names to copy
-     * @param targetPath         Target folder path in project
-     * @param projectName        Project name
+     * @param selectedComponents a {@link List} of component names to copy
+     * @param targetPath         the target directory where components will be copied
+     * @param projectName        the name of the project for logging and resource path updates
      */
     @Override
     public void copySelectedComponents(List<String> selectedComponents, String targetPath, String projectName) {
         if (selectedComponents == null || selectedComponents.isEmpty()) {
-            log.warn("No components selected to copy for project '{}'", projectName);
+            log.info("[copySelectedComponents] No components selected to copy for project '{}'", projectName);
             return;
         }
+
+        log.info("[copySelectedComponents] Starting to copy {} component(s) to project '{}'",
+                selectedComponents.size(), projectName);
 
         String slingModelsSourcePath = System.getProperty(USER_DIR_SYS_PROP) + "/" + SLING_MODELS_SOURCE;
         Path javaSourceRoot = Paths.get(PROJECTS_DIR, projectName, JAVA_SRC_PATH);
 
         Path modelPath = findModelBasePath(javaSourceRoot);
-        log.info("Model path found: {}", modelPath);
+        log.info("[copySelectedComponents] Model base path found: {}", modelPath);
 
         String modelBasePath = modelPath.toString();
         String packageName = javaSourceRoot.relativize(modelPath).toString().replace(File.separatorChar, '.');
@@ -1018,30 +1127,33 @@ public class ComponentServiceImpl implements ComponentService {
                 File destination = new File(targetPath + "/" + component);
 
                 if (!source.exists()) {
-                    log.warn("Source component not found: {}", source.getAbsolutePath());
+                    log.info("[copySelectedComponents] Source component not found: {}", source.getAbsolutePath());
                     continue;
                 }
 
                 if (destination.exists()) {
                     FileUtils.deleteDirectory(destination);
-                    log.info("Deleted existing component folder: {}", destination.getAbsolutePath());
+                    log.info("[copySelectedComponents] Deleted existing component folder: {}", destination.getAbsolutePath());
                 }
 
                 FileUtils.copyDirectory(source, destination);
-                log.info("Copied component '{}' to '{}'", component, destination.getAbsolutePath());
+                log.info("[copySelectedComponents] Copied component '{}' to '{}'", component, destination.getAbsolutePath());
 
+                // Update sling:resourceType in content.xml
                 File contentXml = new File(destination, CONTENT_XML);
                 if (contentXml.exists()) {
                     String content = FileUtils.readFileToString(contentXml, UTF_8);
                     content = content.replaceAll(SLING_RESOURCE_TYPE_PATTERN,
-                            SLING_RESOURCE_TYPE_ATTR + projectName + "/" + COMPONENTS_FOLDER + "/" + component.toLowerCase() + "\"");
+                            SLING_RESOURCE_TYPE_ATTR + projectName + "/" + COMPONENTS_FOLDER + "/" +
+                                    component.toLowerCase() + "\"");
                     FileUtils.writeStringToFile(contentXml, content, UTF_8);
-                    log.info("Updated sling:resourceType in {}", contentXml.getAbsolutePath());
+                    log.info("[copySelectedComponents] Updated sling:resourceType in '{}'", contentXml.getAbsolutePath());
                 }
 
+                // Update HTL model reference
                 File html = new File(destination, component + HTL_FILE_EXTENSION);
                 File parentModel = findMatchingModelFile(slingModelsSourcePath, component);
-                log.info("ParentModel......{}", parentModel);
+                log.info("[copySelectedComponents] Parent model for '{}': {}", component, parentModel);
                 if (html.exists() && parentModel != null) {
                     String htmlContent = FileUtils.readFileToString(html, UTF_8);
                     String fqcn = extractFullyQualifiedClassName(parentModel, packageName);
@@ -1049,36 +1161,40 @@ public class ComponentServiceImpl implements ComponentService {
                         htmlContent = htmlContent.replaceAll(DATA_SLY_USE_MODEL_PATTERN,
                                 DATA_SLY_USE_MODEL + fqcn + "\"");
                         FileUtils.writeStringToFile(html, htmlContent, UTF_8);
-                        log.info("Updated HTL model reference in {}", html.getAbsolutePath());
+                        log.info("[copySelectedComponents] Updated HTL model reference in '{}'", html.getAbsolutePath());
                     }
                 }
 
+                // Copy model and dependencies
                 if (parentModel != null && parentModel.exists()) {
                     copyModelAndDependencies(parentModel, slingModelsSourcePath, modelBasePath, packageName, copiedModels);
-                    log.info("Copied Sling Model and dependencies for component '{}'", component);
+                    log.info("[copySelectedComponents] Copied Sling Model and dependencies for component '{}'", component);
                 } else {
-                    log.warn("No matching Sling Model found for component '{}'", component);
+                    log.info("[copySelectedComponents] No matching Sling Model found for component '{}'", component);
                 }
 
             } catch (IOException e) {
-                log.error("Failed to process component '{}'", component, e);
+                log.error("[copySelectedComponents] Failed to process component '{}'", component, e);
             }
         }
+
+        log.info("[copySelectedComponents] Finished copying selected components for project '{}'", projectName);
     }
 
     /**
-     * Recursively searches for the first "models" directory under the given Java source root.
+     * Searches recursively for the 'models' directory under the given Java source root.
      * <p>
-     * This is typically used to locate the base package for Sling Models within the project's
-     * Java source directory.
+     * This method traverses the directory tree starting from {@code javaSourceRoot} and
+     * returns the first directory named {@code models}. If no such directory is found,
+     * an exception is thrown.
      * </p>
      *
-     * @param javaSourceRoot The root path of the Java source folder (e.g., core/src/main/java)
-     * @return Path to the "models" directory
-     * @throws RuntimeException if the "models" directory is not found or an I/O error occurs
+     * @param javaSourceRoot the root path of Java source files to search
+     * @return the {@link Path} to the 'models' directory
+     * @throws RuntimeException if an I/O error occurs or the 'models' directory is not found
      */
     private static Path findModelBasePath(Path javaSourceRoot) {
-        log.info("Searching for 'models' directory under Java source root: {}", javaSourceRoot);
+        log.info("[findModelBasePath] Searching for 'models' directory under Java source root: {}", javaSourceRoot);
 
         try (Stream<Path> paths = Files.walk(javaSourceRoot)) {
 
@@ -1088,102 +1204,115 @@ public class ComponentServiceImpl implements ComponentService {
                     .findFirst();
 
             if (modelPath.isPresent()) {
-                log.info("'models' directory found at: {}", modelPath.get());
+                log.info("[findModelBasePath] 'models' directory found at: {}", modelPath.get());
                 return modelPath.get();
             } else {
                 String errorMsg = "models directory not found under: " + javaSourceRoot;
-                log.error(errorMsg);
+                log.error("[findModelBasePath] " + errorMsg);
                 throw new IOException(errorMsg);
             }
 
         } catch (IOException e) {
-            log.error("Error while searching for 'models' directory under {}", javaSourceRoot, e);
+            log.error("[findModelBasePath] Error while searching for 'models' directory under {}", javaSourceRoot, e);
             throw new RuntimeException(e);
         }
     }
 
-
     /**
-     * Finds the Java Sling Model file corresponding to a given component.
+     * Searches for a matching Sling Model Java file for the given component in the specified models directory.
      * <p>
-     * The method first attempts an exact match using the pattern
-     * "{componentName}Model.java" (case-insensitive). If not found, it falls back
-     * to a partial match where the file name contains the component name and ends with "Model.java".
+     * The search prioritizes an exact match (componentName + MODEL_FILE_SUFFIX) and then falls back
+     * to partial matches that contain the component name and end with the model suffix.
      * </p>
      *
-     * @param modelsDirPath The absolute path to the directory containing Sling Model Java files.
-     * @param componentName The component name for which the model is being searched.
-     * @return The File object representing the matching Java model, or null if none is found.
+     * @param modelsDirPath the path to the directory containing Sling Model Java files
+     * @param componentName the name of the component whose Sling Model is to be found
+     * @return the {@link File} representing the matching Sling Model, or {@code null} if none is found
      */
     private File findMatchingModelFile(String modelsDirPath, String componentName) {
-        log.info("Searching for Sling Model for component '{}' in directory '{}'", componentName, modelsDirPath);
+        log.info("[findMatchingModelFile] Searching for Sling Model for component '{}' in directory '{}'",
+                componentName, modelsDirPath);
 
         File dir = new File(modelsDirPath);
         if (!dir.exists() || !dir.isDirectory()) {
-            log.warn("Models directory '{}' does not exist or is not a directory", modelsDirPath);
+            log.info("[findMatchingModelFile] Models directory '{}' does not exist or is not a directory", modelsDirPath);
             return null;
         }
 
         File[] files = dir.listFiles((d, name) -> name.endsWith(JAVA_EXTENSION));
         if (files == null || files.length == 0) {
-            log.warn("No Java files found in models directory '{}'", modelsDirPath);
+            log.info("[findMatchingModelFile] No Java files found in models directory '{}'", modelsDirPath);
             return null;
         }
 
         String lcComponent = componentName.toLowerCase();
 
+        // Check exact match first
         for (File file : files) {
             String lcFile = file.getName().toLowerCase();
             if (lcFile.equals(lcComponent + MODEL_FILE_SUFFIX)) {
-                log.info("Exact match found for component '{}' → '{}'", componentName, file.getName());
+                log.info("[findMatchingModelFile] Exact match found for component '{}' → '{}'", componentName, file.getName());
                 return file;
             }
         }
 
+        // Check partial matches
         for (File file : files) {
             String lcFile = file.getName().toLowerCase();
             if (lcFile.contains(lcComponent) && lcFile.endsWith(MODEL_FILE_SUFFIX)) {
-                log.info("Partial match found for component '{}' → '{}'", componentName, file.getName());
+                log.info("[findMatchingModelFile] Partial match found for component '{}' → '{}'", componentName, file.getName());
                 return file;
             }
         }
 
-        log.warn("No matching Sling Model found for component '{}'", componentName);
+        log.info("[findMatchingModelFile] No matching Sling Model found for component '{}'", componentName);
         return null;
     }
 
     /**
-     * Copies a Sling Model Java file to the target location, updating the package
-     * and internal imports, and recursively copies any dependent model classes.
+     * Copies a Sling Model Java file and its dependent models to the target package.
+     * <p>
+     * This method performs the following steps:
+     * <ol>
+     *     <li>Checks if the model file exists and if it has already been copied.</li>
+     *     <li>Updates the package declaration to the target package.</li>
+     *     <li>Updates import statements to reference the target package.</li>
+     *     <li>Writes the updated model file to the target directory.</li>
+     *     <li>Recursively copies all dependent Sling Models referenced in the model.</li>
+     * </ol>
+     * </p>
      *
-     * @param modelFile         The Java file representing the Sling Model to copy.
-     * @param sourceBase        The source directory containing the original models.
-     * @param targetBase        The target directory where the models should be copied.
-     * @param targetPackageName The Java package name to apply in the copied model.
-     * @param copiedModels      A set of model names that have already been copied to avoid duplication.
-     * @throws IOException If reading or writing files fails.
+     * @param modelFile         the source Sling Model Java file to copy
+     * @param sourceBase        the base directory of the source Sling Models
+     * @param targetBase        the target directory to copy the model into
+     * @param targetPackageName the target Java package name
+     * @param copiedModels      a {@link Set} tracking already copied models to avoid duplication
+     * @throws IOException if reading or writing files fails
      */
-    private void copyModelAndDependencies(File modelFile, String sourceBase, String targetBase, String targetPackageName, Set<String> copiedModels) throws IOException {
+    private void copyModelAndDependencies(File modelFile, String sourceBase, String targetBase,
+                                          String targetPackageName, Set<String> copiedModels) throws IOException {
         if (modelFile == null || !modelFile.exists()) {
-            log.warn("Model file is null or does not exist: {}", modelFile);
+            log.info("[copyModelAndDependencies] Model file is null or does not exist: {}", modelFile);
             return;
         }
 
         String modelName = modelFile.getName();
         if (copiedModels.contains(modelName)) {
-            log.info("Model '{}' already copied, skipping", modelName);
+            log.info("[copyModelAndDependencies] Model '{}' already copied, skipping", modelName);
             return;
         }
 
-        log.info("Copying Sling Model '{}'", modelName);
+        log.info("[copyModelAndDependencies] Copying Sling Model '{}'", modelName);
 
         String originalContent = FileUtils.readFileToString(modelFile, UTF_8);
 
+        // Update package declaration
         String content = originalContent.replaceFirst(
                 PACKAGE_DECLARATION_REGEX,
                 "package " + targetPackageName + ";"
         );
 
+        // Update import statements
         Pattern importPattern = Pattern.compile(IMPORT_STATEMENT_REGEX);
         Matcher importMatcher = importPattern.matcher(content);
         StringBuffer updatedContent = new StringBuffer();
@@ -1191,49 +1320,58 @@ public class ComponentServiceImpl implements ComponentService {
             String className = importMatcher.group(1);
             String newImport = "import " + targetPackageName + "." + className + ";";
             importMatcher.appendReplacement(updatedContent, Matcher.quoteReplacement(newImport));
-            log.info("Updated import for '{}' in model '{}'", className, modelName);
+            log.info("[copyModelAndDependencies] Updated import for '{}' in model '{}'", className, modelName);
         }
         importMatcher.appendTail(updatedContent);
         content = updatedContent.toString();
 
+        // Write updated model to target
         File destFile = new File(targetBase, modelFile.getName());
         destFile.getParentFile().mkdirs();
         FileUtils.writeStringToFile(destFile, content, UTF_8);
         copiedModels.add(modelName);
-        log.info("Sling Model '{}' copied to '{}'", modelName, destFile.getAbsolutePath());
+        log.info("[copyModelAndDependencies] Sling Model '{}' copied to '{}'", modelName, destFile.getAbsolutePath());
 
+        // Recursively copy dependent models
         Set<String> dependentTypes = extractReferencedModelTypes(originalContent);
         for (String type : dependentTypes) {
             File depFile = new File(sourceBase, type + JAVA_EXTENSION);
             if (depFile.exists()) {
-                log.info("Copying dependent model '{}' for '{}'", type, modelName);
+                log.info("[copyModelAndDependencies] Copying dependent model '{}' for '{}'", type, modelName);
                 copyModelAndDependencies(depFile, sourceBase, targetBase, targetPackageName, copiedModels);
             } else {
-                log.warn("Dependent model '{}' not found for '{}'", type, modelName);
+                log.info("[copyModelAndDependencies] Dependent model '{}' not found for '{}'", type, modelName);
             }
         }
     }
 
     /**
-     * Extracts referenced Sling Model class names from a given Java source content.
-     * This includes classes referenced via imports and direct usage in the code.
+     * Extracts the names of Sling Model classes referenced within a given Java source content.
+     * <p>
+     * This method detects references in two ways:
+     * <ol>
+     *     <li>Via import statements matching {@code IMPORT_STATEMENT_REGEX}.</li>
+     *     <li>Via usage of class names that exist in the Sling Models source directory.</li>
+     * </ol>
+     * </p>
      *
-     * @param content The Java source content as a string.
-     * @return A set of Sling Model class names referenced in the content.
+     * @param content the Java source code content to analyze
+     * @return a {@link Set} of referenced Sling Model class names
      */
     private Set<String> extractReferencedModelTypes(String content) {
         Set<String> types = new HashSet<>();
 
+        // 1. Extract types via import statements
         Pattern importPattern = Pattern.compile(IMPORT_STATEMENT_REGEX);
         Matcher importMatcher = importPattern.matcher(content);
         while (importMatcher.find()) {
             String type = importMatcher.group(1);
             types.add(type);
-            log.info("Found referenced model via import: {}", type);
+            log.info("[extractReferencedModelTypes] Found referenced model via import: {}", type);
         }
 
+        // 2. Extract types via direct usage in code
         File modelsDir = new File(System.getProperty(USER_DIR_SYS_PROP) + "/" + SLING_MODELS_SOURCE);
-
         if (modelsDir.exists() && modelsDir.isDirectory()) {
             File[] modelFiles = modelsDir.listFiles((dir, name) -> name.endsWith(JAVA_EXTENSION));
             if (modelFiles != null) {
@@ -1243,28 +1381,31 @@ public class ComponentServiceImpl implements ComponentService {
                     Matcher usageMatcher = usagePattern.matcher(content);
                     if (usageMatcher.find()) {
                         types.add(className);
-                        log.info("Found referenced model via usage: {}", className);
+                        log.info("[extractReferencedModelTypes] Found referenced model via usage: {}", className);
                     }
                 }
             }
         } else {
-            log.warn("Sling Models directory not found: {}", modelsDir.getAbsolutePath());
+            log.info("[extractReferencedModelTypes] Sling Models directory not found: {}", modelsDir.getAbsolutePath());
         }
 
         return types;
     }
 
     /**
-     * Extracts the fully qualified class name (FQCN) from a Java file.
-     * Uses the target package name to construct the FQCN.
+     * Extracts the fully qualified class name (FQCN) from a given Java file.
+     * <p>
+     * The FQCN is constructed using the provided target package and the public class
+     * name declared in the Java file.
+     * </p>
      *
-     * @param javaFile      The Java source file
-     * @param targetPackage The package name to prepend
-     * @return Fully qualified class name, or null if not found
+     * @param javaFile      the Java source file to extract the class name from
+     * @param targetPackage the target package name to prepend to the class name
+     * @return the fully qualified class name, or {@code null} if not found
      */
     private String extractFullyQualifiedClassName(File javaFile, String targetPackage) {
         if (javaFile == null || !javaFile.exists()) {
-            log.warn("Java file does not exist: {}", javaFile);
+            log.info("[extractFullyQualifiedClassName] Java file does not exist: {}", javaFile);
             return null;
         }
 
@@ -1276,52 +1417,60 @@ public class ComponentServiceImpl implements ComponentService {
             if (matcher.find()) {
                 String className = matcher.group(1);
                 String fqcn = targetPackage + "." + className;
-                log.info("Extracted FQCN '{}' from file '{}'", fqcn, javaFile.getAbsolutePath());
+                log.info("[extractFullyQualifiedClassName] Extracted FQCN '{}' from file '{}'", fqcn, javaFile.getAbsolutePath());
                 return fqcn;
             } else {
-                log.warn("No public class found in file '{}'", javaFile.getAbsolutePath());
+                log.info("[extractFullyQualifiedClassName] No public class found in file '{}'", javaFile.getAbsolutePath());
             }
         } catch (IOException e) {
-            log.error("Failed to extract FQCN from file '{}'", javaFile.getAbsolutePath(), e);
+            log.error("[extractFullyQualifiedClassName] Failed to extract FQCN from file '{}'", javaFile.getAbsolutePath(), e);
         }
         return null;
     }
 
     /**
-     * Fetches all component groups for a given project.
+     * Retrieves the list of component groups for the specified AEM project.
      * <p>
-     * This method scans the project's components folder recursively and collects all
-     * component groups. It excludes technical groups like Structure, hidden, or Form groups.
+     * This method reads the application title from the POM file (if available),
+     * determines the components folder path, and recursively collects all
+     * component groups. Technical or hidden groups (like structure or form groups)
+     * are excluded from the final list.
+     * </p>
      *
-     * @param projectName the name of the project
-     * @return a list of component groups; if none found, returns a list with the project name
+     * @param projectName the name of the project for which to fetch component groups
+     * @return a list of component group names, or a single entry containing the
+     * project/app title if no groups are found
      */
     @Override
     public List<String> getComponentGroups(String projectName) {
-        log.info("Starting to fetch component groups for project '{}'", projectName);
+        log.info("[getComponentGroups] Starting to fetch component groups for project '{}'", projectName);
 
+        // Resolve application title from POM or fallback to project name
         String appTitle = readAppTitleFromPom(projectName);
         if (appTitle == null || appTitle.isBlank()) {
-            log.info("App title not found in POM, using project name '{}'", projectName);
+            log.info("[getComponentGroups] App title not found in POM, using project name '{}'", projectName);
             appTitle = projectName;
         }
         String appId = AemUtil.getAppId(PROJECTS_DIR, projectName);
 
+        // Resolve the absolute components folder path
         String componentsPath = PROJECTS_DIR + "/" + projectName + CONTENT_ROOT_PATH + appId + "/" + COMPONENTS_FOLDER;
-        log.info("Components folder path resolved to '{}'", componentsPath);
+        log.info("[getComponentGroups] Components folder path resolved to '{}'", componentsPath);
 
         File folder = new File(componentsPath);
         Set<String> groups = new HashSet<>();
-        groups.add(appTitle);
+        groups.add(appTitle); // Ensure app title is always present as a group
 
+        // Collect groups if the folder exists
         if (folder.exists() && folder.isDirectory()) {
-            log.info("Collecting component groups from folder '{}'", componentsPath);
+            log.info("[getComponentGroups] Collecting component groups from folder '{}'", componentsPath);
             collectComponentGroupsRecursive(folder, groups);
-            log.info("Groups collected (before filtering): {}", groups);
+            log.info("[getComponentGroups] Groups collected (before filtering): {}", groups);
         } else {
-            log.warn("Components folder '{}' does not exist for project '{}'", componentsPath, projectName);
+            log.info("[getComponentGroups] Components folder '{}' does not exist for project '{}'", componentsPath, projectName);
         }
 
+        // Filter out technical/hidden groups
         final String finalAppTitle = appTitle;
         groups.removeIf(g -> {
             String trimmed = g.trim();
@@ -1329,34 +1478,39 @@ public class ComponentServiceImpl implements ComponentService {
                     || trimmed.equals(HIDDEN_GROUP)
                     || trimmed.contains(FORM_GROUP_SUFFIX);
             if (remove) {
-                log.debug("Excluding group '{}' as technical or hidden", trimmed);
+                log.info("[getComponentGroups] Excluding group '{}' as technical or hidden", trimmed);
             }
             return remove;
         });
-        log.info("Groups after filtering: {}", groups);
+        log.info("[getComponentGroups] Groups after filtering: {}", groups);
 
+        // Finalize the result, falling back to app title if no groups remain
         List<String> result = groups.isEmpty() ? List.of(appTitle) : new ArrayList<>(groups);
-        log.info("Final component groups for project '{}': {}", projectName, result);
+        log.info("[getComponentGroups] Final component groups for project '{}': {}", projectName, result);
 
         return result;
     }
 
     /**
-     * Recursively collects component groups from a directory.
-     * Skips technical or excluded folders like _cq_, hidden, backup, etc.
+     * Recursively collects component group names from a directory and its subdirectories.
+     * <p>
+     * This method scans each folder for a {@code .content.xml} file and extracts the
+     * {@code componentGroup} property. All found groups are added to the provided {@code groups} set.
+     * Excluded folders are skipped, and filtering of technical/hidden groups is performed later.
+     * </p>
      *
-     * @param dir    the current folder to scan
-     * @param groups the set of collected component groups
+     * @param dir    the directory to scan for component groups
+     * @param groups the set to collect component group names
      */
     private void collectComponentGroupsRecursive(File dir, Set<String> groups) {
         if (!dir.isDirectory()) {
-            log.debug("Skipping non-directory: {}", dir.getAbsolutePath());
+            log.info("[collectComponentGroupsRecursive] Skipping non-directory: {}", dir.getAbsolutePath());
             return;
         }
 
         String dirName = dir.getName();
         if (EXCLUDED_FOLDERS.stream().anyMatch(ex -> dirName.equalsIgnoreCase(ex) || dirName.startsWith(ex))) {
-            log.debug("Skipping excluded folder '{}'", dir.getAbsolutePath());
+            log.info("[collectComponentGroupsRecursive] Skipping excluded folder '{}'", dir.getAbsolutePath());
             return;
         }
 
@@ -1365,10 +1519,10 @@ public class ComponentServiceImpl implements ComponentService {
             String content = FileGenerationUtil.readFile(contentXml);
             String group = extractProperty(content, COMPONENT_GROUP).trim();
             if (!group.isEmpty()) {
-                log.info("Found component group '{}' in folder '{}'", group, dir.getAbsolutePath());
-                groups.add(group); // add all groups; filtering is done later
+                log.info("[collectComponentGroupsRecursive] Found component group '{}' in folder '{}'", group, dir.getAbsolutePath());
+                groups.add(group); // Add all groups; filtering is done later
             } else {
-                log.debug("No componentGroup property found in '{}'", contentXml.getAbsolutePath());
+                log.info("[collectComponentGroupsRecursive] No componentGroup property found in '{}'", contentXml.getAbsolutePath());
             }
         }
 
@@ -1378,21 +1532,25 @@ public class ComponentServiceImpl implements ComponentService {
                 collectComponentGroupsRecursive(subDir, groups);
             }
         } else {
-            log.debug("No subdirectories found in '{}'", dir.getAbsolutePath());
+            log.info("[collectComponentGroupsRecursive] No subdirectories found in '{}'", dir.getAbsolutePath());
         }
     }
 
     /**
-     * Reads the app title (componentGroupName) from a project's pom.xml file.
+     * Reads the application title from the project's pom.xml file.
+     * <p>
+     * The method looks for the {@code <componentGroupName>} element inside the POM.
+     * If found, it returns the trimmed text content; otherwise, it returns {@code null}.
+     * </p>
      *
-     * @param projectName the project folder name
-     * @return the componentGroupName from pom.xml, or null if not found
+     * @param projectName the name of the project whose POM is to be read
+     * @return the application title from the POM, or {@code null} if not found or on error
      */
     public String readAppTitleFromPom(String projectName) {
         File pom = new File(PROJECTS_DIR + "/" + projectName + "/" + POM_FILE_NAME);
 
         if (!pom.exists()) {
-            log.warn("pom.xml not found for project '{}'", projectName);
+            log.info("[readAppTitleFromPom] pom.xml not found for project '{}'", projectName);
             return null;
         }
 
@@ -1403,37 +1561,48 @@ public class ComponentServiceImpl implements ComponentService {
             Node node = doc.getElementsByTagName("componentGroupName").item(0);
             if (node != null) {
                 String title = node.getTextContent().trim();
-                log.info("Read app title '{}' from pom.xml for project '{}'", title, projectName);
+                log.info("[readAppTitleFromPom] Read app title '{}' from pom.xml for project '{}'", title, projectName);
                 return title;
             } else {
-                log.warn("No <componentGroupName> element found in pom.xml for project '{}'", projectName);
+                log.info("[readAppTitleFromPom] No <componentGroupName> element found in pom.xml for project '{}'", projectName);
                 return null;
             }
         } catch (Exception e) {
-            log.error("Failed to read app title from pom.xml for project '{}'", projectName, e);
+            log.error("[readAppTitleFromPom] Failed to read app title from pom.xml for project '{}'", projectName, e);
             return null;
         }
     }
 
     /**
-     * Generates all files for a given component request within the specified project.
+     * Generates a new AEM component for the given project based on the provided request.
+     * <p>
+     * This method delegates the actual file generation to {@link FileGenerationUtil#generateAllFiles(String, ComponentRequest)}.
+     * Logs are added before and after generation for tracking purposes.
+     * </p>
      *
-     * @param projectName the name of the project
-     * @param request     the component request containing metadata and configuration
+     * @param projectName the name of the project where the component will be generated
+     * @param request     the component request containing details like component name and configuration
      */
     @Override
     public void generateComponent(String projectName, ComponentRequest request) {
-        log.info("Generating component '{}' for project '{}'", request.getComponentName(), projectName);
+        String componentName = request.getComponentName();
+        log.info("[generateComponent] Generating component '{}' for project '{}'", componentName, projectName);
+
         FileGenerationUtil.generateAllFiles(projectName, request);
-        log.info("Component '{}' generation completed for project '{}'", request.getComponentName(), projectName);
+
+        log.info("[generateComponent] Component '{}' generation completed for project '{}'", componentName, projectName);
     }
 
     /**
-     * Checks if a given component name is available within a project.
+     * Checks if a component name is available for creation in a given project.
+     * <p>
+     * The method resolves the exact path of the component using {@link #findComponentPathExact(String, String)}.
+     * If the path does not exist or is empty, the component is considered available.
+     * </p>
      *
-     * @param projectName   the name of the project
+     * @param projectName   the project in which to check for component availability
      * @param componentName the component name to check
-     * @return true if the component name is available (does not exist), false otherwise
+     * @return {@code true} if the component name is available, {@code false} otherwise
      */
     @Override
     public boolean isComponentNameAvailable(String projectName, String componentName) {
@@ -1441,55 +1610,66 @@ public class ComponentServiceImpl implements ComponentService {
         String basePath = findComponentPathExact(projectName, componentName);
 
         if (basePath == null || basePath.isBlank()) {
-            log.warn("Base path not found for project '{}' and component '{}'. Assuming available.", projectName, componentName);
+            log.info("[isComponentNameAvailable] Base path not found for project '{}' and component '{}'. Assuming available.", projectName, componentName);
             return true;
         }
 
         File componentDir = new File(basePath);
 
         if (componentDir.exists() && componentDir.isDirectory()) {
-            log.info("Component '{}' already exists at path '{}'", componentName, basePath);
+            log.info("[isComponentNameAvailable] Component '{}' already exists at path '{}'", componentName, basePath);
             return false;
         }
 
-        log.info("Component '{}' is available at path '{}'", componentName, basePath);
+        log.info("[isComponentNameAvailable] Component '{}' is available at path '{}'", componentName, basePath);
         return true;
     }
 
     /**
-     * Fetch all components from the local project structure, grouped by their component group.
+     * Retrieves all components of a project grouped by their component groups.
+     * <p>
+     * The method constructs the components folder path using the project name and app ID,
+     * then recursively scans for components, grouping them by their respective component group names.
+     * </p>
      *
-     * @param projectName the name of the project
-     * @return a map where key = component group, value = list of component names
+     * @param projectName the name of the project whose components are to be fetched
+     * @return a map where the key is the component group name and the value is a list of component names
      */
+    @Override
     public Map<String, List<String>> getComponentsByGroup(String projectName) {
 
         String appId = AemUtil.getAppId(PROJECTS_DIR, projectName);
 
         String componentsPath = PROJECTS_DIR + "/" + projectName + CONTENT_ROOT_PATH + appId + "/" + COMPONENTS_FOLDER;
 
-        log.info("Fetching components for project '{}' from '{}'", projectName, componentsPath);
+        log.info("[getComponentsByGroup] Fetching components for project '{}' from '{}'", projectName, componentsPath);
 
         Map<String, List<String>> groupedComponents = new HashMap<>();
 
         scanComponents(new File(componentsPath), groupedComponents, APPS_PATH_PREFIX + appId + "/" + COMPONENTS_FOLDER);
 
-        log.info("Completed fetching components. Total groups found: {}", groupedComponents.size());
+        log.info("[getComponentsByGroup] Completed fetching components. Total groups found: {}", groupedComponents.size());
 
         return groupedComponents;
     }
 
 
     /**
-     * Recursively scans a folder to find AEM components and groups them by component group.
+     * Recursively scans a folder for AEM components and groups them by their component group names.
+     * <p>
+     * Components are identified by the presence of a `.content.xml` file and validated via {@link #isComponent(File)}.
+     * Skips any folders listed in {@link com.aem.builder.constants.ComponentConstants#EXCLUDED_FOLDERS}.
+     * Updates the provided map with component group names as keys
+     * and a list of relative component paths as values.
+     * </p>
      *
-     * @param folder            the current folder to scan
-     * @param groupedComponents map of component group → list of component paths
-     * @param basePath          the relative base path to prepend to each component path
+     * @param folder            the folder to scan for components
+     * @param groupedComponents the map to populate with components grouped by their component groups
+     * @param basePath          the base path used to calculate relative component paths
      */
     private void scanComponents(File folder, Map<String, List<String>> groupedComponents, String basePath) {
         if (folder == null || !folder.exists() || !folder.isDirectory()) {
-            log.warn("Folder does not exist or is not a directory: {}", folder);
+            log.info("[scanComponents] Folder does not exist or is not a directory: {}", folder);
             return;
         }
 
@@ -1502,7 +1682,7 @@ public class ComponentServiceImpl implements ComponentService {
             String name = file.getName();
 
             if (EXCLUDED_FOLDERS.stream().anyMatch(ex -> name.equalsIgnoreCase(ex) || name.startsWith(ex))) {
-                log.debug("Skipping excluded folder: {}", name);
+                log.info("[scanComponents] Skipping excluded folder: {}", name);
                 continue;
             }
 
@@ -1511,7 +1691,7 @@ public class ComponentServiceImpl implements ComponentService {
             if (contentXml.exists() && isComponent(contentXml)) {
                 String group = getComponentGroup(contentXml);
                 if (group == null) {
-                    log.debug("Skipping hidden or invalid component in folder: {}", file.getAbsolutePath());
+                    log.info("[scanComponents] Skipping hidden or invalid component in folder: {}", file.getAbsolutePath());
                     continue;
                 }
 
@@ -1521,23 +1701,31 @@ public class ComponentServiceImpl implements ComponentService {
 
                 if (!groupedComponents.get(group).contains(relativePath)) {
                     groupedComponents.get(group).add(relativePath);
-                    log.info("Added component '{}' under group '{}'", relativePath, group);
+                    log.info("[scanComponents] Added component '{}' under group '{}'", relativePath, group);
                 }
             }
 
+            // Recurse into subdirectories
             scanComponents(file, groupedComponents, basePath + "/" + name);
         }
     }
 
     /**
-     * Checks whether the given .content.xml file represents an actual AEM component.
+     * Determines whether a given .content.xml file represents a valid AEM component.
+     * <p>
+     * This method parses the XML and checks if the root element's <code>jcr:primaryType</code>
+     * matches the constant <code>CQ_COMPONENT_PRIMARY_TYPE</code> defined in {@link com.aem.builder.constants.ComponentConstants}.
+     * Logs are generated at the start, during validation, and on success or failure.
+     * </p>
      *
      * @param contentXml The .content.xml file to check.
-     * @return true if it represents a component; false otherwise.
+     * @return {@code true} if the file represents a valid AEM component; {@code false} otherwise.
      */
     private boolean isComponent(File contentXml) {
+        log.info("[isComponent] Checking if file '{}' is an AEM component", contentXml);
+
         if (contentXml == null || !contentXml.exists() || !contentXml.isFile()) {
-            log.warn("Invalid .content.xml file: {}", contentXml);
+            log.info("[isComponent] Invalid .content.xml file: {}", contentXml);
             return false;
         }
 
@@ -1545,29 +1733,38 @@ public class ComponentServiceImpl implements ComponentService {
             Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(contentXml);
             Element root = doc.getDocumentElement();
 
-            String primaryType = root.getAttribute(JCR_PRIMARY_TYPE); // use constant if defined
+            String primaryType = root.getAttribute(JCR_PRIMARY_TYPE);
             boolean isComponent = CQ_COMPONENT_PRIMARY_TYPE.equals(primaryType);
 
-            log.debug("Checked file '{}', jcr:primaryType='{}', isComponent={}",
+            log.info("[isComponent] Checked file '{}', jcr:primaryType='{}', isComponent={}",
                     contentXml.getAbsolutePath(), primaryType, isComponent);
 
+            log.info("[isComponent] Result for file '{}': {}", contentXml.getAbsolutePath(), isComponent);
             return isComponent;
 
         } catch (Exception e) {
-            log.error("Error parsing .content.xml: {}", contentXml.getAbsolutePath(), e);
+            log.error("[isComponent] Error parsing .content.xml file '{}'", contentXml.getAbsolutePath(), e);
             return false;
         }
     }
 
     /**
-     * Retrieves the component group from the given .content.xml file.
+     * Retrieves the component group for a given .content.xml file.
+     * <p>
+     * Parses the XML file and returns the value of the <code>componentGroup</code> attribute.
+     * If the component is marked as hidden (via {@link com.aem.builder.constants.ComponentConstants#HIDDEN_GROUP}),
+     * this method returns {@code null}. If no group is defined, returns the default group
+     * ({@link com.aem.builder.constants.ComponentConstants#DEFAULT_COMPONENT_GROUP}).
+     * </p>
      *
      * @param contentXml The .content.xml file of the component.
-     * @return The component group name, or null if it is hidden, or "Others" if not defined.
+     * @return The component group name, {@code null} if hidden, or the default group if undefined.
      */
     private String getComponentGroup(File contentXml) {
+        log.info("[getComponentGroup] Fetching component group for file '{}'", contentXml);
+
         if (contentXml == null || !contentXml.exists() || !contentXml.isFile()) {
-            log.warn("Invalid .content.xml file: {}", contentXml);
+            log.info("[getComponentGroup] Invalid .content.xml file: {}", contentXml);
             return DEFAULT_COMPONENT_GROUP;
         }
 
@@ -1579,67 +1776,84 @@ public class ComponentServiceImpl implements ComponentService {
                 String group = root.getAttribute(COMPONENT_GROUP).trim();
 
                 if (HIDDEN_GROUP.equalsIgnoreCase(group)) {
-                    log.debug("Component '{}' is hidden; skipping group.", contentXml.getName());
+                    log.info("[getComponentGroup] Component '{}' is hidden; skipping group.", contentXml.getName());
                     return null;
                 }
 
-                log.debug("Component '{}' belongs to group '{}'", contentXml.getName(), group);
+                log.info("[getComponentGroup] Component '{}' belongs to group '{}'", contentXml.getName(), group);
                 return group;
             }
         } catch (Exception e) {
-            log.error("Error reading component group from '{}'", contentXml.getAbsolutePath(), e);
+            log.error("[getComponentGroup] Error reading component group from '{}'", contentXml.getAbsolutePath(), e);
         }
 
-        log.debug("Component '{}' has no group defined; assigning default group '{}'", contentXml.getName(), DEFAULT_COMPONENT_GROUP);
+        log.info("[getComponentGroup] Component '{}' has no group defined; assigning default group '{}'",
+                contentXml.getName(), DEFAULT_COMPONENT_GROUP);
         return DEFAULT_COMPONENT_GROUP;
     }
 
     /**
-     * Search for a component anywhere under the project's components folder.
-     * Stops at the first match since component names are unique.
+     * Searches for the exact path of a component within a given AEM project.
+     * <p>
+     * The method constructs the components root folder path based on the project name and app ID,
+     * then recursively searches for a component folder whose name exactly matches the provided component name.
+     * </p>
      *
-     * @param projectName   The AEM project name
-     * @param componentName The exact name of the component to search
-     * @return Full path of the component if found, otherwise null
+     * @param projectName   The name of the AEM project.
+     * @param componentName The exact name of the component to find.
+     * @return The absolute path of the component if found; {@code null} otherwise.
      */
     public String findComponentPathExact(String projectName, String componentName) {
+        log.info("[findComponentPathExact] Searching for component '{}' in project '{}'", componentName, projectName);
+
         String appId = AemUtil.getAppId(PROJECTS_DIR, projectName);
 
-        File componentsRoot = new File(PROJECTS_DIR + "/" + projectName + CONTENT_ROOT_PATH + appId + "/" + COMPONENTS_FOLDER);
+        File componentsRoot = new File(PROJECTS_DIR + "/" + projectName
+                + CONTENT_ROOT_PATH + appId + "/" + COMPONENTS_FOLDER);
 
-        log.debug("Searching for component '{}' in project '{}', under path '{}'", componentName, projectName, componentsRoot.getAbsolutePath());
+        log.info("[findComponentPathExact] Components root path: '{}'", componentsRoot.getAbsolutePath());
 
         if (componentsRoot.exists() && componentsRoot.isDirectory()) {
             String foundPath = searchComponentRecursiveExact(componentsRoot, componentName);
+
             if (foundPath != null) {
-                log.info("Component '{}' found at path '{}'", componentName, foundPath);
+                log.info("[findComponentPathExact] Component '{}' found at '{}'", componentName, foundPath);
             } else {
-                log.warn("Component '{}' not found in project '{}'", componentName, projectName);
+                log.info("[findComponentPathExact] Component '{}' not found in project '{}'", componentName, projectName);
             }
             return foundPath;
         } else {
-            log.error("Components root folder does not exist for project '{}': {}", projectName, componentsRoot.getAbsolutePath());
+            log.error("[findComponentPathExact] Components root folder does not exist for project '{}': {}",
+                    projectName, componentsRoot.getAbsolutePath());
             return null;
         }
     }
 
     /**
-     * Recursively search for a component folder by exact case-sensitive name.
-     * Stops at the first match since component names are unique.
+     * Recursively searches for a component folder that exactly matches the given component name.
+     * <p>
+     * Performs a case-sensitive match against folder names. If the component folder is found, returns its absolute path.
+     * Recurses into all subdirectories otherwise.
+     * </p>
      *
-     * @param dir           Current directory to search
-     * @param componentName The exact name of the component to match
-     * @return Full path of the component if found, otherwise null
+     * @param dir           The directory to start searching from.
+     * @param componentName The exact name of the component to search for.
+     * @return The absolute path of the matching component folder if found; {@code null} otherwise.
      */
     public String searchComponentRecursiveExact(File dir, String componentName) {
+        log.info("[searchComponentRecursiveExact] Searching for component '{}' in directory '{}'",
+                componentName, dir != null ? dir.getPath() : "null");
+
         if (dir == null || !dir.isDirectory()) {
-            log.debug("Skipping non-directory or null path: {}", (dir != null ? dir.getPath() : "null"));
+            log.info("[searchComponentRecursiveExact] Skipping non-directory or null path: {}",
+                    (dir != null ? dir.getPath() : "null"));
             return null;
         }
 
         // Exact case-sensitive match
         if (dir.getName().equals(componentName)) {
-            log.info("Exact match found for component '{}' at '{}'", componentName, dir.getPath());
+            log.info("[searchComponentRecursiveExact] Exact match found for component '{}' at '{}'",
+                    componentName, dir.getPath());
             return dir.getPath();
         }
 
@@ -1653,37 +1867,39 @@ public class ComponentServiceImpl implements ComponentService {
             }
         }
 
-        log.trace("Component '{}' not found in directory '{}'", componentName, dir.getPath());
+        log.trace("[searchComponentRecursiveExact] Component '{}' not found in directory '{}'",
+                componentName, dir.getPath());
         return null;
     }
 
     /**
-     * Fetch all component supertypes defined in the given AEM project.
+     * Fetches the super types of all components in the specified AEM project.
      * <p>
-     * Reads each component's `.content.xml`, extracts the {@code sling:resourceSuperType},
-     * and builds a normalized mapping of component paths → display labels.
-     * The map is returned sorted alphabetically by the label (value).
+     * Iterates through all components, reads their `.content.xml` files, and extracts the
+     * `sling:resourceSuperType` attribute. Returns a map where the key is the component path
+     * or supertype path, and the value is the last segment of the component/supertype name.
+     * Handles missing `.content.xml` files or components gracefully.
+     * </p>
      *
-     * @param projectName The name of the AEM project
-     * @return A sorted map of component path → label
+     * @param projectName The name of the project to fetch component supertypes from.
+     * @return A map of component or supertype paths to their last path segment, sorted alphabetically.
      */
     @Override
     public Map<String, String> fetchComponentSuperTypes(String projectName) {
-        Map<String, String> superTypeMap = new LinkedHashMap<>();
+        log.info("[fetchComponentSuperTypes] Starting to fetch component supertypes for project '{}'", projectName);
 
-        // Constants
+        Map<String, String> superTypeMap = new LinkedHashMap<>();
         final String CONTENT_XML = ".content.xml";
         final String ATTR_SUPER_TYPE = "sling:resourceSuperType";
 
         try {
             Map<String, String> components = fetchComponentsWithGroups(projectName);
-            log.info("Fetching component supertypes for project '{}', found {} components",
-                    projectName, components.size());
+            log.info("[fetchComponentSuperTypes] Found {} components in project '{}'", components.size(), projectName);
 
             for (String componentName : components.keySet()) {
                 String componentPath = findComponentPathExact(projectName, componentName);
                 if (componentPath == null) {
-                    log.warn("Component '{}' not found under project '{}'", componentName, projectName);
+                    log.info("[fetchComponentSuperTypes] Component '{}' not found under project '{}'", componentName, projectName);
                     continue;
                 }
 
@@ -1700,13 +1916,13 @@ public class ComponentServiceImpl implements ComponentService {
                         Element root = doc.getDocumentElement();
                         if (root.hasAttribute(ATTR_SUPER_TYPE)) {
                             superType = root.getAttribute(ATTR_SUPER_TYPE);
-                            log.debug("Found supertype '{}' for component '{}'", superType, componentName);
+                            log.info("[fetchComponentSuperTypes] Found supertype '{}' for component '{}'", superType, componentName);
                         }
                     } catch (Exception e) {
-                        log.error("Error parsing {} for component '{}'", CONTENT_XML, componentName, e);
+                        log.error("[fetchComponentSuperTypes] Error parsing '{}' for component '{}'", CONTENT_XML, componentName, e);
                     }
                 } else {
-                    log.warn("{} not found for component '{}'", CONTENT_XML, componentName);
+                    log.info("[fetchComponentSuperTypes] '{}' not found for component '{}'", CONTENT_XML, componentName);
                 }
 
                 String normalized = componentPath.replace(File.separatorChar, '/');
@@ -1729,8 +1945,10 @@ public class ComponentServiceImpl implements ComponentService {
                     putIfNotExists(superTypeMap, componentRepoPath, compLastName);
                 }
             }
+
+            log.info("[fetchComponentSuperTypes] Successfully fetched supertypes for project '{}'", projectName);
         } catch (Exception e) {
-            log.error("Error fetching component supertypes for project '{}'", projectName, e);
+            log.error("[fetchComponentSuperTypes] Error fetching component supertypes for project '{}'", projectName, e);
         }
 
         return superTypeMap.entrySet().stream()
@@ -1742,50 +1960,46 @@ public class ComponentServiceImpl implements ComponentService {
                         LinkedHashMap::new
                 ));
     }
+
     /**
-     * Inserts a key-value pair into the provided map only if:
-     * <ul>
-     *   <li>The key is not already present</li>
-     *   <li>The value is not already present</li>
-     * </ul>
-     * This helps prevent duplicate entries both by path (key) and by label (value).
+     * Adds a key-value mapping to the provided map if neither the key nor the value already exists.
+     * <p>
+     * This ensures that duplicate keys or values are not inserted. Logs addition and skip decisions
+     * for traceability.
+     * </p>
      *
-     * @param map   Target map of component path → label
-     * @param key   Component path (e.g., /apps/project/components/mycomp)
-     * @param value Display label for the component
+     * @param map   The map to update.
+     * @param key   The key to add.
+     * @param value The value to add.
      */
     private void putIfNotExists(Map<String, String> map, String key, String value) {
+        log.info("[putIfNotExists] Attempting to add mapping [{}] -> [{}]", key, value);
+
         if (!map.containsKey(key) && !map.containsValue(value)) {
             map.put(key, value);
-            log.debug("Added mapping: [{}] -> [{}]", key, value);
+            log.info("[putIfNotExists] Added mapping: [{}] -> [{}]", key, value);
         } else {
-            log.trace("Skipping duplicate entry for key [{}] or value [{}]", key, value);
+            log.trace("[putIfNotExists] Skipping duplicate entry for key [{}] or value [{}]", key, value);
         }
     }
 
     /**
-     * Extracts a human-readable, version-aware label from a component supertype path.
+     * Extracts a version-aware component name from a given superType path.
      * <p>
-     * Examples:
-     * <ul>
-     *   <li>{@code core/wcm/components/button/v1/button} → {@code button (v1)}</li>
-     *   <li>{@code core/wcm/components/container/v2/container} → {@code container (v2)}</li>
-     *   <li>{@code custom/components/teaser} → {@code teaser}</li>
-     * </ul>
+     * If the superType path contains a version segment (e.g., "v1"), it appends the version
+     * in parentheses to the last segment of the path. Otherwise, returns the last segment.
      * </p>
      *
-     * <p>If the path does not contain a version segment (e.g., v1, v2), the method
-     * simply returns the last segment of the path. If parsing fails, the original
-     * {@code superTypePath} is returned unchanged.</p>
-     *
-     * @param superTypePath full supertype path (e.g., {@code core/wcm/components/button/v1/button})
-     * @return version-aware display name
+     * @param superTypePath The full superType path (e.g., "/apps/project/components/v1/button").
+     * @return The version-aware name (e.g., "button (v1)") or the last segment if no version detected.
      */
     private String extractVersionAwareName(String superTypePath) {
         final String VERSION_PATTERN = "v\\d+";
 
+        log.info("[extractVersionAwareName] Extracting version-aware name from '{}'", superTypePath);
+
         if (superTypePath == null || superTypePath.isBlank()) {
-            log.warn("Received blank or null superTypePath for version-aware extraction.");
+            log.info("[extractVersionAwareName] Received blank or null superTypePath.");
             return "";
         }
 
@@ -1796,52 +2010,53 @@ public class ComponentServiceImpl implements ComponentService {
 
             if (secondLast.matches(VERSION_PATTERN)) {
                 String result = last + " (" + secondLast + ")";
-                log.debug("Extracted version-aware name '{}' from superType '{}'", result, superTypePath);
+                log.info("[extractVersionAwareName] Extracted version-aware name '{}' from '{}'", result, superTypePath);
                 return result;
             }
 
-            log.debug("Extracted simple name '{}' from superType '{}'", last, superTypePath);
+            log.info("[extractVersionAwareName] Extracted simple name '{}' from '{}'", last, superTypePath);
             return last;
         }
 
-        log.debug("Could not parse '{}', returning as-is.", superTypePath);
+        log.info("[extractVersionAwareName] Could not parse '{}', returning as-is.", superTypePath);
         return superTypePath;
     }
 
     /**
-     * Fetches all parent dialog tabs from a given component's supertype hierarchy.
+     * Retrieves all parent tabs for a given component superType in a project.
      * <p>
-     * This method traverses up the inheritance chain of the specified superType
-     * and collects all dialog tabs (if present). Tabs are merged into a set to
-     * preserve insertion order and avoid duplicates.
+     * This method recursively collects tabs from the specified superType and aggregates them
+     * into a set to avoid duplicates. The resulting map contains a flag indicating whether any
+     * tabs were found and a list of the collected tab names.
      * </p>
      *
-     * @param projectName the name of the AEM project
-     * @param superType   the component's sling:resourceSuperType path
-     * @return a result map with:
+     * @param projectName The name of the AEM project.
+     * @param superType   The sling:resourceSuperType of the component to fetch tabs for.
+     * @return A map containing:
      * <ul>
-     *     <li>{@code hasTabs} → boolean, true if any tabs were found</li>
-     *     <li>{@code tabs} → list of tab names</li>
+     *     <li>"hasTabs": {@code true} if any tabs were found; {@code false} otherwise.</li>
+     *     <li>"tabs": A list of tab names (empty if none found).</li>
      * </ul>
      */
     @Override
     public Map<String, Object> getParentTabs(String projectName, String superType) {
+        log.info("[getParentTabs] Fetching parent tabs for superType '{}' in project '{}'", superType, projectName);
+
         Map<String, Object> result = new HashMap<>();
         Set<String> tabs = new LinkedHashSet<>();
 
         try {
-
             collectTabsRecursively(projectName, superType, tabs);
 
             boolean hasTabs = !tabs.isEmpty();
             result.put("hasTabs", hasTabs);
             result.put("tabs", new ArrayList<>(tabs));
 
-            log.info("Final merged tabs for superType '{}' in project '{}': {}",
+            log.info("[getParentTabs] Final merged tabs for superType '{}' in project '{}': {}",
                     superType, projectName, tabs);
 
         } catch (Exception e) {
-            log.error(" Error while fetching parent tabs for superType '{}' in project '{}'",
+            log.error("[getParentTabs] Error while fetching parent tabs for superType '{}' in project '{}'",
                     superType, projectName, e);
 
             result.put("hasTabs", false);
@@ -1852,23 +2067,23 @@ public class ComponentServiceImpl implements ComponentService {
     }
 
     /**
-     * Recursively collects dialog tabs from the given component and its superTypes.
+     * Recursively collects all tabs defined for a component and its parent superTypes.
      * <p>
-     * The method works by:
-     * <ol>
-     *     <li>Checking if the component has a {@code _cq_dialog/.content.xml} and extracting its tabs.</li>
-     *     <li>Looking for a {@code .content.xml} to identify its {@code sling:resourceSuperType}.</li>
-     *     <li>Recursively traversing into the parent superType if found.</li>
-     * </ol>
+     * This method traverses the superType hierarchy of a component, parsing dialog files
+     * to collect tab names. Tabs from core components and project-specific components are
+     * merged into the provided {@code tabs} set to avoid duplicates.
+     * </p>
      *
-     * @param projectName the AEM project name
-     * @param superType   the sling:resourceSuperType path to process
-     * @param tabs        the set to which tab names are added
-     * @throws Exception if file parsing fails
+     * @param projectName The name of the AEM project.
+     * @param superType   The sling:resourceSuperType of the component whose tabs are being collected.
+     * @param tabs        A set to accumulate tab names; duplicates are ignored.
+     * @throws Exception If there is an error reading or parsing dialog files.
      */
     private void collectTabsRecursively(String projectName, String superType, Set<String> tabs) throws Exception {
+        log.info("[collectTabsRecursively] Collecting tabs for superType '{}' in project '{}'", superType, projectName);
+
         if (superType == null || superType.isBlank()) {
-            log.warn("Skipping empty superType for project '{}'", projectName);
+            log.info("[collectTabsRecursively] Skipping empty superType for project '{}'", projectName);
             return;
         }
 
@@ -1886,23 +2101,23 @@ public class ComponentServiceImpl implements ComponentService {
 
             if (!currentTabs.isEmpty()) {
                 tabs.addAll(currentTabs);
-                log.info("Tabs collected from '{}' [{}]: {}", superType, (isCore ? "core" : "project"), currentTabs);
+                log.info("[collectTabsRecursively] Tabs collected from '{}' [{}]: {}", superType, (isCore ? "core" : "project"), currentTabs);
             }
         }
 
         File compContentFile = new File(basePath, CONTENT_XML);
         if (!compContentFile.exists()) {
-            log.debug("No .content.xml found for '{}'", superType);
+            log.info("[collectTabsRecursively] No .content.xml found for '{}'", superType);
             return;
         }
 
         String parentSuperType = readSuperType(compContentFile);
         if (parentSuperType == null || parentSuperType.isBlank()) {
-            log.debug("No parent superType defined for '{}'", superType);
+            log.info("[collectTabsRecursively] No parent superType defined for '{}'", superType);
             return;
         }
 
-        log.info(" '{}' extends '{}'", superType, parentSuperType);
+        log.info("[collectTabsRecursively] '{}' extends '{}'", superType, parentSuperType);
 
         if (parentSuperType.startsWith(CORE_PREFIX)) {
             String corePath = System.getProperty(USER_DIR_SYS_PROP) + CORE_RESOURCE_PATH_PREFIX + parentSuperType;
@@ -1912,10 +2127,10 @@ public class ComponentServiceImpl implements ComponentService {
                 List<String> coreTabs = parseCoreTabsFromDialog(coreDialog);
                 if (!coreTabs.isEmpty()) {
                     tabs.addAll(coreTabs);
-                    log.info("Core Tabs collected from '{}': {}", parentSuperType, coreTabs);
+                    log.info("[collectTabsRecursively] Core Tabs collected from '{}': {}", parentSuperType, coreTabs);
                 }
             } else {
-                log.warn("Core dialog not found for '{}': {}", parentSuperType, coreDialog.getAbsolutePath());
+                log.info("[collectTabsRecursively] Core dialog not found for '{}': {}", parentSuperType, coreDialog.getAbsolutePath());
             }
         } else {
             collectTabsRecursively(projectName, parentSuperType, tabs);
@@ -1923,18 +2138,18 @@ public class ComponentServiceImpl implements ComponentService {
     }
 
     /**
-     * Parse dialog file (.content.xml) and extract tab names for project-specific (non-core) components.
+     * Parses a project-specific dialog file to extract all defined tab titles.
      * <p>
-     * It looks for nodes with sling:resourceType = granite/ui/components/coral/foundation/tabs
-     * and then iterates through their <items> children to collect tab containers.
+     * The method searches for nodes with sling:resourceType = "granite/ui/components/coral/foundation/tabs"
+     * and then iterates through their child items to collect tab titles from granite containers.
      * </p>
      *
-     * @param dialogFile the dialog .content.xml file for the component
-     * @return list of tab titles detected (may be empty if no tabs found)
-     * @throws Exception if XML parsing fails
+     * @param dialogFile The dialog XML file to parse.
+     * @return A list of tab titles defined in the dialog. Returns an empty list if no tabs are found.
+     * @throws Exception If an error occurs while reading or parsing the dialog file.
      */
     private List<String> parseProjectTabsFromDialog(File dialogFile) throws Exception {
-        log.info("Parsing project dialog for tabs: {}", dialogFile.getAbsolutePath());
+        log.info("[parseProjectTabsFromDialog] Parsing project dialog for tabs: {}", dialogFile.getAbsolutePath());
 
         List<String> tabs = new ArrayList<>();
 
@@ -1951,7 +2166,7 @@ public class ComponentServiceImpl implements ComponentService {
             // Check if this node is a <tabs> definition (granite resource type)
             org.w3c.dom.Node resType = attrs.getNamedItem(SLING_RESOURCE_TYPE);
             if (resType != null && GRANITE_TABS.equals(resType.getNodeValue())) {
-                log.debug(" Found granite tabs node at index {}", i);
+                log.info("[parseProjectTabsFromDialog] Found granite tabs node at index {}", i);
 
                 NodeList itemsNodes = node.getChildNodes();
                 for (int j = 0; j < itemsNodes.getLength(); j++) {
@@ -1974,7 +2189,7 @@ public class ComponentServiceImpl implements ComponentService {
                                     : tabNode.getNodeName();
 
                             tabs.add(tabTitle);
-                            log.info("   ➕ Project Tab detected: {}", tabTitle);
+                            log.info("[parseProjectTabsFromDialog] ➕ Project Tab detected: {}", tabTitle);
                         }
                     }
                 }
@@ -1982,23 +2197,28 @@ public class ComponentServiceImpl implements ComponentService {
         }
 
         if (tabs.isEmpty()) {
-            log.warn("No project tabs found in {}", dialogFile.getName());
+            log.info("[parseProjectTabsFromDialog] No project tabs found in {}", dialogFile.getName());
         } else {
-            log.info("Total project tabs collected: {}", tabs.size());
+            log.info("[parseProjectTabsFromDialog] Total project tabs collected: {}", tabs.size());
         }
 
         return tabs;
     }
 
     /**
-     * Parse dialog file and extract tab names for Core components.
-     * This method searches recursively until the first <tabs> node is found.
+     * Parses a core AEM dialog file to extract all tab titles recursively.
+     * <p>
+     * This method handles core components where tabs can be nested within containers.
+     * It delegates the recursive extraction to {@link #parseTabsRecursive(org.w3c.dom.Node, List)}.
+     * </p>
      *
-     * @param dialogFile the .content.xml dialog file
-     * @return list of tab titles found in the Core component
-     * @throws Exception if parsing fails
+     * @param dialogFile The core dialog XML file to parse.
+     * @return A list of tab titles found in the core dialog. Returns an empty list if none are found.
+     * @throws Exception If an error occurs while reading or parsing the dialog file.
      */
     private List<String> parseCoreTabsFromDialog(File dialogFile) throws Exception {
+        log.info("[parseCoreTabsFromDialog] Parsing core dialog for tabs: {}", dialogFile.getAbsolutePath());
+
         List<String> tabs = new ArrayList<>();
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);
@@ -2006,23 +2226,31 @@ public class ComponentServiceImpl implements ComponentService {
         Document doc = builder.parse(dialogFile);
 
         org.w3c.dom.Node root = doc.getDocumentElement();
-        log.debug("Starting recursive parsing for Core tabs in file: {}", dialogFile.getAbsolutePath());
+        log.info("[parseCoreTabsFromDialog] Starting recursive parsing from root element: {}", root.getNodeName());
 
         parseTabsRecursive(root, tabs);
 
-        log.info("Core tabs parsed from {}: {}", dialogFile.getName(), tabs);
+        if (tabs.isEmpty()) {
+            log.info("[parseCoreTabsFromDialog] No core tabs found in {}", dialogFile.getName());
+        } else {
+            log.info("[parseCoreTabsFromDialog] Core tabs parsed from {}: {}", dialogFile.getName(), tabs);
+        }
+
         return tabs;
     }
 
+
     /**
-     * Recursively parses XML nodes to extract tab names.
-     * Supports both Core and project components.
+     * Recursively parses an XML node to extract tab titles for core AEM dialogs.
      * <p>
-     * Stops at <tabs> nodes or nodes with sling:resourceType = coral/foundation/tabs,
-     * and extracts <container> nodes with jcr:title as tab titles.
+     * This method traverses all child nodes, identifies <tabs> nodes (or nodes with
+     * granite/ui/components/coral/foundation/tabs resource type), and collects the titles
+     * of each tab container. It adds detected tab titles to the provided list and
+     * continues recursion for nested containers.
+     * </p>
      *
-     * @param node current XML node being inspected
-     * @param tabs collection of tab titles found so far
+     * @param node The XML node to inspect recursively.
+     * @param tabs The list to populate with discovered tab titles.
      */
     private void parseTabsRecursive(org.w3c.dom.Node node, List<String> tabs) {
         if (node.getNodeType() != org.w3c.dom.Node.ELEMENT_NODE) {
@@ -2031,11 +2259,12 @@ public class ComponentServiceImpl implements ComponentService {
 
         NamedNodeMap attrs = node.getAttributes();
 
-        if (TYPE_TABS.equals(node.getNodeName()) ||
+        boolean isTabsNode = TYPE_TABS.equals(node.getNodeName()) ||
                 (attrs != null && attrs.getNamedItem(SLING_RESOURCE_TYPE) != null &&
-                        GRANITE_TABS.equals(attrs.getNamedItem(SLING_RESOURCE_TYPE).getNodeValue()))) {
+                        GRANITE_TABS.equals(attrs.getNamedItem(SLING_RESOURCE_TYPE).getNodeValue()));
 
-            log.debug(" Found <tabs> node at: {}", node.getNodeName());
+        if (isTabsNode) {
+            log.info("[parseTabsRecursive] Found <tabs> node at '{}'", node.getNodeName());
 
             NodeList itemsNodes = node.getChildNodes();
             for (int i = 0; i < itemsNodes.getLength(); i++) {
@@ -2051,20 +2280,18 @@ public class ComponentServiceImpl implements ComponentService {
                     if (tabAttrs == null) continue;
 
                     org.w3c.dom.Node resTypeAttr = tabAttrs.getNamedItem(SLING_RESOURCE_TYPE);
-                    if (resTypeAttr != null &&
-                            GRANITE_CONTAINER.equals(resTypeAttr.getNodeValue())) {
-
+                    if (resTypeAttr != null && GRANITE_CONTAINER.equals(resTypeAttr.getNodeValue())) {
                         org.w3c.dom.Node titleAttr = tabAttrs.getNamedItem(JCR_TITLE);
                         String tabTitle = (titleAttr != null) ? titleAttr.getNodeValue() : tabNode.getNodeName();
                         tabs.add(tabTitle);
-                        log.info("   ➕ Core Tab detected: {}", tabTitle);
+                        log.info("[parseTabsRecursive] ➕ Core Tab detected: {}", tabTitle);
                     }
 
+                    // Recursive call for nested structures
                     parseTabsRecursive(tabNode, tabs);
                 }
             }
         } else {
-
             NodeList children = node.getChildNodes();
             for (int i = 0; i < children.getLength(); i++) {
                 parseTabsRecursive(children.item(i), tabs);
@@ -2072,18 +2299,21 @@ public class ComponentServiceImpl implements ComponentService {
         }
     }
 
-
-
     /**
-     * Reads sling:resourceSuperType from .content.xml.
-     * This method parses the given component's .content.xml file
-     * and looks for the sling:resourceSuperType attribute.
+     * Reads the superType of an AEM component from its .content.xml file.
+     * <p>
+     * This method parses the XML file, inspects all attributes of all nodes, and
+     * returns the value of the attribute representing the component's super type.
+     * It checks for both the standard {@code sling:resourceSuperType} attribute
+     * and any attribute ending with the configured suffix {@code :resourceSuperType}.
+     * </p>
      *
-     * @param compContentFile the .content.xml file of the component
-     * @return the value of sling:resourceSuperType if found, otherwise null
+     * @param compContentFile The .content.xml file of the component.
+     * @return The superType as a string if found; {@code null} otherwise.
+     * @throws Exception If there is an error parsing the XML file.
      */
     private String readSuperType(File compContentFile) throws Exception {
-        log.info(" Reading superType from file: {}", compContentFile.getAbsolutePath());
+        log.info("[readSuperType] Reading superType from file: {}", compContentFile.getAbsolutePath());
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);
@@ -2101,42 +2331,63 @@ public class ComponentServiceImpl implements ComponentService {
                     String name = attr.getNodeName();
                     String value = attr.getNodeValue();
 
-                    log.debug("Attribute found: {} = {}", name, value);
+                    log.info("[readSuperType] Attribute found: {} = {}", name, value);
 
                     if (SLING_RESOURCE_SUPER_TYPE.equals(name) || name.endsWith(SUFFIX_RESOURCE_SUPER_TYPE)) {
-                        log.info(" Found superType: {}", value);
+                        log.info("[readSuperType] Found superType: {}", value);
                         return value;
                     }
                 }
             }
         }
 
-        log.warn("No sling:resourceSuperType found in {}", compContentFile.getName());
+        log.info("[readSuperType] No sling:resourceSuperType found in {}", compContentFile.getName());
         return null;
     }
+
     /**
-     * Returns a list of editable components by filtering out hidden/system structure components.
+     * Filters and returns a list of editable AEM components from the provided component map.
+     * <p>
+     * A component is considered editable if its component group is either:
+     * <ul>
+     *     <li>null</li>
+     *     <li>not a structure group (i.e., does not equal "{@code appTitle - Structure}")</li>
+     *     <li>not hidden (i.e., does not equal ".hidden")</li>
+     * </ul>
+     * </p>
      *
-     * @param compMap Map of componentName → componentGroup
-     * @param appTitle The title of the application/project (used to filter "Structure" group)
-     * @return List of editable component names
+     * @param compMap  A map of component paths to their respective groups.
+     * @param appTitle The application title used to identify structure groups.
+     * @return A list of component paths that are editable.
      */
     public List<String> getEditableComponents(Map<String, String> compMap, String appTitle) {
+        log.info("[getEditableComponents] Filtering editable components for app '{}'", appTitle);
+
         if (compMap == null || compMap.isEmpty()) {
+            log.info("[getEditableComponents] Component map is null or empty. Returning empty list.");
             return List.of();
         }
 
-        return compMap.entrySet()
+        List<String> editableComponents = compMap.entrySet()
                 .stream()
                 .filter(entry -> {
                     String group = Optional.ofNullable(entry.getValue())
                             .map(String::trim)
                             .orElse(null);
-                    // Editable if group is null, or not structure, and not hidden
-                    return group == null
+                    boolean isEditable = group == null
                             || (!group.equals(appTitle + " - Structure") && !group.equals(".hidden"));
+                    if (!isEditable) {
+                        log.info("[getEditableComponents] Excluding component '{}' in group '{}'", entry.getKey(), group);
+                    } else {
+                        log.info("[getEditableComponents] Including editable component '{}'", entry.getKey());
+                    }
+                    return isEditable;
                 })
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toList());
+
+        log.info("[getEditableComponents] Total editable components found: {}", editableComponents.size());
+        return editableComponents;
     }
+
 }


### PR DESCRIPTION
- Enhanced JavaDoc comments for methods like getEditableComponents, isComponent, getComponentGroup, 
  getParentTabs, collectTabsRecursively, parseProjectTabsFromDialog, parseCoreTabsFromDialog, 
  parseTabsRecursive, readSuperType.
- Added detailed log statements (log.info) for better traceability 
  of component scanning, tab collection, superType reading, and editable component filtering.
- Improved readability and maintainability of AEM component service methods.