### PR TITLE
Update componentGroup in copied AEM components to use project-specifi…

### DIFF
--- a/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/aem/builder/service/impl/ComponentServiceImpl.java
@@ -1179,6 +1179,20 @@ public class ComponentServiceImpl implements ComponentService {
                         log.info("[copySelectedComponents] Updated HTL model reference in '{}'", html.getAbsolutePath());
                     }
                 }
+                // Update componentGroup in .content.xml
+                //File contentXml = new File(destination, CONTENT_XML);
+                String capitalizedProject = projectName.substring(0, 1).toUpperCase() + projectName.substring(1);
+
+                if (contentXml.exists()) {
+                    String content = FileUtils.readFileToString(contentXml, UTF_8);
+
+                    // Replace componentGroup="anything"
+                    content = content.replaceAll("componentGroup=\"[^\"]*\"",
+                            "componentGroup=\"" + capitalizedProject + " - Content\"");
+                    FileUtils.writeStringToFile(contentXml, content, UTF_8);
+                    log.info("[copySelectedComponents] Updated componentGroup in '{}'", contentXml.getAbsolutePath());
+                }
+
 
                 // Copy model and dependencies
                 if (parentModel != null && parentModel.exists()) {

--- a/src/main/resources/templates/deploy.html
+++ b/src/main/resources/templates/deploy.html
@@ -105,7 +105,7 @@
                     <div class="col" th:each="component : ${components}">
                         <div class="border rounded p-2 bg-light d-flex justify-content-between align-items-center shadow-sm">
                             <span th:text="${component}"></span>
-                            <a th:if="${#lists.contains(editableComponents, component)}"
+                            <a th:if="${#lists.contains(editableComponents, component) and component != 'helloworld'}"
                                th:href="@{/{projectName}/editcomponent(componentName=${component}, projectName=${projectName})}"
                                class="btn btn-sm btn-outline-secondary ms-2"
                                onclick="return checkRestrictedBranch('edit this component')">Edit</a>


### PR DESCRIPTION

When copying each component:

- Read the .content.xml file inside the copied component folder.
- Replace the existing componentGroup value with:
- project name - Content